### PR TITLE
feat(extension): connect the common state between editor and viewer

### DIFF
--- a/extension/src/prototypes/ui-components/editor/EditorPanel.tsx
+++ b/extension/src/prototypes/ui-components/editor/EditorPanel.tsx
@@ -18,6 +18,8 @@ export type EditorSectionProps = {
   main: React.ReactNode;
   header?: React.ReactNode;
   showSaveButton?: boolean;
+  showApplyButton?: boolean;
+  onApply?: () => void;
   onSave?: () => void;
 };
 
@@ -27,7 +29,9 @@ export const EditorSection: React.FC<EditorSectionProps> = ({
   main,
   header,
   showSaveButton,
+  showApplyButton,
   onSave,
+  onApply,
 }) => {
   return (
     <ContentWrapper>
@@ -38,6 +42,17 @@ export const EditorSection: React.FC<EditorSectionProps> = ({
       <Main>
         {header && <SectionHeader>{header}</SectionHeader>}
         <SectionContent>{main}</SectionContent>
+        {showApplyButton && (
+          <SectionAction>
+            <StyledButton
+              startIcon={<SaveOutlinedIcon />}
+              variant="contained"
+              color="primary"
+              onClick={onApply}>
+              Apply
+            </StyledButton>
+          </SectionAction>
+        )}
         {showSaveButton && (
           <SectionAction>
             <StyledButton

--- a/extension/src/prototypes/view/ui-containers/editorContainers/common/fieldComponentEditor/fields/point/EditorPointColorField.tsx
+++ b/extension/src/prototypes/view/ui-containers/editorContainers/common/fieldComponentEditor/fields/point/EditorPointColorField.tsx
@@ -1,5 +1,22 @@
+import { useEffect, useRef } from "react";
+
 import { BasicFieldProps } from "..";
 
-export const EditorPointColorField: React.FC<BasicFieldProps<"POINT_COLOR_FIELD">> = () => {
-  return <div>EditorPointColorField</div>;
+export const EditorPointColorField: React.FC<BasicFieldProps<"POINT_COLOR_FIELD">> = ({
+  component,
+  onUpdate,
+}) => {
+  const componentRef = useRef(component);
+  componentRef.current = component;
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+  useEffect(() => {
+    onUpdateRef.current({
+      ...componentRef.current,
+      preset: {
+        defaultValue: "#f00000",
+      },
+    });
+  }, []);
+  return <div>EditorPointColorField: {component.preset?.defaultValue}</div>;
 };

--- a/extension/src/prototypes/view/ui-containers/editorContainers/common/fieldComponentEditor/fields/point/EditorPointSizeField.tsx
+++ b/extension/src/prototypes/view/ui-containers/editorContainers/common/fieldComponentEditor/fields/point/EditorPointSizeField.tsx
@@ -1,5 +1,22 @@
+import { useEffect, useRef } from "react";
+
 import { BasicFieldProps } from "..";
 
-export const EditorPointSizeField: React.FC<BasicFieldProps<"POINT_SIZE_FIELD">> = () => {
-  return <div>EditorPointSizeField</div>;
+export const EditorPointSizeField: React.FC<BasicFieldProps<"POINT_SIZE_FIELD">> = ({
+  component,
+  onUpdate,
+}) => {
+  const componentRef = useRef(component);
+  componentRef.current = component;
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+  useEffect(() => {
+    onUpdateRef.current({
+      ...componentRef.current,
+      preset: {
+        defaultValue: 100,
+      },
+    });
+  }, []);
+  return <div>EditorPointSizeField: {component.preset?.defaultValue}</div>;
 };

--- a/extension/src/sampleEditor/Widget.tsx
+++ b/extension/src/sampleEditor/Widget.tsx
@@ -23,12 +23,11 @@ const mockSetting: Setting = {
       {
         id: "1",
         name: "",
-        default: true,
         components: [
           {
             type: POINT_COLOR_FIELD,
             preset: {
-              defaultValue: `"#f0ff00"`,
+              defaultValue: "#f0ff00",
             },
             storeable: false,
           } as SettingComponent<"POINT_COLOR_FIELD">,
@@ -51,7 +50,7 @@ const ComponentItem: FC<{
   settingIndex: number;
   componentIndex: number;
   groupIndex: number;
-}> = ({ component, setting, settingIndex, componentIndex, groupIndex }) => {
+}> = ({ component, setting, componentIndex, groupIndex }) => {
   const [value, setValue] = useState({
     type: typeof component.preset?.defaultValue,
     groupIndex,
@@ -72,32 +71,29 @@ const ComponentItem: FC<{
   const apply = useCallback(() => {
     const s = settingRef.current;
 
-    updateSetting(
-      {
-        ...s,
-        fieldComponents: {
-          ...s.fieldComponents,
-          groups: s.fieldComponents?.groups?.map((g, gi) => ({
-            ...g,
-            components: g.components.map((c, ci) =>
-              deferredValue.groupIndex === gi && deferredValue.componentIndex === ci
-                ? {
-                    ...c,
-                    preset: {
-                      defaultValue:
-                        deferredValue.type === "string"
-                          ? (deferredValue.value as any)
-                          : Number(deferredValue.value) ?? 0,
-                    },
-                  }
-                : c,
-            ),
-          })),
-        },
+    updateSetting({
+      ...s,
+      fieldComponents: {
+        ...s.fieldComponents,
+        groups: s.fieldComponents?.groups?.map((g, gi) => ({
+          ...g,
+          components: g.components.map((c, ci) =>
+            deferredValue.groupIndex === gi && deferredValue.componentIndex === ci
+              ? {
+                  ...c,
+                  preset: {
+                    defaultValue:
+                      deferredValue.type === "string"
+                        ? (deferredValue.value as any)
+                        : Number(deferredValue.value) ?? 0,
+                  },
+                }
+              : c,
+          ),
+        })),
       },
-      settingIndex,
-    );
-  }, [deferredValue, settingIndex, updateSetting]);
+    });
+  }, [deferredValue, updateSetting]);
 
   return (
     <li>

--- a/extension/src/shared/api/constants.ts
+++ b/extension/src/shared/api/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SETTING_DATA_ID = "default";

--- a/extension/src/shared/api/hooks/settings.ts
+++ b/extension/src/shared/api/hooks/settings.ts
@@ -1,26 +1,8 @@
-// TODO: REMOVE THIS FILE
+import { settingsAtom } from "../../states/setting";
 
-import { atom, useAtom } from "jotai";
-import { useCallback } from "react";
-
-// import { DATA_API } from "../../constants";
-import { mockSettings } from "../mock";
-import { Setting } from "../types";
-
-const settingsAtom = atom<Setting[]>([]);
-
+// TODO: Imple saving setting state to API
 export default () => {
-  const [_, setSettings] = useAtom(settingsAtom);
-  const handleSettingsFetch = useCallback(async () => {
-    // TODO: use the new settings API
-    // const response = await fetch(`${DATA_API}/sidebar/plateauview3/data`);
-    // const settings = await response.json();
-
-    setSettings(mockSettings);
-  }, [setSettings]);
-
   return {
     settingsAtom,
-    handleSettingsFetch,
   };
 };

--- a/extension/src/shared/api/mock.ts
+++ b/extension/src/shared/api/mock.ts
@@ -21,7 +21,6 @@ export const mockSettings: Setting[] = [
       groups: [
         {
           id: "1",
-          default: true,
           name: "Default",
           components: [
             {
@@ -50,7 +49,6 @@ export const mockSettings: Setting[] = [
       groups: [
         {
           id: "1",
-          default: true,
           name: "Default",
           components: [
             {
@@ -79,7 +77,6 @@ export const mockSettings: Setting[] = [
       groups: [
         {
           id: "1",
-          default: true,
           name: "Default",
           components: [
             {
@@ -87,7 +84,7 @@ export const mockSettings: Setting[] = [
               type: POINT_COLOR_FIELD,
               storeable: false,
               preset: {
-                defaultValue: `"#0ffffff"`,
+                defaultValue: "#0fffff",
               },
             },
             {
@@ -114,7 +111,6 @@ export const mockFieldComponentTemplates: ComponentTemplate[] = [
     groups: [
       {
         id: "1",
-        default: true,
         name: "Default",
         components: [
           {
@@ -141,7 +137,6 @@ export const mockFieldComponentTemplates: ComponentTemplate[] = [
     groups: [
       {
         id: "1",
-        default: true,
         name: "Default",
         components: [
           {

--- a/extension/src/shared/api/types/component.ts
+++ b/extension/src/shared/api/types/component.ts
@@ -7,7 +7,6 @@ export type SettingComponent<T extends ComponentBase["type"] = ComponentBase["ty
 export type ComponentGroup = {
   id: string;
   name: string;
-  default?: boolean; // TODO: remove this. The first element in the array should be the default
   components: SettingComponent<ComponentBase["type"]>[];
 };
 

--- a/extension/src/shared/layerContainers/general.tsx
+++ b/extension/src/shared/layerContainers/general.tsx
@@ -7,27 +7,25 @@ import {
   ScreenSpaceSelectionEntry,
   useScreenSpaceSelectionResponder,
 } from "../../prototypes/screen-space-selection";
-import { useOptionalAtomValue } from "../hooks";
 import { GeneralProps, GeneralLayer, GENERAL_FEATURE } from "../reearth/layers";
 import { Properties } from "../reearth/utils";
-import { PointColorField, PointSizeField } from "../types/fieldComponents/point";
-import { WritableAtomForComponent } from "../view-layers/component";
+import { ComponentAtom } from "../view-layers/component";
 
-type GeneralContainerProps = GeneralProps & {
+import { useEvaluateGeneralAppearance } from "./hooks/useEvaluateGeneralAppearance";
+
+type GeneralContainerProps = Omit<GeneralProps, "appearances"> & {
   layerIdAtom: PrimitiveAtom<string | null>;
   propertiesAtom: PrimitiveAtom<Properties | null>;
-  pointColorAtom?: WritableAtomForComponent<PointColorField>;
-  pointSizeAtom?: WritableAtomForComponent<PointSizeField>;
   selections?: ScreenSpaceSelectionEntry<typeof GENERAL_FEATURE>[];
   hidden: boolean;
   type: LayerType;
+  componentAtoms: ComponentAtom[] | undefined;
 };
 
 export const GeneralLayerContainer: FC<GeneralContainerProps> = ({
   onLoad,
   layerIdAtom,
-  pointColorAtom,
-  pointSizeAtom,
+  componentAtoms,
   propertiesAtom,
   hidden,
   ...props
@@ -74,8 +72,7 @@ export const GeneralLayerContainer: FC<GeneralContainerProps> = ({
     [onLoad, setProperties, setLayerId],
   );
 
-  const pointColor = useOptionalAtomValue(pointColorAtom);
-  const pointSize = useOptionalAtomValue(pointSizeAtom);
+  const generalAppearances = useEvaluateGeneralAppearance({ componentAtoms });
 
   const theme = useTheme();
 
@@ -83,8 +80,7 @@ export const GeneralLayerContainer: FC<GeneralContainerProps> = ({
     <GeneralLayer
       {...props}
       onLoad={handleLoad}
-      pointColor={pointColor?.value}
-      pointSize={pointSize?.value ? JSON.stringify(pointSize?.value) : undefined}
+      appearances={generalAppearances}
       visible={!hidden}
       selectedFeatureColor={theme.palette.primary.main}
     />

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+
+import { useOptionalAtomValue } from "../../hooks";
+import { GeneralAppearances } from "../../reearth/layers";
+import { POINT_COLOR_FIELD, POINT_SIZE_FIELD } from "../../types/fieldComponents/point";
+import { ComponentAtom } from "../../view-layers/component";
+import { useFindComponent } from "../../view-layers/hooks";
+
+export const useEvaluateGeneralAppearance = ({
+  componentAtoms,
+}: {
+  componentAtoms: ComponentAtom[] | undefined;
+}) => {
+  const pointColor = useOptionalAtomValue(
+    useFindComponent<typeof POINT_COLOR_FIELD>(componentAtoms ?? [], POINT_COLOR_FIELD),
+  );
+  const pointSize = useOptionalAtomValue(
+    useFindComponent<typeof POINT_SIZE_FIELD>(componentAtoms ?? [], POINT_SIZE_FIELD),
+  );
+
+  const generalAppearances: GeneralAppearances = useMemo(
+    () => ({
+      marker: {
+        style: pointColor || pointSize ? "point" : undefined,
+        ...(pointColor?.value
+          ? {
+              pointColor: pointColor.value,
+            }
+          : {}),
+        ...(pointSize?.value ? { pointSize: pointSize.value } : {}),
+      },
+    }),
+    [pointColor, pointSize],
+  );
+
+  return generalAppearances;
+};

--- a/extension/src/shared/states/setting.ts
+++ b/extension/src/shared/states/setting.ts
@@ -24,13 +24,17 @@ export const removeSettingAtom = atom(undefined, (get, set, setting: PrimitiveAt
   });
 });
 
-export const updateSettingAtom = atom(undefined, (get, set, setting: Setting, index: number) => {
+export const updateSettingAtom = atom(undefined, (get, set, setting: Setting) => {
   set(updateRootLayerBySetting, setting);
-  console.log("updateSettingAtom", setting, index);
 
   const settings = get(settingsAtomsAtom);
-  const settingAtom = settings[index];
-  set(settingAtom, setting);
+  const settingAtom = settings.find(s => {
+    const prevSetting = get(s);
+    return prevSetting.datasetId === setting.datasetId && prevSetting.dataId === setting.dataId;
+  });
+  if (settingAtom) {
+    set(settingAtom, setting);
+  }
 });
 
 export const filterSettingAtom = atom(

--- a/extension/src/shared/view-layers/general/GeneralDatasetLayer.tsx
+++ b/extension/src/shared/view-layers/general/GeneralDatasetLayer.tsx
@@ -7,8 +7,6 @@ import { createViewLayerModel, ConfigurableLayerModel } from "../../../prototype
 import { GeneralLayerContainer } from "../../layerContainers/general";
 import { GENERAL_FEATURE } from "../../reearth/layers";
 import { Properties } from "../../reearth/utils";
-import { POINT_COLOR_FIELD, POINT_SIZE_FIELD } from "../../types/fieldComponents/point";
-import { useFindComponent } from "../hooks";
 import { LayerModel, LayerModelParams } from "../model";
 
 import { GENERAL_FORMAT } from "./format";
@@ -84,15 +82,6 @@ export const GeneralDatasetLayer: FC<LayerProps<GeneralLayerType>> = ({
   // TODO(ReEarth): Need a wireframe API
   // const showWireframe = useAtomValue(showWireframeAtom);
 
-  const pointColorAtom = useFindComponent<typeof POINT_COLOR_FIELD>(
-    componentAtoms ?? [],
-    POINT_COLOR_FIELD,
-  );
-  const pointSizeAtom = useFindComponent<typeof POINT_SIZE_FIELD>(
-    componentAtoms ?? [],
-    POINT_SIZE_FIELD,
-  );
-
   if (!url) {
     return null;
   }
@@ -110,8 +99,7 @@ export const GeneralDatasetLayer: FC<LayerProps<GeneralLayerType>> = ({
         // hiddenFeaturesAtom={hiddenFeaturesAtom}
         propertiesAtom={propertiesAtom}
         selections={selections as ScreenSpaceSelectionEntry<typeof GENERAL_FEATURE>[]}
-        pointColorAtom={pointColorAtom}
-        pointSizeAtom={pointSizeAtom}
+        componentAtoms={componentAtoms}
         // showWireframe={showWireframe}
       />
     );

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -25,7 +25,7 @@ export const fieldSettings: {
   },
   // point
   POINT_COLOR_FIELD: {
-    defaultValue: `"#f0ff00"`,
+    defaultValue: "#f0ff00",
     hasLegendUI: true,
   },
   POINT_SIZE_FIELD: {


### PR DESCRIPTION
I setup the connection with the common state between viewer and editor. But I haven't done API connection yet. I will work on it after this PR.

You can test as follows.
1. Select dataset(e.g. ランドマーク)
2. Default appearance is displayed first
3. You can add `Point color` and `Point size` field which have hard coded value.
4. Click apply button, then the setting is attached.