### PR TITLE
fix(extension): component atom for viewer

### DIFF
--- a/extension/src/sampleEditor/Widget.tsx
+++ b/extension/src/sampleEditor/Widget.tsx
@@ -53,7 +53,7 @@ const ComponentItem: FC<{
   groupIndex: number;
 }> = ({ component, setting, settingIndex, componentIndex, groupIndex }) => {
   const [value, setValue] = useState({
-    type: typeof component.type,
+    type: typeof component.preset?.defaultValue,
     groupIndex,
     componentIndex,
     value: component.preset?.defaultValue,

--- a/extension/src/shared/layerContainers/3dtiles.tsx
+++ b/extension/src/shared/layerContainers/3dtiles.tsx
@@ -11,6 +11,7 @@ import { ViewLayerModel } from "../../prototypes/view-layers";
 import { useOptionalAtomValue } from "../hooks";
 import { PlateauTilesetProperties, TileFeatureIndex } from "../plateau";
 import { TILESET_FEATURE, TilesetLayer, TilesetProps } from "../reearth/layers";
+import { OpacityField } from "../types/fieldComponents/general";
 import { WritableAtomForComponent } from "../view-layers/component";
 
 import { useEvaluateFeatureColor } from "./hooks/useEvaluateFeatureColor";
@@ -23,7 +24,7 @@ type TilesetContainerProps = TilesetProps & {
   colorMapAtom: PrimitiveAtom<ColorMap>;
   colorRangeAtom: PrimitiveAtom<number[]>;
   colorSchemeAtom: ViewLayerModel["colorSchemeAtom"];
-  opacityAtom?: WritableAtomForComponent<number>;
+  opacityAtom?: WritableAtomForComponent<OpacityField>;
   selections?: ScreenSpaceSelectionEntry<typeof TILESET_FEATURE>[];
   hidden: boolean;
 };
@@ -102,7 +103,7 @@ export const TilesetLayerContainer: FC<TilesetContainerProps> = ({
   const color = useEvaluateFeatureColor({
     colorProperty: colorProperty ?? undefined,
     colorScheme: colorScheme ?? undefined,
-    opacity: opacity,
+    opacity: opacity?.value,
     selections,
   });
 
@@ -113,7 +114,7 @@ export const TilesetLayerContainer: FC<TilesetContainerProps> = ({
       {...props}
       onLoad={handleLoad}
       color={color}
-      enableShadow={!opacity || opacity === 1}
+      enableShadow={!opacity || opacity.value === 1}
       visible={!hidden}
       selectedFeatureColor={theme.palette.primary.main}
     />

--- a/extension/src/shared/layerContainers/general.tsx
+++ b/extension/src/shared/layerContainers/general.tsx
@@ -10,13 +10,14 @@ import {
 import { useOptionalAtomValue } from "../hooks";
 import { GeneralProps, GeneralLayer, GENERAL_FEATURE } from "../reearth/layers";
 import { Properties } from "../reearth/utils";
+import { PointColorField, PointSizeField } from "../types/fieldComponents/point";
 import { WritableAtomForComponent } from "../view-layers/component";
 
 type GeneralContainerProps = GeneralProps & {
   layerIdAtom: PrimitiveAtom<string | null>;
   propertiesAtom: PrimitiveAtom<Properties | null>;
-  pointColorAtom?: WritableAtomForComponent<string>;
-  pointSizeAtom?: WritableAtomForComponent<number>;
+  pointColorAtom?: WritableAtomForComponent<PointColorField>;
+  pointSizeAtom?: WritableAtomForComponent<PointSizeField>;
   selections?: ScreenSpaceSelectionEntry<typeof GENERAL_FEATURE>[];
   hidden: boolean;
   type: LayerType;
@@ -82,8 +83,8 @@ export const GeneralLayerContainer: FC<GeneralContainerProps> = ({
     <GeneralLayer
       {...props}
       onLoad={handleLoad}
-      pointColor={pointColor}
-      pointSize={JSON.stringify(pointSize)}
+      pointColor={pointColor?.value}
+      pointSize={pointSize?.value ? JSON.stringify(pointSize?.value) : undefined}
       visible={!hidden}
       selectedFeatureColor={theme.palette.primary.main}
     />

--- a/extension/src/shared/view-layers/3dtiles/BuildingLayer.tsx
+++ b/extension/src/shared/view-layers/3dtiles/BuildingLayer.tsx
@@ -8,9 +8,9 @@ import {
   BUILDING_LAYER,
   ConfigurableLayerModel,
 } from "../../../prototypes/view-layers";
-import { OPACITY_FIELD } from "../../types/fieldComponents/general";
 import { TilesetLayerContainer } from "../../layerContainers/3dtiles";
 import { TILESET_FEATURE } from "../../reearth/layers";
+import { OPACITY_FIELD } from "../../types/fieldComponents/general";
 import { useFindComponent } from "../hooks";
 import { LayerModel, LayerModelParams } from "../model";
 

--- a/extension/src/shared/view-layers/component.ts
+++ b/extension/src/shared/view-layers/component.ts
@@ -17,7 +17,7 @@ export type WritableAtomForComponent<T> = WritableAtom<T, [update: T], void>;
 
 export type ComponentAtom<T extends ComponentBase["type"] = ComponentBase["type"]> = {
   type: Component<T>["type"];
-  atom: WritableAtomForComponent<Component<T>["value"]>;
+  atom: WritableAtomForComponent<Component<T>>;
 };
 
 export type ComponentIdParams = {
@@ -55,10 +55,12 @@ export const makeComponentAtoms = (
   invariant(datasetId);
   return components.map(component => {
     const name = makeComponentId({ datasetId, componentType: component.type, shareId });
-    const defaultValue =
-      component.preset?.defaultValue ?? fieldSettings[component.type].defaultValue;
+    const componentForAtom = {
+      ...component,
+      value: component.preset?.defaultValue || fieldSettings[component.type].defaultValue,
+    } as Component;
     // TODO: load value from shared data
-    const a = sharedAtom(name, defaultValue);
+    const a = sharedAtom(name, componentForAtom);
     if (component.storeable) {
       return {
         type: component.type,

--- a/extension/src/shared/view/fields/general/LayerOpacityField.tsx
+++ b/extension/src/shared/view/fields/general/LayerOpacityField.tsx
@@ -1,23 +1,47 @@
-import { type FC } from "react";
+import { atom } from "jotai";
+import { useMemo, type FC } from "react";
 
 import {
   formatPercent,
   ParameterList,
   SliderParameterItem,
 } from "../../../../prototypes/ui-components";
+import { OpacityField } from "../../../types/fieldComponents/general";
 import { WritableAtomForComponent } from "../../../view-layers/component";
 
 export interface LayerOpacityFieldProps {
-  atoms: WritableAtomForComponent<number>[];
+  atoms: WritableAtomForComponent<OpacityField>[];
 }
 
 export const LayerOpacityField: FC<LayerOpacityFieldProps> = ({ atoms }) => {
+  const wrappedAtoms: [WritableAtomForComponent<number>] = useMemo(
+    () => [
+      atom(
+        get => (atoms[0] ? get(atoms[0]).value : 1),
+        (get, set, update: number) => {
+          if (!atoms[0]) {
+            return;
+          }
+          set(atoms[0], { ...get(atoms[0]), value: update });
+        },
+      ),
+    ],
+    [atoms],
+  );
+
   if (atoms.length === 0) {
     return null;
   }
+
   return (
     <ParameterList>
-      <SliderParameterItem label="不透明度" atom={atoms} min={0} max={1} format={formatPercent} />
+      <SliderParameterItem
+        label="不透明度"
+        atom={wrappedAtoms}
+        min={0}
+        max={1}
+        format={formatPercent}
+      />
     </ParameterList>
   );
 };


### PR DESCRIPTION
I fixed the component atom to take the entire field component which is set from editor. Therefore we can refer the setting value from editor in viewer.