### PR TITLE
feat(extension): visibility filter field for polygon

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField.tsx
@@ -14,14 +14,14 @@ import {
 } from "../../../../ui-components";
 import { generateID } from "../../../../utils";
 
-type PointVisibilityFilterFieldPresetRule = {
+type VisibilityFilterFieldPresetRule = {
   id: string;
   propertyName?: string;
   legendName?: string;
-  conditions?: PointVisibilityFilterFieldPresetRuleCondition[];
+  conditions?: VisibilityFilterFieldPresetRuleCondition[];
 };
 
-type PointVisibilityFilterFieldPresetRuleCondition = {
+type VisibilityFilterFieldPresetRuleCondition = {
   id: string;
   operation?: "=" | "!=" | ">" | ">=" | "<" | "<=";
   value?: string;
@@ -29,13 +29,16 @@ type PointVisibilityFilterFieldPresetRuleCondition = {
   legendName?: string;
 };
 
-export type PointVisibilityFilterFieldPreset = {
-  rules?: PointVisibilityFilterFieldPresetRule[];
+export type VisibilityFilterFieldPreset = {
+  rules?: VisibilityFilterFieldPresetRule[];
 };
 
-export const EditorPointVisibilityFilterField: React.FC<
-  BasicFieldProps<"POINT_VISIBILITY_FILTER_FIELD">
-> = ({ component, onUpdate }) => {
+type SupportedFieldTypes = "POINT_VISIBILITY_FILTER_FIELD" | "POLYGON_VISIBILITY_FILTER_FIELD";
+
+export const EditorVisibilityFilterField: React.FC<BasicFieldProps<SupportedFieldTypes>> = ({
+  component,
+  onUpdate,
+}) => {
   const [currentRuleId, setCurrentRuleId] = useState<string>();
   const [movingId, setMovingId] = useState<string>();
 
@@ -48,7 +51,7 @@ export const EditorPointVisibilityFilterField: React.FC<
   }, [rules, currentRuleId]);
 
   const handleRuleCreate = useCallback(() => {
-    const newRule: PointVisibilityFilterFieldPresetRule = {
+    const newRule: VisibilityFilterFieldPresetRule = {
       id: generateID(),
       conditions: [],
     };
@@ -100,7 +103,7 @@ export const EditorPointVisibilityFilterField: React.FC<
   );
 
   const handleRuleUpdate = useCallback(
-    (rule: PointVisibilityFilterFieldPresetRule) => {
+    (rule: VisibilityFilterFieldPresetRule) => {
       onUpdate?.({
         ...component,
         preset: {
@@ -181,7 +184,7 @@ export const EditorPointVisibilityFilterField: React.FC<
   );
 
   const handleConditionUpdate = useCallback(
-    (condition: PointVisibilityFilterFieldPresetRuleCondition) => {
+    (condition: VisibilityFilterFieldPresetRuleCondition) => {
       if (!currentRule?.conditions) return;
       onUpdate?.({
         ...component,
@@ -255,8 +258,8 @@ export const EditorPointVisibilityFilterField: React.FC<
 };
 
 type RulePanelProps = {
-  rule: PointVisibilityFilterFieldPresetRule;
-  onRuleUpdate: (rule: PointVisibilityFilterFieldPresetRule) => void;
+  rule: VisibilityFilterFieldPresetRule;
+  onRuleUpdate: (rule: VisibilityFilterFieldPresetRule) => void;
 };
 
 const RuleMainPanel: React.FC<RulePanelProps> = ({ rule, onRuleUpdate }) => {
@@ -300,8 +303,8 @@ const RuleLegendPanel: React.FC<RulePanelProps> = ({ rule, onRuleUpdate }) => {
 };
 
 type ConditionPanelProps = {
-  condition: PointVisibilityFilterFieldPresetRuleCondition;
-  onConditionUpdate: (condition: PointVisibilityFilterFieldPresetRuleCondition) => void;
+  condition: VisibilityFilterFieldPresetRuleCondition;
+  onConditionUpdate: (condition: VisibilityFilterFieldPresetRuleCondition) => void;
 };
 
 const ConditionMainPanel: React.FC<ConditionPanelProps> = ({ condition, onConditionUpdate }) => {

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -17,6 +17,7 @@ import { EditorTilesetFloodModelFilterField } from "./3dtiles/EditorTilesetFlood
 import { EditorFillColorConditionField } from "./common/EditorFillColorConditionField";
 import { EditorFillColorGradientField } from "./common/EditorFillColorGradientField";
 import { EditorFillColorValueField } from "./common/EditorFillColorValueField";
+import { EditorVisibilityFilterField } from "./common/EditorVisibilityFilterField";
 import {
   FIELD_CATEGORY_GENERAL,
   FIELD_CATEGORY_POINT,
@@ -26,6 +27,7 @@ import {
   FIELD_GROUP_POINT_USE_IMAGE,
   FIELD_GROUP_POINT_VISIBILITY,
   FIELD_GROUP_POLYGON_FILL_COLOR,
+  FIELD_GROUP_POLYGON_VISIBILITY,
   FIELD_GROUP_THREE_D_TILES_FILL_COLOR,
   FIELD_GROUP_THREE_D_TILES_FILTER,
 } from "./constants";
@@ -39,7 +41,6 @@ import { EditorPointStyleField } from "./point/EditorPointStyleField";
 import { EditorPointUse3DModelField } from "./point/EditorPointUse3DModelField";
 import { EditorPointUseImageConditionField } from "./point/EditorPointUseImageConditionField";
 import { EditorPointUseImageValueField } from "./point/EditorPointUseImageValueField";
-import { EditorPointVisibilityFilterField } from "./point/EditorPointVisibilityFilterField";
 import { EditorPolygonStrokeColorField } from "./polygon/EditorPolygonStrokeColorField";
 import { EditorPolygonStrokeWeightField } from "./polygon/EditorPolygonStrokeWeightField";
 
@@ -84,7 +85,9 @@ export const fields: {
     category: FIELD_CATEGORY_POINT,
     group: FIELD_GROUP_POINT_VISIBILITY,
     name: "Filter",
-    Component: EditorPointVisibilityFilterField,
+    Component: EditorVisibilityFilterField as React.FC<
+      BasicFieldProps<"POINT_VISIBILITY_FILTER_FIELD">
+    >,
   },
   POINT_FILL_COLOR_VALUE_FIELD: {
     category: FIELD_CATEGORY_POINT,
@@ -165,6 +168,14 @@ export const fields: {
     name: "Condition",
     Component: EditorFillColorConditionField as React.FC<
       BasicFieldProps<"POLYGON_FILL_COLOR_CONDITION_FIELD">
+    >,
+  },
+  POLYGON_VISIBILITY_FILTER_FIELD: {
+    category: FIELD_CATEGORY_POLYGON,
+    group: FIELD_GROUP_POLYGON_VISIBILITY,
+    name: "Filter",
+    Component: EditorVisibilityFilterField as React.FC<
+      BasicFieldProps<"POLYGON_VISIBILITY_FILTER_FIELD">
     >,
   },
   // 3dtiles

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -30,6 +30,7 @@ import {
   POLYGON_FILL_COLOR_VALUE_FIELD,
   POLYGON_STROKE_COLOR_FIELD,
   POLYGON_STROKE_WEIGHT_FIELD,
+  POLYGON_VISIBILITY_FILTER_FIELD,
 } from "../../types/fieldComponents/polygon";
 import { ComponentAtom } from "../../view-layers/component";
 import { useFindComponent } from "../../view-layers/hooks";
@@ -156,9 +157,12 @@ export const makeGradientExpression = (
 };
 
 const makeVisibilityFilterExpression = (
-  comp: Component<typeof POINT_VISIBILITY_FILTER_FIELD> | undefined,
+  comp:
+    | Component<typeof POINT_VISIBILITY_FILTER_FIELD | typeof POLYGON_VISIBILITY_FILTER_FIELD>
+    | undefined,
 ): ExpressionContainer | undefined => {
-  const rule = comp?.preset?.rules?.find(rule => rule.id === comp.value);
+  const rule =
+    comp?.preset?.rules?.find(rule => rule.id === comp.value) ?? comp?.preset?.rules?.[0];
   const property = rule?.propertyName;
 
   if (!rule?.conditions || !property) return;
@@ -305,6 +309,9 @@ export const useEvaluateGeneralAppearance = ({
   const polygonFillColorCondition = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], POLYGON_FILL_COLOR_CONDITION_FIELD),
   );
+  const polygonVisibilityFilter = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POLYGON_VISIBILITY_FILTER_FIELD),
+  );
 
   // Tileset
   const tilesetFillColorCondition = useOptionalAtomValue(
@@ -348,6 +355,7 @@ export const useEvaluateGeneralAppearance = ({
           strokeColor: polygonStrokeColor?.preset?.defaultValue,
           strokeWidth: polygonStrokeWeight?.preset?.defaultValue,
           stroke: !!polygonStrokeColor || !!polygonStrokeWeight,
+          show: makeVisibilityFilterExpression(polygonVisibilityFilter),
         },
         model: pointModel?.preset
           ? {
@@ -381,6 +389,7 @@ export const useEvaluateGeneralAppearance = ({
       polygonFillColorCondition,
       polygonStrokeColor,
       polygonStrokeWeight,
+      polygonVisibilityFilter,
       // Tileset
       tilesetFillColorCondition,
       tilesetFillGradientColor,

--- a/extension/src/shared/types/fieldComponents/point.ts
+++ b/extension/src/shared/types/fieldComponents/point.ts
@@ -1,9 +1,9 @@
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillGradientColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField";
 import { FillColorValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorValueField";
+import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField";
 import { PointUseImageConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageConditionField";
 import { PointUseImageValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageValueField";
-import { PointVisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointVisibilityFilterField";
 
 import { FieldBase } from "./base";
 import {
@@ -55,7 +55,7 @@ export const POINT_VISIBILITY_FILTER_FIELD = "POINT_VISIBILITY_FILTER_FIELD";
 export type PointVisibilityFilterField = FieldBase<{
   type: typeof POINT_VISIBILITY_FILTER_FIELD;
   value?: string;
-  preset?: PointVisibilityFilterFieldPreset;
+  preset?: VisibilityFilterFieldPreset;
 }>;
 
 export const POINT_USE_IMAGE_VALUE_FIELD = "POINT_USE_IMAGE_VALUE_FIELD";

--- a/extension/src/shared/types/fieldComponents/polygon.ts
+++ b/extension/src/shared/types/fieldComponents/polygon.ts
@@ -1,5 +1,6 @@
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillColorValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorValueField";
+import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField";
 
 import { FieldBase } from "./base";
 import { ConditionalColorSchemeValue, ValueColorSchemeValue } from "./colorScheme";
@@ -34,8 +35,16 @@ export type PolygonFillColorConditionField = FieldBase<{
   preset?: FillColorConditionFieldPreset;
 }>;
 
+export const POLYGON_VISIBILITY_FILTER_FIELD = "POLYGON_VISIBILITY_FILTER_FIELD";
+export type PolygonVisibilityFilterField = FieldBase<{
+  type: typeof POLYGON_VISIBILITY_FILTER_FIELD;
+  value?: string;
+  preset?: VisibilityFilterFieldPreset;
+}>;
+
 export type PolygonFields =
   | PolygonStrokeColorField
   | PolygonStrokeWeightField
   | PolygonFillColorConditionField
-  | PolygonFillColorValueField;
+  | PolygonFillColorValueField
+  | PolygonVisibilityFilterField;

--- a/extension/src/shared/view/fields/Fields.tsx
+++ b/extension/src/shared/view/fields/Fields.tsx
@@ -20,7 +20,10 @@ import {
   POINT_USE_IMAGE_CONDITION_FIELD,
   POINT_VISIBILITY_FILTER_FIELD,
 } from "../../types/fieldComponents/point";
-import { POLYGON_FILL_COLOR_CONDITION_FIELD } from "../../types/fieldComponents/polygon";
+import {
+  POLYGON_FILL_COLOR_CONDITION_FIELD,
+  POLYGON_VISIBILITY_FILTER_FIELD,
+} from "../../types/fieldComponents/polygon";
 import { LayerModel } from "../../view-layers";
 import { ComponentAtom } from "../../view-layers/component";
 import { useIsMultipleSelectableField } from "../hooks/useIsMultipleSelectableField";
@@ -29,6 +32,7 @@ import { BuildingFilterSection } from "../selection/BuildingFilterSection";
 import { LayerTilesetClippingField } from "./3dtiles/LayerTilesetClippingField";
 import { LayerTilesetFillColorConditionField } from "./3dtiles/LayerTilesetFillColorConditionField";
 import { LayerTilesetFillGradientColorField } from "./3dtiles/LayerTilesetFillGradientColorField";
+import { LayerVisibilityFilterField } from "./common/LayerPolygonVisibilityFilterField";
 import { LayerOpacityField } from "./general/LayerOpacityField";
 import { LayerPointFillColorConditionField } from "./point/LayerPointFillColorConditionField";
 import { LayerPointFillGradientColorField } from "./point/LayerPointFillGradientColorField";
@@ -98,6 +102,15 @@ export const Fields: FC<Props> = ({ layers, type, atoms }) => {
         <LayerPolygonFillColorConditionField
           layers={layers}
           atoms={atoms as ComponentAtom<"POLYGON_FILL_COLOR_CONDITION_FIELD">["atom"][]}
+        />
+      );
+      break;
+    }
+    case POLYGON_VISIBILITY_FILTER_FIELD: {
+      component = (
+        <LayerVisibilityFilterField
+          layers={layers}
+          atoms={atoms as ComponentAtom<"POLYGON_VISIBILITY_FILTER_FIELD">["atom"][]}
         />
       );
       break;

--- a/extension/src/shared/view/fields/common/LayerPolygonVisibilityFilterField.tsx
+++ b/extension/src/shared/view/fields/common/LayerPolygonVisibilityFilterField.tsx
@@ -1,0 +1,57 @@
+import { FormControlLabel, Radio, RadioGroup } from "@mui/material";
+import { useAtom } from "jotai";
+import { useMemo, useCallback, ChangeEventHandler, ReactElement } from "react";
+
+import { ParameterItem, ParameterList } from "../../../../prototypes/ui-components";
+import { PointVisibilityFilterField } from "../../../types/fieldComponents/point";
+import { PolygonVisibilityFilterField } from "../../../types/fieldComponents/polygon";
+import { LayerModel } from "../../../view-layers";
+import { WritableAtomForComponent } from "../../../view-layers/component";
+
+type SupportFields = PointVisibilityFilterField | PolygonVisibilityFilterField;
+
+export interface LayerVisibilityFilterFieldProps<T extends SupportFields> {
+  layers: readonly LayerModel[];
+  atoms: WritableAtomForComponent<T>[];
+}
+
+export const LayerVisibilityFilterField = <T extends SupportFields>({
+  atoms,
+}: LayerVisibilityFilterFieldProps<T>): ReactElement | null => {
+  const [component, setComponent] = useAtom(atoms[0]);
+
+  const items: [id: string, label: string][] = useMemo(
+    () =>
+      component.preset?.rules?.map(
+        r => [r.id, r.legendName || r.propertyName] as [id: string, label: string],
+      ) ?? [],
+    [component],
+  );
+
+  const overriddenRuleId = component.value;
+  const currentRuleId = overriddenRuleId || items[0][0];
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    e => {
+      setComponent({ ...component, value: e.target.value });
+    },
+    [component, setComponent],
+  );
+
+  return (
+    <ParameterList>
+      <ParameterItem label="表示の切り替え">
+        <RadioGroup value={currentRuleId} onChange={handleChange}>
+          {items.map(item => (
+            <FormControlLabel
+              key={item[0]}
+              value={item[0]}
+              control={<Radio size="small" />}
+              label={item[1]}
+            />
+          ))}
+        </RadioGroup>
+      </ParameterItem>
+    </ParameterList>
+  );
+};

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -118,6 +118,10 @@ export const fieldSettings: {
   },
   POLYGON_STROKE_COLOR_FIELD: {},
   POLYGON_STROKE_WEIGHT_FIELD: {},
+  POLYGON_VISIBILITY_FILTER_FIELD: {
+    defaultValue: "",
+    hasLayerUI: true,
+  },
   // 3dtiles
   TILESET_BUILDING_MODEL_COLOR: {},
   TILESET_FLOOD_MODEL_COLOR: {},

--- a/extension/src/shared/view/fields/polygon/LayerPolygonVisibilityFilterField.tsx
+++ b/extension/src/shared/view/fields/polygon/LayerPolygonVisibilityFilterField.tsx
@@ -1,16 +1,16 @@
 import { type FC } from "react";
 
-import { PointVisibilityFilterField } from "../../../types/fieldComponents/point";
+import { PolygonVisibilityFilterField } from "../../../types/fieldComponents/polygon";
 import { LayerModel } from "../../../view-layers";
 import { WritableAtomForComponent } from "../../../view-layers/component";
 import { LayerVisibilityFilterField } from "../common/LayerPolygonVisibilityFilterField";
 
-export interface LayerPointVisibilityFilterFieldProps {
+export interface LayerPolygonVisibilityFilterFieldProps {
   layers: readonly LayerModel[];
-  atoms: WritableAtomForComponent<PointVisibilityFilterField>[];
+  atoms: WritableAtomForComponent<PolygonVisibilityFilterField>[];
 }
 
-export const LayerPointVisibilityFilterField: FC<LayerPointVisibilityFilterFieldProps> = ({
+export const LayerPolygonVisibilityFilterField: FC<LayerPolygonVisibilityFilterFieldProps> = ({
   layers,
   atoms,
 }) => {


### PR DESCRIPTION
## Test
- You can use `土地利用モデル（東京都23区）` with `visibility` group for testing


![Screenshot 2023-11-16 at 17 34 08](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/c048f8cc-7158-4dc6-9547-caf4faf14135)
