### PR TITLE
feat(extension): add notice and status control for editor saving

### DIFF
--- a/extension/src/editor/containers/common/commonTemplate/TemplateAddButton.tsx
+++ b/extension/src/editor/containers/common/commonTemplate/TemplateAddButton.tsx
@@ -6,12 +6,14 @@ import { EditorButton, EditorDialog, EditorTextField } from "../../ui-components
 type TemplateAddButtonProps = {
   base: string;
   templateNames: string[];
+  disabled?: boolean;
   onTemplateAdd: (name: string) => void;
 };
 
 export const TemplateAddButton: React.FC<TemplateAddButtonProps> = ({
   base,
   templateNames,
+  disabled,
   onTemplateAdd,
 }) => {
   const [addTemplateOpen, setAddTemplateOpen] = useState(false);
@@ -54,6 +56,7 @@ export const TemplateAddButton: React.FC<TemplateAddButtonProps> = ({
         startIcon={<AddOutlinedIcon />}
         color="primary"
         fullWidth
+        disabled={disabled}
         onClick={handleOpenAddTemplate}>
         New Template
       </EditorButton>

--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -18,7 +18,7 @@ export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) =
   return (
     <EditorBlock title="Status" expandable {...props}>
       <BlockContentWrapper>
-        <EditorCommonField label="Status">
+        <EditorCommonField label="Status" inline>
           <PublishStatus published={dataset?.published}>
             {dataset?.published ? "CMS公開済" : "CMS未公開"}
           </PublishStatus>

--- a/extension/src/editor/containers/index.tsx
+++ b/extension/src/editor/containers/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useMemo, useCallback } from "react";
+import { type FC, useState, useMemo, useCallback, useRef } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -6,6 +6,7 @@ import { EditorFieldComponentsTemplateSection } from "./component-template";
 import { EditorDatasetSection } from "./dataset";
 import { EditorInspectorEmphasisPropertyTemplateSection } from "./emphasis-property-template";
 import { EditorBar, EditorPanel } from "./ui-components";
+import { EditorNotice, EditorNoticeRef } from "./ui-components/editor/EditorNotice";
 import useCache from "./useCache";
 
 export const PLATEAUVIEW_EDITOR_DOM_ID = "__plateauview_editor__";
@@ -37,6 +38,8 @@ export const Editor: FC = () => {
 
   const cache = useCache();
 
+  const editorNoticeRef = useRef<EditorNoticeRef>(null);
+
   return (
     <div id={PLATEAUVIEW_EDITOR_DOM_ID}>
       <DndProvider backend={HTML5Backend}>
@@ -47,12 +50,13 @@ export const Editor: FC = () => {
         />
         <EditorPanel>
           {editorType === "dataset" ? (
-            <EditorDatasetSection cache={cache} />
+            <EditorDatasetSection cache={cache} editorNoticeRef={editorNoticeRef} />
           ) : editorType === "fieldComponentsTemplate" ? (
-            <EditorFieldComponentsTemplateSection />
+            <EditorFieldComponentsTemplateSection editorNoticeRef={editorNoticeRef} />
           ) : editorType === "inspectorEmphasisPropertyTemplate" ? (
-            <EditorInspectorEmphasisPropertyTemplateSection />
+            <EditorInspectorEmphasisPropertyTemplateSection editorNoticeRef={editorNoticeRef} />
           ) : null}
+          <EditorNotice ref={editorNoticeRef} />
         </EditorPanel>
       </DndProvider>
     </div>

--- a/extension/src/editor/containers/ui-components/editor/EditorNotice.tsx
+++ b/extension/src/editor/containers/ui-components/editor/EditorNotice.tsx
@@ -1,0 +1,45 @@
+import { Alert, Snackbar } from "@mui/material";
+import { forwardRef, useImperativeHandle, useState } from "react";
+
+export type EditorNoticeRef = {
+  show: (notice: {
+    severity: "success" | "info" | "warning" | "error" | undefined;
+    message: string;
+  }) => void;
+};
+
+export const EditorNotice = forwardRef((_, ref) => {
+  const [open, setOpen] = useState(false);
+  const [severity, setSeverity] = useState<"success" | "info" | "warning" | "error" | undefined>();
+  const [message, setMessage] = useState<string>();
+
+  const handleClose = (_?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+  };
+
+  useImperativeHandle(ref, () => ({
+    show: (notice: {
+      severity: "success" | "info" | "warning" | "error" | undefined;
+      message: string;
+    }) => {
+      setSeverity(notice.severity);
+      setMessage(notice.message);
+      setOpen(true);
+    },
+  }));
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={3000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: "top", horizontal: "right" }}>
+      <Alert severity={severity} sx={{ width: "100%" }}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+});

--- a/extension/src/editor/containers/ui-components/editor/EditorPanel.tsx
+++ b/extension/src/editor/containers/ui-components/editor/EditorPanel.tsx
@@ -15,6 +15,7 @@ export type EditorSectionProps = {
   sidebarBottom?: React.ReactNode;
   main: React.ReactNode;
   header?: React.ReactNode;
+  saveDisabled?: boolean;
   showSaveButton?: boolean;
   showApplyButton?: boolean;
   onApply?: () => void;
@@ -26,6 +27,7 @@ export const EditorSection: React.FC<EditorSectionProps> = ({
   sidebarBottom,
   main,
   header,
+  saveDisabled,
   showSaveButton,
   showApplyButton,
   onSave,
@@ -58,6 +60,7 @@ export const EditorSection: React.FC<EditorSectionProps> = ({
                 variant="contained"
                 color="primary"
                 fullWidth
+                disabled={saveDisabled}
                 onClick={onSave}>
                 Save
               </EditorButton>


### PR DESCRIPTION
## Overview

This PR 
- adds a EditorNotice and use after saving on editor.
- adds status control for save button when saving.
- update style for StatusBlock a little bit.

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/aff7e4e4-c3af-47dd-b76f-3f572814eda9)
