### PR TITLE
feat(extension): connect location bread crumbs

### DIFF
--- a/extension/src/prototypes/view/containers/ReverseGeocoding.tsx
+++ b/extension/src/prototypes/view/containers/ReverseGeocoding.tsx
@@ -1,0 +1,19 @@
+import { useSetAtom } from "jotai";
+import { useEffect, type FC } from "react";
+
+import { addressAtom } from "../../../shared/states/address";
+import { useReverseGeocoder } from "../hooks/useReverseGeocoder";
+// import { readyAtom } from "../states/app";
+
+export const ReverseGeocoding: FC = () => {
+  const address = useReverseGeocoder();
+  const setAddress = useSetAtom(addressAtom);
+  // TODO: connect app ready state
+  // const ready = useAtomValue(readyAtom);
+  useEffect(() => {
+    // if (ready) {
+    setAddress(address ?? null);
+    // }
+  }, [address, setAddress]);
+  return null;
+};

--- a/extension/src/prototypes/view/hooks/useReverseGeocoder.ts
+++ b/extension/src/prototypes/view/hooks/useReverseGeocoder.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+import { useAreas } from "../../../shared/graphql/hooks";
+import { useReEarthEvent } from "../../../shared/reearth/hooks";
+import type { Address } from "../../../shared/states/address";
+
+export type ReverseGeocoderResult = Address<true>;
+
+export function useReverseGeocoder(): ReverseGeocoderResult | undefined {
+  const [croods, setCroods] = useState<{
+    longitude?: number;
+    latitude?: number;
+  }>({});
+
+  const viewSize = useRef<number>();
+
+  const [getAreas, { data }] = useAreas({
+    longitude: croods.longitude ?? 0,
+    latitude: croods.latitude ?? 0,
+    includeRadii: true,
+  });
+  const [result, setResult] = useState<ReverseGeocoderResult>();
+
+  useEffect(() => {
+    if (data?.areas) {
+      const areas = data.areas;
+      if (viewSize.current) {
+        const threshold = viewSize.current * 0.5;
+        areas.areas = areas.areas.filter(area => area.radius > threshold);
+        console.log(data.areas, viewSize.current);
+      }
+      setResult(areas as ReverseGeocoderResult);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    getAreas();
+  }, [croods, getAreas]);
+
+  const updateFovInfo = useCallback(() => {
+    const fovInfo = window.reearth?.camera?.getFovInfo({ withTerrain: true, calcViewSize: true });
+    setCroods({
+      longitude: fovInfo?.center?.lng,
+      latitude: fovInfo?.center?.lat,
+    });
+    viewSize.current = fovInfo?.viewSize;
+  }, []);
+
+  useReEarthEvent("cameramove", updateFovInfo);
+
+  return result;
+}

--- a/extension/src/prototypes/view/hooks/useReverseGeocoder.ts
+++ b/extension/src/prototypes/view/hooks/useReverseGeocoder.ts
@@ -27,7 +27,6 @@ export function useReverseGeocoder(): ReverseGeocoderResult | undefined {
       if (viewSize.current) {
         const threshold = viewSize.current * 0.5;
         areas.areas = areas.areas.filter(area => area.radius > threshold);
-        console.log(data.areas, viewSize.current);
       }
       setResult(areas as ReverseGeocoderResult);
     }

--- a/extension/src/prototypes/view/ui-containers/LocationBreadcrumbs.tsx
+++ b/extension/src/prototypes/view/ui-containers/LocationBreadcrumbs.tsx
@@ -1,13 +1,13 @@
+import { useAtomValue } from "jotai";
 import { type FC } from "react";
 
+import { areasAtom } from "../../../shared/states/address";
 import { AppBreadcrumbs, AppBreadcrumbsItem } from "../../ui-components";
 // FIXME
-// import { areasAtom } from "../../shared/states/address";
 // import { LocationBreadcrumbItem } from "./LocationBreadcrumbItem";
 
 export const LocationBreadcrumbs: FC = () => {
-  const areas = ["Prefecture", "Municipality", "City"];
-  // useAtomValue(areasAtom);
+  const areas = useAtomValue(areasAtom);
   if (areas == null) {
     return null;
   }
@@ -15,7 +15,7 @@ export const LocationBreadcrumbs: FC = () => {
     <AppBreadcrumbs>
       {[...areas].reverse().map(area => (
         // <LocationBreadcrumbItem key={area.code} area={area} />
-        <AppBreadcrumbsItem key={area}>{area}</AppBreadcrumbsItem>
+        <AppBreadcrumbsItem key={area.code}>{area.name}</AppBreadcrumbsItem>
       ))}
     </AppBreadcrumbs>
   );

--- a/extension/src/shared/graphql/base/__gen__/gql.ts
+++ b/extension/src/shared/graphql/base/__gen__/gql.ts
@@ -13,6 +13,7 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
+    "\n  query GetAreas($longitude: Float!, $latitude: Float!, $includeRadii: Boolean) {\n    areas(longitude: $longitude, latitude: $latitude, includeRadii: $includeRadii) {\n      areas {\n        code\n        name\n        radius\n        type\n      },\n      address\n    }\n  }\n": types.GetAreasDocument,
     "\n  query Health($id: ID!) {\n    health(id: $id) {\n      id\n      date\n    }\n  }\n": types.HealthDocument,
 };
 
@@ -30,6 +31,10 @@ const documents = {
  */
 export function gql(source: string): unknown;
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  query GetAreas($longitude: Float!, $latitude: Float!, $includeRadii: Boolean) {\n    areas(longitude: $longitude, latitude: $latitude, includeRadii: $includeRadii) {\n      areas {\n        code\n        name\n        radius\n        type\n      },\n      address\n    }\n  }\n"): (typeof documents)["\n  query GetAreas($longitude: Float!, $latitude: Float!, $includeRadii: Boolean) {\n    areas(longitude: $longitude, latitude: $latitude, includeRadii: $includeRadii) {\n      areas {\n        code\n        name\n        radius\n        type\n      },\n      address\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/extension/src/shared/graphql/base/__gen__/graphql.ts
+++ b/extension/src/shared/graphql/base/__gen__/graphql.ts
@@ -56,6 +56,15 @@ export type QueryHealthArgs = {
   id: Scalars['ID']['input'];
 };
 
+export type GetAreasQueryVariables = Exact<{
+  longitude: Scalars['Float']['input'];
+  latitude: Scalars['Float']['input'];
+  includeRadii?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+
+export type GetAreasQuery = { __typename?: 'Query', areas?: { __typename?: 'Areas', address: string, areas: Array<{ __typename?: 'Area', code: string, name: string, radius: number, type: string }> } | null };
+
 export type HealthQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -64,4 +73,5 @@ export type HealthQueryVariables = Exact<{
 export type HealthQuery = { __typename?: 'Query', health: { __typename?: 'Health', id: string, date: any } };
 
 
+export const GetAreasDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAreas"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"longitude"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Float"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"latitude"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Float"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"includeRadii"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"areas"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"longitude"},"value":{"kind":"Variable","name":{"kind":"Name","value":"longitude"}}},{"kind":"Argument","name":{"kind":"Name","value":"latitude"},"value":{"kind":"Variable","name":{"kind":"Name","value":"latitude"}}},{"kind":"Argument","name":{"kind":"Name","value":"includeRadii"},"value":{"kind":"Variable","name":{"kind":"Name","value":"includeRadii"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"areas"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"radius"}},{"kind":"Field","name":{"kind":"Name","value":"type"}}]}},{"kind":"Field","name":{"kind":"Name","value":"address"}}]}}]}}]} as unknown as DocumentNode<GetAreasQuery, GetAreasQueryVariables>;
 export const HealthDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Health"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"health"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"date"}}]}}]}}]} as unknown as DocumentNode<HealthQuery, HealthQueryVariables>;

--- a/extension/src/shared/graphql/base/queries/areas.ts
+++ b/extension/src/shared/graphql/base/queries/areas.ts
@@ -1,0 +1,15 @@
+import { gql } from "../__gen__/gql";
+
+export const AREAS = gql(`
+  query GetAreas($longitude: Float!, $latitude: Float!, $includeRadii: Boolean) {
+    areas(longitude: $longitude, latitude: $latitude, includeRadii: $includeRadii) {
+      areas {
+        code
+        name
+        radius
+        type
+      },
+      address
+    }
+  }
+`);

--- a/extension/src/shared/graphql/hooks/areas.ts
+++ b/extension/src/shared/graphql/hooks/areas.ts
@@ -1,0 +1,21 @@
+import { AREAS } from "../base/queries/areas";
+
+import { useLasyQuery } from "./base";
+
+export const useAreas = ({
+  longitude,
+  latitude,
+  includeRadii,
+}: {
+  longitude: number;
+  latitude: number;
+  includeRadii?: boolean;
+}) => {
+  return useLasyQuery(AREAS, {
+    variables: {
+      longitude,
+      latitude,
+      includeRadii,
+    },
+  });
+};

--- a/extension/src/shared/graphql/hooks/base.ts
+++ b/extension/src/shared/graphql/hooks/base.ts
@@ -1,11 +1,13 @@
 import {
   useQuery as useApolloQuery,
+  useLazyQuery as useApolloLazyQuery,
   DocumentNode,
   TypedDocumentNode,
   OperationVariables,
   QueryHookOptions,
   NoInfer,
   QueryResult,
+  LazyQueryResultTuple,
 } from "@apollo/client";
 
 import { client } from "../client";
@@ -15,6 +17,19 @@ export const useQuery = <TData = any, TVariables extends OperationVariables = Op
   options?: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
 ): QueryResult<TData, TVariables> => {
   return useApolloQuery(query, {
+    ...options,
+    client,
+  });
+};
+
+export const useLasyQuery = <
+  TData = any,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options?: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
+): LazyQueryResultTuple<TData, TVariables> => {
+  return useApolloLazyQuery(query, {
     ...options,
     client,
   });

--- a/extension/src/shared/graphql/hooks/index.ts
+++ b/extension/src/shared/graphql/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./health";
+export * from "./areas";

--- a/extension/src/shared/reearth/types/camera.ts
+++ b/extension/src/shared/reearth/types/camera.ts
@@ -27,6 +27,12 @@ export type Camera = {
     options?: CameraOptions,
     offset?: number,
   ) => void;
+  readonly getFovInfo: (options: { withTerrain?: boolean; calcViewSize?: boolean }) =>
+    | {
+        center?: LatLngHeight;
+        viewSize?: number;
+      }
+    | undefined;
 };
 
 export type FlyToDestination = {

--- a/extension/src/shared/states/address.ts
+++ b/extension/src/shared/states/address.ts
@@ -1,0 +1,66 @@
+import { atom, type SetStateAction } from "jotai";
+
+import { type ReverseGeocoderResult } from "../../prototypes/view/hooks/useReverseGeocoder";
+
+export interface Address<R extends boolean = boolean> {
+  areas: Array<Area<R>>;
+  address?: string;
+}
+
+export interface AreaCodes {
+  prefectures: Record<string, string>;
+  municipalities: Record<string, string | [string, string] | [string, string[]]>;
+}
+
+export type AreaRadii = Record<string, number>;
+
+export type AreaType = "prefecture" | "municipality";
+
+export interface Area<R extends boolean = boolean> {
+  type: AreaType;
+  code: string;
+  name: string;
+  radius: R extends true ? number : number | undefined;
+}
+
+export type PrefectureArea<R extends boolean = boolean> = Area<R> & {
+  type: "prefecture";
+};
+
+export type MunicipalityArea<R extends boolean = boolean> = Area<R> & {
+  type: "municipality";
+};
+
+const addressPrimitiveAtom = atom<ReverseGeocoderResult | null>(null);
+
+export const addressAtom = atom(
+  get => get(addressPrimitiveAtom),
+  (get, set, value: SetStateAction<ReverseGeocoderResult | null>) => {
+    set(addressPrimitiveAtom, value);
+
+    // Propagate changes to municipality and prefecture.
+    const address = get(addressPrimitiveAtom) as ReverseGeocoderResult | null;
+    set(areasPrimitiveAtom, prevValue =>
+      address != null
+        ? address.areas[0]?.code !== prevValue?.[0]?.code
+          ? address.areas
+          : prevValue
+        : null,
+    );
+    set(prefecturePrimitiveAtom, prevValue =>
+      address != null
+        ? address.areas[address.areas.length - 1]?.code !== prevValue?.code
+          ? address.areas.find(
+              (area: Area): area is PrefectureArea => area.type === "prefecture",
+            ) ?? null
+          : prevValue
+        : null,
+    );
+  },
+);
+
+const areasPrimitiveAtom = atom<Area[] | null>(null);
+export const areasAtom = atom(get => get(areasPrimitiveAtom));
+
+const prefecturePrimitiveAtom = atom<PrefectureArea | null>(null);
+export const prefectureAtom = atom(get => get(prefecturePrimitiveAtom));

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -4,6 +4,7 @@ import { LayersRenderer } from "../prototypes/layers";
 import { AppFrame } from "../prototypes/ui-components";
 import { Environments } from "../prototypes/view/containers/Environments";
 import { InitialLayers } from "../prototypes/view/containers/InitialLayers";
+import { ReverseGeocoding } from "../prototypes/view/containers/ReverseGeocoding";
 import { ToolMachineEvents } from "../prototypes/view/containers/ToolMachineEvents";
 import { AppHeader } from "../prototypes/view/ui-containers/AppHeader";
 import { layerComponents } from "../prototypes/view-layers/layerComponents";
@@ -31,6 +32,7 @@ export const Widget = () => {
       <Environments />
       <ToolMachineEvents />
       <InitialLayers />
+      <ReverseGeocoding />
     </WidgetContext>
   );
 };


### PR DESCRIPTION
## Overview

This PR connect location bread crumbs with reearth camera move & areas API.

## What I haven't done

Currently using AppBreadcrumbsItem to display the area names, didn't implement the popup with layers etc.

## Screenshot

![localhost_3000_scene_01h8xpy29t9jr0xpwcqdrw0zr6_map(Desktop 1920)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/a376c075-d48e-4990-a333-96d093cfa2e7)
m