### PR TITLE
fix(extension): use first rule as default

### DIFF
--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -75,12 +75,16 @@ export const makeConditionalExpression = (
 ): ExpressionContainer | undefined => {
   if (!comp) return;
 
+  const currentRuleId = comp.value?.useDefault
+    ? comp.value?.currentRuleId ?? comp.preset?.rules?.[0].id
+    : comp.value?.currentRuleId;
+
   return {
     expression: {
       conditions: [
         ...(
           comp.preset?.rules?.flatMap(rule => {
-            if (rule.id !== comp.value?.currentRuleId) return;
+            if (rule.id !== currentRuleId) return;
             const overriddenRules = comp.value?.overrideRules.filter(r => r.ruleId === rule.id);
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);
@@ -118,7 +122,10 @@ export const makeGradientExpression = (
 
   const preset = comp.preset;
   const value = comp.value;
-  const rule = preset?.rules?.find(r => r.id === value?.currentRuleId);
+  const currentRuleId = comp.value?.useDefault
+    ? comp.value?.currentRuleId ?? comp.preset?.rules?.[0].id
+    : comp.value?.currentRuleId;
+  const rule = preset?.rules?.find(r => r.id === currentRuleId);
 
   const conditions: [string, string][] = [["true", color(DEFAULT_COLOR, 1)]];
 
@@ -187,12 +194,13 @@ export const makeConditionalImageExpression = (
   comp: Component<typeof POINT_USE_IMAGE_CONDITION_FIELD> | undefined,
 ): ExpressionContainer | undefined => {
   if (!comp) return;
+  const currentRuleId = comp.value?.currentRuleId ?? comp.preset?.rules?.[0].id;
   return {
     expression: {
       conditions: [
         ...(
           comp.preset?.rules?.flatMap(rule => {
-            if (rule.id !== comp.value?.currentRuleId) return;
+            if (rule.id !== currentRuleId) return;
             const overriddenRules = comp.value?.overrideRules.filter(r => r.ruleId === rule.id);
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);
@@ -224,12 +232,13 @@ export const makeConditionalImageColorExpression = (
   comp: Component<typeof POINT_USE_IMAGE_CONDITION_FIELD> | undefined,
 ): ExpressionContainer | undefined => {
   if (!comp) return;
+  const currentRuleId = comp.value?.currentRuleId ?? comp.preset?.rules?.[0].id;
   return {
     expression: {
       conditions: [
         ...(
           comp.preset?.rules?.flatMap(rule => {
-            if (rule.id !== comp.value?.currentRuleId) return;
+            if (rule.id !== currentRuleId) return;
             const overriddenRules = comp.value?.overrideRules.filter(r => r.ruleId === rule.id);
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);

--- a/extension/src/shared/types/fieldComponents/colorScheme.ts
+++ b/extension/src/shared/types/fieldComponents/colorScheme.ts
@@ -13,6 +13,7 @@ export type ConditionalColorSchemeValue = {
     conditionId: string;
     color: string;
   }[];
+  useDefault: boolean; // Whether use first rule as default rule or not. Otherwise default will be "none".
 };
 
 export const GRADIENT_COLOR_SCHEME = "GRADIENT_COLOR_SCHEME";
@@ -22,4 +23,5 @@ export type GradientColorSchemeValue = {
   currentColorMapName: string | undefined;
   currentMin: number | undefined;
   currentMax: number | undefined;
+  useDefault: boolean; // Whether use first rule as default rule or not. Otherwise default will be "none".
 };

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -53,6 +53,7 @@ export const fieldSettings: {
       type: CONDITIONAL_COLOR_SCHEME,
       currentRuleId: undefined,
       overrideRules: [],
+      useDefault: true,
       storeable: {
         omitPropertyNames: ["value.currentRuleId"],
       },
@@ -67,6 +68,7 @@ export const fieldSettings: {
       currentColorMapName: undefined,
       currentMax: undefined,
       currentMin: undefined,
+      useDefault: true,
       storeable: {
         omitPropertyNames: ["value.currentRuleId"],
       },
@@ -109,6 +111,7 @@ export const fieldSettings: {
       type: CONDITIONAL_COLOR_SCHEME,
       currentRuleId: undefined,
       overrideRules: [],
+      useDefault: true,
       storeable: {
         omitPropertyNames: ["value.currentRuleId"],
       },
@@ -126,6 +129,7 @@ export const fieldSettings: {
       type: CONDITIONAL_COLOR_SCHEME,
       currentRuleId: undefined,
       overrideRules: [],
+      useDefault: false,
       storeable: {
         omitPropertyNames: ["value.currentRuleId"],
       },
@@ -140,6 +144,7 @@ export const fieldSettings: {
       currentColorMapName: undefined,
       currentMax: undefined,
       currentMin: undefined,
+      useDefault: false,
       storeable: {
         omitPropertyNames: ["value.currentRuleId"],
       },

--- a/extension/src/shared/view/fields/polygon/LayerPolygonFillColorConditionField.tsx
+++ b/extension/src/shared/view/fields/polygon/LayerPolygonFillColorConditionField.tsx
@@ -18,5 +18,5 @@ export const LayerPolygonFillColorConditionField: FC<LayerPolygonFillColorCondit
     return null;
   }
 
-  return <ColorSchemeSectionForComponentField layers={layers} useNone={false} />;
+  return <ColorSchemeSectionForComponentField layers={layers} />;
 };

--- a/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
+++ b/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
@@ -79,10 +79,7 @@ export const ImageSchemeSectionForComponentField: FC<ImageSchemeSectionForCompon
                 }
               })
               .filter(isNotNullish) ?? [];
-          return [
-            [null, "なし"],
-            ...rules.map((rule): [string, string] => [rule.id, rule.propertyName ?? ""]),
-          ];
+          return rules.map((rule): [string, string] => [rule.id, rule.propertyName ?? ""]);
         }),
       [layers, recalcPropertyItems], // eslint-disable-line react-hooks/exhaustive-deps
     ),
@@ -96,7 +93,9 @@ export const ImageSchemeSectionForComponentField: FC<ImageSchemeSectionForCompon
           for (const componentAtom of layers[0].componentAtoms) {
             const componentValue = get(componentAtom.atom);
             if (isConditionalImageSchemeComponent(componentValue)) {
-              const ruleId = componentValue.value?.currentRuleId;
+              const currentRuleId =
+                componentValue.value?.currentRuleId ?? componentValue.preset?.rules?.[0].id;
+              const ruleId = currentRuleId;
               if (ruleId) {
                 return ruleId;
               }
@@ -109,10 +108,9 @@ export const ImageSchemeSectionForComponentField: FC<ImageSchemeSectionForCompon
             const componentValue = get(componentAtom.atom);
 
             if (isConditionalImageSchemeComponent(componentValue)) {
-              const update =
-                typeof action === "function"
-                  ? action(componentValue.value?.currentRuleId ?? null)
-                  : action;
+              const currentRuleId =
+                componentValue.value?.currentRuleId ?? componentValue.preset?.rules?.[0].id;
+              const update = typeof action === "function" ? action(currentRuleId ?? null) : action;
               set(componentAtom.atom, {
                 ...componentValue,
                 value: {

--- a/extension/src/shared/view/state/colorSchemeForComponent.ts
+++ b/extension/src/shared/view/state/colorSchemeForComponent.ts
@@ -94,7 +94,10 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
       case GRADIENT_COLOR_SCHEME: {
         if (!isGradientColorSchemeComponent(component)) return;
 
-        const rule = component.preset?.rules?.find(rule => rule.id === colorScheme.currentRuleId);
+        const currentRuleId = colorScheme.useDefault
+          ? colorScheme.currentRuleId ?? component.preset?.rules?.[0].id
+          : colorScheme.currentRuleId;
+        const rule = component.preset?.rules?.find(rule => rule.id === currentRuleId);
         const value = component.value;
         const colorMap = COLOR_MAPS.find(
           c => c.name === (value?.currentColorMapName ?? rule?.colorMapName),
@@ -148,7 +151,11 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
       }
       case CONDITIONAL_COLOR_SCHEME: {
         if (!isConditionalColorSchemeComponent(component)) return;
-        const rule = component.preset?.rules?.find(rule => rule.id === colorScheme.currentRuleId);
+
+        const currentRuleId = colorScheme.useDefault
+          ? colorScheme.currentRuleId ?? component.preset?.rules?.[0].id
+          : colorScheme.currentRuleId;
+        const rule = component.preset?.rules?.find(rule => rule.id === currentRuleId);
         if (!rule?.propertyName || !rule.conditions) return;
         const colors = rule?.conditions
           ?.map((c): QualitativeColor | undefined => {
@@ -170,7 +177,9 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
           () => colors,
           (_get, set, action: SetStateAction<QualitativeColor[]>) => {
             const update = typeof action === "function" ? action(colors) : action;
-            const currentRuleId = component.value?.currentRuleId;
+            const currentRuleId = colorScheme.useDefault
+              ? colorScheme.currentRuleId ?? component.preset?.rules?.[0].id
+              : colorScheme.currentRuleId;
             set(componentAtom.atom, {
               ...component,
               value: {

--- a/extension/src/shared/view/state/imageSchemaForComponent.ts
+++ b/extension/src/shared/view/state/imageSchemaForComponent.ts
@@ -59,7 +59,8 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
     switch (imageScheme.type) {
       case CONDITIONAL_IMAGE_SCHEME: {
         if (!isConditionalImageSchemeComponent(component)) return;
-        const rule = component.preset?.rules?.find(rule => rule.id === imageScheme.currentRuleId);
+        const currentRuleId = imageScheme.currentRuleId ?? component.preset?.rules?.[0].id;
+        const rule = component.preset?.rules?.find(rule => rule.id === currentRuleId);
         if (!rule?.propertyName || !rule.conditions) return;
         const imageIcons = rule?.conditions
           ?.map((c): ImageIcon | undefined => {
@@ -83,7 +84,7 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
           () => imageIcons,
           (_get, set, action: SetStateAction<ImageIcon[]>) => {
             const update = typeof action === "function" ? action(imageIcons) : action;
-            const currentRuleId = component.value?.currentRuleId;
+            const currentRuleId = imageScheme.currentRuleId ?? component.preset?.rules?.[0].id;
             set(componentAtom.atom, {
               ...component,
               value: {


### PR DESCRIPTION
I fixed to use first rule as default in some field which has condition. Basically general layer other than BuildingModel and FloodModel should use first rule as default.
For VisibilityFilter, I fixed it in [another PR](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/pulls).