### PR TITLE
feat(extension): Basic scene support

### DIFF
--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -32,13 +32,12 @@ const yml = {
       name: "Search",
       widgetLayout: {
         extendable: {
-          horizontally: true,
           vertically: true,
         },
         defaultLocation: {
           zone: "inner",
           section: "left",
-          area: "top",
+          area: "middle",
         },
         extended: true,
       },

--- a/extension/src/prototypes/ui-components/AppBar.tsx
+++ b/extension/src/prototypes/ui-components/AppBar.tsx
@@ -12,6 +12,7 @@ import { DarkThemeOverride } from "./DarkThemeOverride";
 
 const StyledAppBar = styled(MuiAppBar)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
+  maxWidth: "100%",
 }));
 
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({

--- a/extension/src/prototypes/ui-components/AppOverlayLayout.tsx
+++ b/extension/src/prototypes/ui-components/AppOverlayLayout.tsx
@@ -21,6 +21,7 @@ const Root = styled("div", {
   position: "absolute",
   inset: 0,
   top: 0,
+  minHeight: 81,
   pointerEvents: "none",
   "& > *": {
     direction: "ltr",
@@ -102,7 +103,7 @@ const Main = styled("main", {
   flexShrink: 1,
   flexGrow: 0,
   width: mainWidth,
-  minHeight: 0,
+  // minHeight: 0,
   // marginRight: theme.spacing(spacing),
   [`@container (min-width: calc(${mainWidth + contextWidth}px + ${theme.spacing(spacing)}))`]: {
     flexBasis: mainWidth,

--- a/extension/src/prototypes/ui-components/SearchField.tsx
+++ b/extension/src/prototypes/ui-components/SearchField.tsx
@@ -19,6 +19,7 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
+  boxSizing: "border-box",
   minHeight: theme.spacing(6),
   padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
 }));

--- a/extension/src/prototypes/view/containers/Environments.tsx
+++ b/extension/src/prototypes/view/containers/Environments.tsx
@@ -1,0 +1,95 @@
+import { atom, useAtomValue } from "jotai";
+import { type FC } from "react";
+
+import { ShadowProps } from "../../../shared/reearth/scene";
+import { AmbientOcclusion } from "../../../shared/reearth/types";
+import {
+  sharableEnvironmentTypeAtom,
+  sharableGraphicsQualityAtom,
+} from "../../../shared/states/scene";
+import { colorModeAtom } from "../../shared-states";
+import { ElevationEnvironment } from "../environments/ElevationEnvironment";
+import { GooglePhotorealisticEnvironment } from "../environments/GooglePhotorealisticEnvironment";
+import { MapEnvironment } from "../environments/MapEnvironment";
+import { SatelliteEnvironment } from "../environments/SatelliteEnvironment";
+import { debugSphericalHarmonicsAtom } from "../states/app";
+import {
+  ambientOcclusionEnabledAtom,
+  ambientOcclusionIntensityAtom,
+  ambientOcclusionOutputTypeAtom,
+  shadowMapEnabledAtom,
+  shadowMapSizeAtom,
+  shadowMapSoftShadowsAtom,
+} from "../states/graphics";
+import { AmbientOcclusionOutputType } from "../types/hbao";
+
+export type EnvironmentType = "map" | "satellite" | "elevation" | "google-photorealistic";
+
+const shadowMapPropsAtom = atom(
+  (get): ShadowProps => ({
+    enabled: get(shadowMapEnabledAtom),
+    size: get(shadowMapSizeAtom),
+    softShadows: get(shadowMapSoftShadowsAtom),
+  }),
+);
+
+const ambientOcclusionPropsAtom = atom((get): AmbientOcclusion => {
+  const quality = get(sharableGraphicsQualityAtom) || undefined;
+  return {
+    enabled: get(ambientOcclusionEnabledAtom),
+    intensity: get(ambientOcclusionIntensityAtom),
+    quality: quality === "ultra" ? "extreme" : quality,
+    // TODO(ReEarth): Support other output type
+    ambientOcclusionOnly:
+      get(ambientOcclusionOutputTypeAtom) === AmbientOcclusionOutputType.Occlusion,
+  };
+});
+
+export const Environments: FC = () => {
+  const environmentType = useAtomValue(sharableEnvironmentTypeAtom);
+  const colorMode = useAtomValue(colorModeAtom);
+  const debugSphericalHarmonics = useAtomValue(debugSphericalHarmonicsAtom);
+  const shadowProps = useAtomValue(shadowMapPropsAtom);
+  const ambientOcclusionProps = useAtomValue(ambientOcclusionPropsAtom);
+  const graphicsQuality = useAtomValue(sharableGraphicsQualityAtom) || undefined;
+  const antialias = graphicsQuality === "ultra" ? "extreme" : graphicsQuality;
+
+  switch (environmentType) {
+    case "map":
+      return (
+        <MapEnvironment
+          debugSphericalHarmonics={debugSphericalHarmonics}
+          colorMode={colorMode}
+          ambientOcclusion={ambientOcclusionProps}
+          shadows={shadowProps}
+          antialias={antialias}
+        />
+      );
+    case "satellite":
+      return (
+        <SatelliteEnvironment
+          debugSphericalHarmonics={debugSphericalHarmonics}
+          ambientOcclusion={ambientOcclusionProps}
+          shadows={shadowProps}
+          antialias={antialias}
+        />
+      );
+    case "elevation":
+      return (
+        <ElevationEnvironment
+          debugSphericalHarmonics={debugSphericalHarmonics}
+          ambientOcclusion={ambientOcclusionProps}
+          shadows={shadowProps}
+          antialias={antialias}
+        />
+      );
+    case "google-photorealistic":
+      return (
+        <GooglePhotorealisticEnvironment
+          ambientOcclusion={ambientOcclusionProps}
+          shadows={shadowProps}
+          antialias={antialias}
+        />
+      );
+  }
+};

--- a/extension/src/prototypes/view/containers/Environments.tsx
+++ b/extension/src/prototypes/view/containers/Environments.tsx
@@ -4,8 +4,8 @@ import { type FC } from "react";
 import { ShadowProps } from "../../../shared/reearth/scene";
 import { AmbientOcclusion } from "../../../shared/reearth/types";
 import {
-  sharableEnvironmentTypeAtom,
-  sharableGraphicsQualityAtom,
+  shareableEnvironmentTypeAtom,
+  shareableGraphicsQualityAtom,
 } from "../../../shared/states/scene";
 import { colorModeAtom } from "../../shared-states";
 import { ElevationEnvironment } from "../environments/ElevationEnvironment";
@@ -34,7 +34,7 @@ const shadowMapPropsAtom = atom(
 );
 
 const ambientOcclusionPropsAtom = atom((get): AmbientOcclusion => {
-  const quality = get(sharableGraphicsQualityAtom) || undefined;
+  const quality = get(shareableGraphicsQualityAtom) || undefined;
   return {
     enabled: get(ambientOcclusionEnabledAtom),
     intensity: get(ambientOcclusionIntensityAtom),
@@ -46,12 +46,12 @@ const ambientOcclusionPropsAtom = atom((get): AmbientOcclusion => {
 });
 
 export const Environments: FC = () => {
-  const environmentType = useAtomValue(sharableEnvironmentTypeAtom);
+  const environmentType = useAtomValue(shareableEnvironmentTypeAtom);
   const colorMode = useAtomValue(colorModeAtom);
   const debugSphericalHarmonics = useAtomValue(debugSphericalHarmonicsAtom);
   const shadowProps = useAtomValue(shadowMapPropsAtom);
   const ambientOcclusionProps = useAtomValue(ambientOcclusionPropsAtom);
-  const graphicsQuality = useAtomValue(sharableGraphicsQualityAtom) || undefined;
+  const graphicsQuality = useAtomValue(shareableGraphicsQualityAtom) || undefined;
   const antialias = graphicsQuality === "ultra" ? "extreme" : graphicsQuality;
 
   switch (environmentType) {

--- a/extension/src/prototypes/view/environments/ElevationEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/ElevationEnvironment.tsx
@@ -1,0 +1,112 @@
+import { useAtomValue } from "jotai";
+import { type FC } from "react";
+import invariant from "tiny-invariant";
+
+// import { TerrainElevationImageryLayer, VertexTerrainElevationMaterial } from "../../datasets";
+import { Scene, SceneProps } from "../../../shared/reearth/scene";
+import {
+  enableTerrainLightingAtom,
+  // logarithmicTerrainElevationAtom,
+  // terrainElevationHeightRangeAtom,
+} from "../states/app";
+
+const sphericalHarmonicCoefficients: [x: number, y: number, z: number][] = [
+  [0.82368016242981, 0.89996325969696, 1.057950735092163], // L00, irradiance, pre-scaled base
+  [0.95617014169693, 1.087422609329224, 1.246641397476196], // L1-1, irradiance, pre-scaled base
+  [0.460439652204514, 0.642218351364136, 0.81517082452774], // L10, irradiance, pre-scaled base
+  [-0.000934832380153, 0.014073264785111, 0.01713084615767], // L11, irradiance, pre-scaled base
+  [-0.064062088727951, -0.072207100689411, -0.074556961655617], // L2-2, irradiance, pre-scaled base
+  [0.508748233318329, 0.619970560073853, 0.730030000209808], // L2-1, irradiance, pre-scaled base
+  [-0.031152218580246, -0.053586609661579, -0.066098868846893], // L20, irradiance, pre-scaled base
+  [0.014958278276026, -0.027591468766332, -0.043796796351671], // L21, irradiance, pre-scaled base
+  [-0.192780449986458, -0.223674207925797, -0.249334931373596], // L22, irradiance, pre-scaled base
+];
+
+export const ElevationEnvironment: FC<SceneProps> = props => {
+  invariant(
+    process.env.NEXT_PUBLIC_API_BASE_URL != null,
+    "Missing environment variable: NEXT_PUBLIC_API_BASE_URL",
+  );
+
+  // const globeShader = useConstant(() => ({
+  //   material: new VertexTerrainElevationMaterial(),
+  //   matcher: new StringMatcher().replace(
+  //     [
+  //       "#ifdef APPLY_COLOR_TO_ALPHA",
+  //       "vec3 colorDiff = abs(color.rgb - colorToAlpha.rgb);",
+  //       "colorDiff.r = max(max(colorDiff.r, colorDiff.g), colorDiff.b);",
+  //       "alpha = czm_branchFreeTernary(colorDiff.r < colorToAlpha.a, 0.0, alpha);",
+  //       "#endif",
+  //     ],
+  //     /* glsl */ `
+  //     // colorToAlpha is used as an identification of imagery layer here.
+  //     if (greaterThan(colorToAlpha, vec4(0.9)) == bvec4(true)) {
+  //       float decodedValue = dot(color, vec3(16711680.0, 65280.0, 255.0));
+  //       float height = (decodedValue - 8388607.0) * 0.01;
+  //       float minHeight = czm_branchFreeTernary(
+  //         logarithmic_3,
+  //         pseudoLog(minHeight_1),
+  //         minHeight_1
+  //       );
+  //       float maxHeight = czm_branchFreeTernary(
+  //         logarithmic_3,
+  //         pseudoLog(maxHeight_2),
+  //         maxHeight_2
+  //       );
+  //       float value = czm_branchFreeTernary(
+  //         logarithmic_3,
+  //         pseudoLog(height),
+  //         height
+  //       );
+  //       float normalizedHeight = clamp(
+  //         (value - minHeight) / (maxHeight - minHeight),
+  //         0.0,
+  //         1.0
+  //       );
+  //       vec4 mappedColor = texture(colorMap_0, vec2(normalizedHeight, 0.5));
+  //       color = mappedColor.rgb;
+  //     }`,
+  //   ),
+  // }));
+
+  // const terrainElevationHeightRange = useAtomValue(terrainElevationHeightRangeAtom);
+  // const logarithmicTerrainElevation = useAtomValue(logarithmicTerrainElevationAtom);
+  // globeShader.material.uniforms.minHeight = terrainElevationHeightRange[0];
+  // globeShader.material.uniforms.maxHeight = terrainElevationHeightRange[1];
+  // globeShader.material.uniforms.logarithmic = logarithmicTerrainElevation;
+  // const scene = useCesium(({ scene }) => scene);
+  // scene.requestRender();
+
+  const enableTerrainLighting = useAtomValue(enableTerrainLightingAtom);
+
+  // const [layer, setLayer] = useState<ImageryLayerHandle | null>(null);
+  // useEffect(() => {
+  //   layer?.sendToBack();
+  // }, [layer]);
+
+  return (
+    <>
+      <Scene
+        backgroundColor={"black"}
+        globeBaseColor={"black"}
+        enableGlobeLighting={enableTerrainLighting}
+        // globeShader={globeShader}
+        lightIntensity={10}
+        shadowDarkness={0.5}
+        imageBasedLightingIntensity={1}
+        sphericalHarmonicCoefficients={sphericalHarmonicCoefficients}
+        showSkyBox={false}
+        atmosphereSaturationShift={-1}
+        groundAtmosphereBrightnessShift={2}
+        {...props}
+      />
+      {/* TODO(ReEarth): Support terrain heat-map */}
+      {/* <TerrainElevationImageryLayer
+        ref={setLayer}
+        baseUrl={process.env.NEXT_PUBLIC_API_BASE_URL}
+        colorToAlpha={Color.WHITE}
+        colorToAlphaThreshold={1}
+      /> */}
+    </>
+  );
+};

--- a/extension/src/prototypes/view/environments/GooglePhotorealisticEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/GooglePhotorealisticEnvironment.tsx
@@ -1,0 +1,18 @@
+import { type FC } from "react";
+import invariant from "tiny-invariant";
+
+import { Scene, SceneProps } from "../../../shared/reearth/scene";
+
+export const GooglePhotorealisticEnvironment: FC<SceneProps> = props => {
+  invariant(
+    process.env.NEXT_PUBLIC_GOOGLE_MAP_TILES_API_KEY != null,
+    "Missing environment variable: NEXT_PUBLIC_GOOGLE_MAP_TILES_API_KEY",
+  );
+  return (
+    <>
+      <Scene showGlobe={false} shadowDarkness={0.7} {...props} />
+      {/* TODO(ReEarth): Support Google photorealistic */}
+      {/* <GooglePhotorealisticTileset apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAP_TILES_API_KEY} /> */}
+    </>
+  );
+};

--- a/extension/src/prototypes/view/environments/MapEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/MapEnvironment.tsx
@@ -1,6 +1,6 @@
 // import { VectorMapImageryLayer } from "@takram/plateau-datasets";
 import { useAtomValue } from "jotai";
-import { type FC } from "react";
+import { useMemo, type FC } from "react";
 
 import { Scene, SceneProps } from "../../../shared/reearth/scene";
 import { type ColorMode } from "../../shared-states";
@@ -35,6 +35,8 @@ export const MapEnvironment: FC<MapEnvironmentProps> = ({ colorMode = "light", .
   //   layer?.sendToBack();
   // }, [layer]);
 
+  const tiles = useMemo(() => [{ id: "default", tile_type: "stamen_toner" }], []);
+
   return (
     <Scene
       // TODO: Define in theme
@@ -50,7 +52,7 @@ export const MapEnvironment: FC<MapEnvironmentProps> = ({ colorMode = "light", .
       groundAtmosphereBrightnessShift={2}
       // TODO(ReEarth): Use Takram's tile
       // TODO(ReEarth): Support tile brightness
-      tiles={[{ id: "default", tile_type: "stamen_toner" }]}
+      tiles={tiles}
       {...props}
     />
   );

--- a/extension/src/prototypes/view/environments/MapEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/MapEnvironment.tsx
@@ -1,0 +1,57 @@
+// import { VectorMapImageryLayer } from "@takram/plateau-datasets";
+import { useAtomValue } from "jotai";
+import { type FC } from "react";
+
+import { Scene, SceneProps } from "../../../shared/reearth/scene";
+import { type ColorMode } from "../../shared-states";
+import { enableTerrainLightingAtom } from "../states/app";
+
+// Flat white sky and gray ground
+const sphericalHarmonicCoefficients: [x: number, y: number, z: number][] = [
+  [0.651181936264038, 0.651181936264038, 0.651181936264038], // L00, irradiance, pre-scaled base
+  [0.335859775543213, 0.335859775543213, 0.335859775543213], // L1-1, irradiance, pre-scaled base
+  [0.000000874592729, 0.000000874592729, 0.000000874592729], // L10, irradiance, pre-scaled base
+  [0.000000027729817, 0.000000027729817, 0.000000027729817], // L11, irradiance, pre-scaled base
+  [0.000000014838997, 0.000000014838997, 0.000000014838997], // L2-2, irradiance, pre-scaled base
+  [-0.000000005038311, -0.000000005038311, -0.000000005038311], // L2-1, irradiance, pre-scaled base
+  [0.000121221753943, 0.000121221753943, 0.000121221753943], // L20, irradiance, pre-scaled base
+  [0.000000282587223, 0.000000282587223, 0.000000282587223], // L21, irradiance, pre-scaled base
+  [0.000364663166692, 0.000364663166692, 0.000364663166692], // L22, irradiance, pre-scaled base
+];
+
+export interface MapEnvironmentProps extends SceneProps {
+  colorMode?: ColorMode;
+}
+
+export const MapEnvironment: FC<MapEnvironmentProps> = ({ colorMode = "light", ...props }) => {
+  // invariant(
+  //   process.env.NEXT_PUBLIC_TILES_BASE_URL != null,
+  //   "Missing environment variable: NEXT_PUBLIC_TILES_BASE_URL",
+  // );
+  const enableTerrainLighting = useAtomValue(enableTerrainLightingAtom);
+
+  // const [layer, setLayer] = useState<ImageryLayerHandle | null>(null);
+  // useEffect(() => {
+  //   layer?.sendToBack();
+  // }, [layer]);
+
+  return (
+    <Scene
+      // TODO: Define in theme
+      // TODO: Swap background when view is ready
+      globeBaseColor={colorMode === "light" ? "#f7f7f7" : "#000000"}
+      enableGlobeLighting={enableTerrainLighting}
+      lightIntensity={10}
+      shadowDarkness={colorMode === "light" ? 0.7 : 0.3}
+      imageBasedLightingIntensity={1}
+      sphericalHarmonicCoefficients={sphericalHarmonicCoefficients}
+      showSkyBox={false}
+      atmosphereSaturationShift={-1}
+      groundAtmosphereBrightnessShift={2}
+      // TODO(ReEarth): Use Takram's tile
+      // TODO(ReEarth): Support tile brightness
+      tiles={[{ id: "default", tile_type: "stamen_toner" }]}
+      {...props}
+    />
+  );
+};

--- a/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
@@ -31,6 +31,7 @@ export const SatelliteEnvironment: FC<SceneProps> = props => {
     <Scene
       enableGlobeLighting={enableTerrainLighting}
       lightIntensity={1}
+      globeImageBasedLightingFactor={0.8}
       shadowDarkness={0.5}
       sphericalHarmonicCoefficients={sphericalHarmonicCoefficients}
       tiles={[

--- a/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
@@ -1,0 +1,52 @@
+import { useAtomValue } from "jotai";
+import { type FC } from "react";
+
+import { SceneProps, Scene } from "../../../shared/reearth/scene";
+import { enableTerrainLightingAtom } from "../states/app";
+
+// TODO: Create time-based interpolation of sky atmosphere.
+// Spherical harmonic coefficients generated from a modified version of:
+// https://polyhaven.com/a/teufelsberg_ground_2
+const sphericalHarmonicCoefficients: [x: number, y: number, z: number][] = [
+  [1.221931219100952, 1.266084671020508, 1.019550442695618],
+  [0.800345599651337, 0.841745376586914, 0.723761379718781],
+  [0.912390112876892, 0.922998011112213, 0.649103164672852],
+  [-0.843475937843323, -0.853787302970886, -0.601324439048767],
+  [-0.495116978883743, -0.5034259557724, -0.360104471445084],
+  [0.497776478528976, 0.507052302360535, 0.364346027374268],
+  [0.082192525267601, 0.082608506083488, 0.056836795061827],
+  [-0.925247848033905, -0.940086245536804, -0.678709805011749],
+  [0.114833705127239, 0.114355310797691, 0.067587599158287],
+];
+
+export const SatelliteEnvironment: FC<SceneProps> = props => {
+  const enableTerrainLighting = useAtomValue(enableTerrainLightingAtom);
+
+  // const [layer, setLayer] = useState<ImageryLayerHandle | null>(null);
+  // useEffect(() => {
+  //   layer?.sendToBack();
+  // }, [layer]);
+
+  return (
+    <Scene
+      enableGlobeLighting={enableTerrainLighting}
+      lightIntensity={1}
+      shadowDarkness={0.5}
+      sphericalHarmonicCoefficients={sphericalHarmonicCoefficients}
+      tiles={[
+        {
+          id: "tokyo_1",
+          tile_url: "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg",
+          tile_type: "url",
+        },
+        {
+          id: "tokyo_2",
+          tile_url:
+            "https://gic-plateau.s3.ap-northeast-1.amazonaws.com/2020/ortho/tiles/{z}/{x}/{y}.png",
+          tile_type: "url",
+        },
+      ]}
+      {...props}
+    />
+  );
+};

--- a/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
+++ b/extension/src/prototypes/view/environments/SatelliteEnvironment.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from "jotai";
-import { type FC } from "react";
+import { useMemo, type FC } from "react";
 
 import { SceneProps, Scene } from "../../../shared/reearth/scene";
 import { enableTerrainLightingAtom } from "../states/app";
@@ -27,6 +27,23 @@ export const SatelliteEnvironment: FC<SceneProps> = props => {
   //   layer?.sendToBack();
   // }, [layer]);
 
+  const tiles = useMemo(
+    () => [
+      {
+        id: "tokyo_1",
+        tile_url: "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg",
+        tile_type: "url",
+      },
+      {
+        id: "tokyo_2",
+        tile_url:
+          "https://gic-plateau.s3.ap-northeast-1.amazonaws.com/2020/ortho/tiles/{z}/{x}/{y}.png",
+        tile_type: "url",
+      },
+    ],
+    [],
+  );
+
   return (
     <Scene
       enableGlobeLighting={enableTerrainLighting}
@@ -34,19 +51,7 @@ export const SatelliteEnvironment: FC<SceneProps> = props => {
       globeImageBasedLightingFactor={0.8}
       shadowDarkness={0.5}
       sphericalHarmonicCoefficients={sphericalHarmonicCoefficients}
-      tiles={[
-        {
-          id: "tokyo_1",
-          tile_url: "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg",
-          tile_type: "url",
-        },
-        {
-          id: "tokyo_2",
-          tile_url:
-            "https://gic-plateau.s3.ap-northeast-1.amazonaws.com/2020/ortho/tiles/{z}/{x}/{y}.png",
-          tile_type: "url",
-        },
-      ]}
+      tiles={tiles}
       {...props}
     />
   );

--- a/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
@@ -7,7 +7,7 @@ import darkMapImage from "../../../prototypes/view/assets/dark_map.webp";
 import elevationImage from "../../../prototypes/view/assets/elevation.webp";
 import lightMapImage from "../../../prototypes/view/assets/light_map.webp";
 import satelliteImage from "../../../prototypes/view/assets/satellite.webp";
-import { sharableEnvironmentTypeAtom } from "../../../shared/states/scene";
+import { shareableEnvironmentTypeAtom } from "../../../shared/states/scene";
 import { colorMapTurbo } from "../../color-maps";
 import { colorModeAtom } from "../../shared-states";
 import {
@@ -160,7 +160,7 @@ const ElevationLegendButton: FC = () => {
 
 export const EnvironmentSelect: FC = () => {
   // FIXME
-  const [environmentType, setEnvironmentType] = useAtom(sharableEnvironmentTypeAtom);
+  const [environmentType, setEnvironmentType] = useAtom(shareableEnvironmentTypeAtom);
   const [colorMode, setColorMode] = useAtom(colorModeAtom);
 
   const id = useId();

--- a/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
@@ -3,6 +3,11 @@ import { useAtom, useAtomValue } from "jotai";
 import { bindPopover, bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { useCallback, useId, type FC } from "react";
 
+import darkMapImage from "../../../prototypes/view/assets/dark_map.webp";
+import elevationImage from "../../../prototypes/view/assets/elevation.webp";
+import lightMapImage from "../../../prototypes/view/assets/light_map.webp";
+import satelliteImage from "../../../prototypes/view/assets/satellite.webp";
+import { sharableEnvironmentTypeAtom } from "../../../shared/states/scene";
 import { colorMapTurbo } from "../../color-maps";
 import { colorModeAtom } from "../../shared-states";
 import {
@@ -17,15 +22,7 @@ import {
   SwitchParameterItem,
   type SelectItemProps,
 } from "../../ui-components";
-import darkMapImage from "../../../prototypes/view/assets/dark_map.webp";
-import elevationImage from "../../../prototypes/view/assets/elevation.webp";
-import lightMapImage from "../../../prototypes/view/assets/light_map.webp";
-import satelliteImage from "../../../prototypes/view/assets/satellite.webp";
-import {
-  environmentTypeAtom,
-  logarithmicTerrainElevationAtom,
-  terrainElevationHeightRangeAtom,
-} from "../states/app";
+import { logarithmicTerrainElevationAtom, terrainElevationHeightRangeAtom } from "../states/app";
 
 const LegendButton = styled(Button)(({ theme }) => ({
   display: "flex",
@@ -163,7 +160,7 @@ const ElevationLegendButton: FC = () => {
 
 export const EnvironmentSelect: FC = () => {
   // FIXME
-  const [environmentType, setEnvironmentType] = useAtom(environmentTypeAtom);
+  const [environmentType, setEnvironmentType] = useAtom(sharableEnvironmentTypeAtom);
   const [colorMode, setColorMode] = useAtom(colorModeAtom);
 
   const id = useId();

--- a/extension/src/prototypes/view/ui-containers/SettingsPanel.tsx
+++ b/extension/src/prototypes/view/ui-containers/SettingsPanel.tsx
@@ -1,16 +1,14 @@
 import { styled } from "@mui/material";
 import { type FC } from "react";
 
+import { sharableGraphicsQualityAtom } from "../../../shared/states/scene";
 import {
   FloatingPanel,
   ParameterList,
   SegmentParameterItem,
   SwitchParameterItem,
 } from "../../ui-components";
-import {
-  graphicsQualityAtom,
-  nativeResolutionEnabledAtom,
-} from "../states/graphics";
+import { nativeResolutionEnabledAtom } from "../states/graphics";
 
 const Root = styled(FloatingPanel)(({ theme }) => ({
   width: 360,
@@ -30,7 +28,7 @@ export const SettingsPanel: FC = () => {
         <SegmentParameterItem
           label="グラフィック品質"
           exclusive
-          atom={graphicsQualityAtom}
+          atom={sharableGraphicsQualityAtom}
           items={[
             ["low", "低"],
             ["medium", "中"],

--- a/extension/src/prototypes/view/ui-containers/SettingsPanel.tsx
+++ b/extension/src/prototypes/view/ui-containers/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@mui/material";
 import { type FC } from "react";
 
-import { sharableGraphicsQualityAtom } from "../../../shared/states/scene";
+import { shareableGraphicsQualityAtom } from "../../../shared/states/scene";
 import {
   FloatingPanel,
   ParameterList,
@@ -28,7 +28,7 @@ export const SettingsPanel: FC = () => {
         <SegmentParameterItem
           label="グラフィック品質"
           exclusive
-          atom={sharableGraphicsQualityAtom}
+          atom={shareableGraphicsQualityAtom}
           items={[
             ["low", "低"],
             ["medium", "中"],

--- a/extension/src/shared/reearth/hooks/useView.ts
+++ b/extension/src/shared/reearth/hooks/useView.ts
@@ -1,9 +1,0 @@
-import { useEffect } from "react";
-
-import { FlyToDestination } from "../types";
-
-export const useView = (destination: FlyToDestination) => {
-  useEffect(() => {
-    window.reearth?.camera?.flyTo(destination, { withoutAnimation: true });
-  }, [destination]);
-};

--- a/extension/src/shared/reearth/layers/3dtiles.ts
+++ b/extension/src/shared/reearth/layers/3dtiles.ts
@@ -18,7 +18,9 @@ export const TilesetLayer: FC<Props> = ({ url, onLoad }) => {
         type: "3dtiles",
         url,
       },
-      "3dtiles": {},
+      "3dtiles": {
+        pbr: false,
+      },
     });
 
     setTimeout(() => {

--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -1,0 +1,198 @@
+/** Correspond to https://github.com/takram-design-engineering/plateau-view/blob/main/libs/cesium/src/Environment.tsx */
+
+import { FC, useEffect } from "react";
+
+import { AmbientOcclusion, Antialias, Tile } from "../types";
+
+// nx = red
+// ny = green
+// nz = blue
+// px = cyan
+// py = magenta
+// pz = yellow
+const debugSphericalHarmonicCoefficients: [x: number, y: number, z: number][] = [
+  [0.499745965003967, 0.499196201562881, 0.500154078006744], // L00, irradiance, pre-scaled base
+  [0.265826553106308, -0.266099184751511, 0.265922993421555], // L1-1, irradiance, pre-scaled base
+  [0.243236944079399, 0.266723394393921, -0.265380442142487], // L10, irradiance, pre-scaled base
+  [-0.266895800828934, 0.265416264533997, 0.266921550035477], // L11, irradiance, pre-scaled base
+  [0.000195000306121, -0.000644546060357, -0.000383183418307], // L2-2, irradiance, pre-scaled base
+  [-0.000396036746679, -0.000622032093816, 0.000262127199676], // L2-1, irradiance, pre-scaled base
+  [-0.000214280473301, 0.00004872302452, -0.000059724134189], // L20, irradiance, pre-scaled base
+  [0.000107143961941, -0.000126510843984, -0.000425444566645], // L21, irradiance, pre-scaled base
+  [-0.000069071611506, 0.000134039684781, -0.000119135256682], // L22, irradiance, pre-scaled base
+];
+
+export type EnvironmentProps = {
+  backgroundColor?: string;
+  globeBaseColor?: string;
+  showGlobe?: boolean;
+  enableGlobeLighting?: boolean;
+  globeImageBasedLightingFactor?: number;
+  terrainHeatmap?: boolean;
+  lightColor?: string;
+  lightIntensity?: number;
+  shadowDarkness?: number;
+  imageBasedLightingIntensity?: number;
+  sphericalHarmonicCoefficients?: [x: number, y: number, z: number][];
+  debugSphericalHarmonics?: boolean;
+  showSun?: boolean;
+  showMoon?: boolean;
+  showSkyBox?: boolean;
+  enableFog?: boolean;
+  fogDensity?: number;
+  showSkyAtmosphere?: boolean;
+  showGroundAtmosphere?: boolean;
+  atmosphereSaturationShift?: number;
+  atmosphereBrightnessShift?: number;
+  skyAtmosphereSaturationShift?: number;
+  skyAtmosphereBrightnessShift?: number;
+  groundAtmosphereSaturationShift?: number;
+  groundAtmosphereBrightnessShift?: number;
+};
+
+export type ShadowProps = { enabled?: boolean; size?: 1024 | 2048 | 4096; softShadows?: boolean };
+
+export type SceneProps = EnvironmentProps & {
+  ambientOcclusion?: AmbientOcclusion;
+  tiles?: Tile[];
+  shadows?: ShadowProps;
+  antialias?: Antialias;
+  terrainNormal?: boolean;
+};
+
+export const Scene: FC<SceneProps> = ({
+  backgroundColor = "black",
+  globeBaseColor = "black",
+  // showGlobe = true,
+  enableGlobeLighting = false,
+  globeImageBasedLightingFactor = 0.3,
+  // TODO(ReEarth): Support terrain heat-map
+  // terrainHeatmap = false,
+  lightColor = "white",
+  lightIntensity = 2,
+  shadowDarkness = 0.3,
+  imageBasedLightingIntensity = 1,
+  sphericalHarmonicCoefficients,
+  debugSphericalHarmonics = false,
+  showSun = true,
+  showMoon = false,
+  showSkyBox = true,
+  enableFog = true,
+  fogDensity = 0.0002,
+  showSkyAtmosphere = true,
+  showGroundAtmosphere = true,
+  atmosphereSaturationShift = 0,
+  atmosphereBrightnessShift = 0,
+  skyAtmosphereSaturationShift,
+  skyAtmosphereBrightnessShift,
+  groundAtmosphereSaturationShift,
+  groundAtmosphereBrightnessShift,
+  tiles,
+  ambientOcclusion,
+  shadows,
+  antialias,
+}) => {
+  useEffect(() => {
+    window.reearth?.scene?.overrideProperty({
+      default: {
+        camera: {
+          lng: 139.755,
+          lat: 35.675,
+          height: 1000,
+          heading: Math.PI * 0.4,
+          pitch: -Math.PI * 0.2,
+        },
+        bgcolor: backgroundColor,
+        skybox: showSkyBox,
+      },
+      atmosphere: {
+        // Globe
+        enable_lighting: enableGlobeLighting,
+        globeImageBasedLighting: enableGlobeLighting,
+        globeShadowDarkness: globeImageBasedLightingFactor,
+        globeBaseColor,
+
+        // Shadow
+        shadowDarkness,
+        shadows: shadows?.enabled,
+        shadowResolution: shadows?.size,
+        softShadow: shadows?.softShadows,
+        shadowMaximumDistance: 10000,
+
+        // Camera
+        fog: enableFog,
+        fog_density: fogDensity,
+
+        // Sun
+        enable_sun: showSun,
+
+        // Moon
+        enableMoon: showMoon,
+
+        // Sky
+        sky_atmosphere: showSkyAtmosphere,
+        skyboxSurturationShift: skyAtmosphereSaturationShift ?? atmosphereSaturationShift,
+        skyboxBrightnessShift: skyAtmosphereBrightnessShift ?? atmosphereBrightnessShift,
+
+        // Ground
+        ground_atmosphere: showGroundAtmosphere,
+        surturation_shift: groundAtmosphereSaturationShift ?? atmosphereSaturationShift,
+        brightness_shift: groundAtmosphereBrightnessShift ?? atmosphereBrightnessShift,
+      },
+      ambientOcclusion,
+      light: {
+        lightType: "directionalLight",
+        lightColor,
+        lightIntensity: debugSphericalHarmonics ? 0.5 : lightIntensity,
+
+        // Spherical harmonic
+        sphericalHarmonicCoefficients: debugSphericalHarmonics
+          ? debugSphericalHarmonicCoefficients
+          : sphericalHarmonicCoefficients,
+        imageBasedLightIntensity: imageBasedLightingIntensity,
+      },
+      tiles,
+      terrain: {
+        terrain: true,
+        terrainType: "cesiumion",
+        terrainCesiumIonAccessToken:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5N2UyMjcwOS00MDY1LTQxYjEtYjZjMy00YTU0ZTg5MmViYWQiLCJpZCI6ODAzMDYsImlhdCI6MTY0Mjc0ODI2MX0.dkwAL1CcljUV7NA7fDbhXXnmyZQU_c-G5zRx8PtEcxE",
+        terrainCesiumIonAsset: "770371",
+        terrainNormal: true,
+      },
+      render: {
+        antialias,
+      },
+    });
+  }, [
+    antialias,
+    ambientOcclusion,
+    atmosphereBrightnessShift,
+    atmosphereSaturationShift,
+    backgroundColor,
+    debugSphericalHarmonics,
+    enableFog,
+    enableGlobeLighting,
+    fogDensity,
+    globeImageBasedLightingFactor,
+    groundAtmosphereBrightnessShift,
+    groundAtmosphereSaturationShift,
+    imageBasedLightingIntensity,
+    lightColor,
+    lightIntensity,
+    shadowDarkness,
+    showGroundAtmosphere,
+    showSkyAtmosphere,
+    showSkyBox,
+    showSun,
+    showMoon,
+    sphericalHarmonicCoefficients,
+    tiles,
+    shadows,
+    globeBaseColor,
+    skyAtmosphereBrightnessShift,
+    skyAtmosphereSaturationShift,
+  ]);
+
+  return null;
+};

--- a/extension/src/shared/reearth/scene/index.ts
+++ b/extension/src/shared/reearth/scene/index.ts
@@ -1,0 +1,1 @@
+export * from "./Scene";

--- a/extension/src/shared/reearth/types/camera.ts
+++ b/extension/src/shared/reearth/types/camera.ts
@@ -1,6 +1,6 @@
 export type Camera = {
   /** Current camera position */
-  readonly position: CameraPosition | undefined;
+  readonly position: Partial<CameraPosition> | undefined;
   //   readonly viewport: Rect | undefined;
   readonly zoomIn: (amount: number, options?: CameraOptions) => void;
   readonly zoomOut: (amount: number, options?: CameraOptions) => void;

--- a/extension/src/shared/reearth/types/scene.ts
+++ b/extension/src/shared/reearth/types/scene.ts
@@ -1,4 +1,4 @@
-import { Camera, LatLngHeight } from "./camera";
+import { CameraPosition, LatLngHeight } from "./camera";
 
 export type TerrainProperty = {
   terrain?: boolean;
@@ -13,9 +13,39 @@ export type TerrainProperty = {
   terrainNormal?: boolean;
 };
 
+export type Tile = {
+  id: string;
+  tile_type?: string;
+  tile_url?: string;
+  tile_maxLevel?: number;
+  tile_minLevel?: number;
+  tile_opacity?: number;
+};
+
+export type AmbientOcclusion = {
+  enabled?: boolean;
+  quality?: "low" | "medium" | "high" | "extreme";
+  intensity?: number;
+  ambientOcclusionOnly?: boolean;
+};
+
+export type Antialias = "low" | "medium" | "high" | "extreme";
+
+export type Timeline = {
+  animation?: boolean;
+  visible?: boolean;
+  current?: string;
+  start?: string;
+  stop?: string;
+  stepType?: "rate" | "fixed";
+  multiplier?: number;
+  step?: number;
+  rangeType?: "unbounded" | "clamped" | "bounced";
+};
+
 export type SceneProperty = {
   default?: {
-    camera?: Camera;
+    camera?: Partial<CameraPosition>;
     allowEnterGround?: boolean;
     skybox?: boolean;
     bgcolor?: string;
@@ -26,7 +56,7 @@ export type SceneProperty = {
   cameraLimiter?: {
     cameraLimitterEnabled?: boolean;
     cameraLimitterShowHelper?: boolean;
-    cameraLimitterTargetArea?: Camera;
+    cameraLimitterTargetArea?: CameraPosition;
     cameraLimitterTargetWidth?: number;
     cameraLimitterTargetLength?: number;
   };
@@ -35,17 +65,11 @@ export type SceneProperty = {
   //     indicator_image?: string;
   //     indicator_image_scale?: number;
   //   };
-  tiles?: {
-    id: string;
-    tile_type?: string;
-    tile_url?: string;
-    tile_maxLevel?: number;
-    tile_minLevel?: number;
-    tile_opacity?: number;
-  }[];
+  tiles?: Tile[];
   terrain?: TerrainProperty;
   atmosphere?: {
     enable_sun?: boolean;
+    enableMoon?: boolean;
     enable_lighting?: boolean;
     ground_atmosphere?: boolean;
     sky_atmosphere?: boolean;
@@ -53,25 +77,19 @@ export type SceneProperty = {
     shadowResolution?: 1024 | 2048 | 4096;
     softShadow?: boolean;
     shadowDarkness?: number;
+    shadowMaximumDistance?: number;
     fog?: boolean;
     fog_density?: number;
     brightness_shift?: number;
     hue_shift?: number;
     surturation_shift?: number;
+    skyboxBrightnessShift?: number;
+    skyboxSurturationShift?: number;
     globeShadowDarkness?: number;
     globeImageBasedLighting?: boolean;
+    globeBaseColor?: string;
   };
-  timeline?: {
-    animation?: boolean;
-    visible?: boolean;
-    current?: string;
-    start?: string;
-    stop?: string;
-    stepType?: "rate" | "fixed";
-    multiplier?: number;
-    step?: number;
-    rangeType?: "unbounded" | "clamped" | "bounced";
-  };
+  timeline?: Timeline;
   googleAnalytics?: {
     enableGA?: boolean;
     trackingId?: string;
@@ -82,12 +100,7 @@ export type SceneProperty = {
     themeSelectColor?: string;
     themeBackgroundColor?: string;
   };
-  ambientOcclusion?: {
-    enabled?: boolean;
-    quality?: "low" | "medium" | "high" | "extreme";
-    intensity?: number;
-    ambientOcclusionOnly?: boolean;
-  };
+  ambientOcclusion?: AmbientOcclusion;
   light?: {
     lightType?: "sunLight" | "directionalLight";
     lightDirectionX?: number;
@@ -100,7 +113,7 @@ export type SceneProperty = {
     imageBasedLightIntensity?: number;
   };
   render?: {
-    antialias?: "low" | "medium" | "high" | "extreme";
+    antialias?: Antialias;
     debugFramePerSecond?: boolean;
   };
 };

--- a/extension/src/shared/sharedAtoms/store.ts
+++ b/extension/src/shared/sharedAtoms/store.ts
@@ -1,26 +1,36 @@
-declare global {
-  interface Window {
-    __PLATEAUVIEW3_SHARED?: Record<string, any>;
-  }
-}
-
 // Initialize stores for the share feature.
-window.__PLATEAUVIEW3_SHARED = window.__PLATEAUVIEW3_SHARED ?? {};
+let SHARED_STORE: Promise<Record<string, any>> = Promise.resolve({});
 
 // TODO(ReEarth): Support share feature
-// await fetch("share API").then(sharedData => {
-//   window.__PLATEAUVIEW3_SHARED = { ...window.__PLATEAUVIEW3_SHARED, ...sharedData };
-// });
+
+const fetchShare = () => {
+  const shareId = new URLSearchParams(window.location.search).get("share");
+  if (!shareId) return;
+  // window.__PLATEAUVIEW3_SHARED = fetch("share API").then(sharedData => {
+  //   return { ...window.__PLATEAUVIEW3_SHARED, ...sharedData };
+  // });
+  // NOTE: This is for test.
+  SHARED_STORE = new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        graphicsQuality: ["ultra"],
+        environmentType: ["satellite"],
+      });
+    }, 3000);
+  });
+};
+fetchShare();
 
 const STORAGE_PREFIX = "PLATEAUVIEW3_STORAGE";
 const makeStorageKey = (k: string) => `${STORAGE_PREFIX}_${k}`;
 
-export const getSharedStoreValue = <T>(k: string): T | undefined =>
-  window.__PLATEAUVIEW3_SHARED?.[k] as T;
+export const getSharedStoreValue = async <T>(k: string): Promise<T | undefined> =>
+  SHARED_STORE.then(v => v[k] as T);
 export const getStorageStoreValue = <T>(k: string): T | undefined =>
   JSON.parse(window.localStorage.getItem(makeStorageKey(k)) ?? "null");
 
-export const setSharedStoreValue = <T>(k: string, v: T) =>
-  window.__PLATEAUVIEW3_SHARED?.[k] ? (window.__PLATEAUVIEW3_SHARED[k] = v) : undefined;
+export const setSharedStoreValue = <T>(k: string, v: T) => {
+  SHARED_STORE.then(o => (o[k] = v));
+};
 export const setStorageStoreValue = <T>(k: string, v: T) =>
   window.localStorage.setItem(makeStorageKey(k), JSON.stringify(v ?? null));

--- a/extension/src/shared/states/scene.ts
+++ b/extension/src/shared/states/scene.ts
@@ -1,6 +1,12 @@
-import { SceneProperty } from "../reearth/types";
-import { sharedAtom } from "../sharedAtoms";
+import { environmentTypeAtom } from "../../prototypes/view/states/app";
+import { graphicsQualityAtom } from "../../prototypes/view/states/graphics";
+import { sharedStoreAtomWrapper } from "../sharedAtoms";
 
-const initialScene: SceneProperty = {};
-
-export const sceneAtom = sharedAtom("scene", initialScene);
+export const sharableGraphicsQualityAtom = sharedStoreAtomWrapper(
+  "graphicsQuality",
+  graphicsQualityAtom,
+);
+export const sharableEnvironmentTypeAtom = sharedStoreAtomWrapper(
+  "environmentType",
+  environmentTypeAtom,
+);

--- a/extension/src/shared/states/scene.ts
+++ b/extension/src/shared/states/scene.ts
@@ -2,11 +2,11 @@ import { environmentTypeAtom } from "../../prototypes/view/states/app";
 import { graphicsQualityAtom } from "../../prototypes/view/states/graphics";
 import { sharedStoreAtomWrapper } from "../sharedAtoms";
 
-export const sharableGraphicsQualityAtom = sharedStoreAtomWrapper(
+export const shareableGraphicsQualityAtom = sharedStoreAtomWrapper(
   "graphicsQuality",
   graphicsQualityAtom,
 );
-export const sharableEnvironmentTypeAtom = sharedStoreAtomWrapper(
+export const shareableEnvironmentTypeAtom = sharedStoreAtomWrapper(
   "environmentType",
   environmentTypeAtom,
 );

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -1,25 +1,15 @@
 import { LayersRenderer } from "../prototypes/layers";
 import { AppFrame } from "../prototypes/ui-components";
+import { Environments } from "../prototypes/view/containers/Environments";
 import { InitialLayers } from "../prototypes/view/containers/InitialLayers";
 import { ToolMachineEvents } from "../prototypes/view/containers/ToolMachineEvents";
 import { AppHeader } from "../prototypes/view/ui-containers/AppHeader";
 import { layerComponents } from "../prototypes/view-layers/layerComponents";
 import { WidgetContext } from "../shared/context/WidgetContext";
-import { useView } from "../shared/reearth/hooks/useView";
-import { FlyToDestination } from "../shared/reearth/types";
 
 import { useInteractionMode } from "./hooks/useInteractionMode";
 
-const InitialDestination: FlyToDestination = {
-  lng: 139.755,
-  lat: 35.675,
-  height: 1000,
-  heading: Math.PI * 0.4,
-  pitch: -Math.PI * 0.2,
-};
-
 export const Widget = () => {
-  useView(InitialDestination);
   useInteractionMode();
 
   return (
@@ -34,6 +24,7 @@ export const Widget = () => {
       <LayersRenderer components={layerComponents} />
       {/* </SuspendUntilTilesLoaded>
       </Suspense> */}
+      <Environments />
       <ToolMachineEvents />
       <InitialLayers />
     </WidgetContext>


### PR DESCRIPTION
NOTE: To work this PR, this PR is necessary. https://github.com/reearth/reearth/pull/663

I added a basic scene support.
- Same view with VIEW3.0 prototype
  - The `map` type base-map is an alternative. I will update this after the same one with prototype is implemented.
- Share scene feature
  - You can test the share feature by adding `?share=123`.
![Screenshot 2023-09-06 at 9 09 36](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/1764923d-dd74-4ff5-9ef6-183e5600cdbf)


