### PR TITLE
fix(extension): better number field

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFillColorGradientField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFillColorGradientField.tsx
@@ -15,6 +15,7 @@ import {
   PropertyWrapper,
 } from "../../../../ui-components";
 import { generateID } from "../../../../utils";
+import { useNumberFieldState } from "../../hooksUtils";
 
 type TilesetFillColorGradientFieldPresetRule = {
   id: string;
@@ -202,28 +203,30 @@ const RuleMainPanel: React.FC<RulePanelProps> = ({ rule, onRuleUpdate }) => {
     [rule, onRuleUpdate],
   );
 
-  const [minText, setMinText] = useState(rule.min?.toString());
-  const handleMinChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setMinText(e.target.value);
-      onRuleUpdate({
-        ...rule,
-        min: Number(e.target.value) ?? 0,
-      });
-    },
-    [rule, onRuleUpdate],
+  const [minText, handleMinChange] = useNumberFieldState(
+    rule.min,
+    useCallback(
+      v => {
+        onRuleUpdate({
+          ...rule,
+          min: v ?? 0,
+        });
+      },
+      [rule, onRuleUpdate],
+    ),
   );
 
-  const [maxText, setMaxText] = useState(rule.max?.toString());
-  const handleMaxChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setMaxText(e.target.value);
-      onRuleUpdate({
-        ...rule,
-        max: Number(e.target.value) ?? 0,
-      });
-    },
-    [rule, onRuleUpdate],
+  const [maxText, handleMaxChange] = useNumberFieldState(
+    rule.max,
+    useCallback(
+      v => {
+        onRuleUpdate({
+          ...rule,
+          max: v ?? 0,
+        });
+      },
+      [rule, onRuleUpdate],
+    ),
   );
 
   return (

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField.tsx
@@ -15,6 +15,7 @@ import {
   PropertyWrapper,
 } from "../../../../ui-components";
 import { generateID } from "../../../../utils";
+import { useNumberFieldState } from "../../hooksUtils";
 
 type FillColorGradientFieldPresetRule = {
   id: string;
@@ -205,28 +206,30 @@ const RuleMainPanel: React.FC<RulePanelProps> = ({ rule, onRuleUpdate }) => {
     [rule, onRuleUpdate],
   );
 
-  const [minText, setMinText] = useState(rule.min?.toString());
-  const handleMinChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setMinText(e.target.value);
-      onRuleUpdate({
-        ...rule,
-        min: Number(e.target.value) ?? 0,
-      });
-    },
-    [rule, onRuleUpdate],
+  const [minText, handleMinChange] = useNumberFieldState(
+    rule.min,
+    useCallback(
+      v => {
+        onRuleUpdate({
+          ...rule,
+          min: v ?? 0,
+        });
+      },
+      [rule, onRuleUpdate],
+    ),
   );
 
-  const [maxText, setMaxText] = useState(rule.max?.toString());
-  const handleMaxChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setMaxText(e.target.value);
-      onRuleUpdate({
-        ...rule,
-        max: Number(e.target.value) ?? 0,
-      });
-    },
-    [rule, onRuleUpdate],
+  const [maxText, handleMaxChange] = useNumberFieldState(
+    rule.max,
+    useCallback(
+      v => {
+        onRuleUpdate({
+          ...rule,
+          max: v ?? 0,
+        });
+      },
+      [rule, onRuleUpdate],
+    ),
   );
 
   return (

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointImageSizeField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointImageSizeField.tsx
@@ -9,24 +9,26 @@ import {
   PropertySwitch,
   PropertyWrapper,
 } from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
 
 export const EditorPointImageSizeField: React.FC<BasicFieldProps<"POINT_IMAGE_SIZE_FIELD">> = ({
   component,
   onUpdate,
 }) => {
-  const handleSizeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const numberSize = Number(e.target.value);
-      if (isNaN(numberSize)) return;
-      onUpdate({
-        ...component,
-        preset: {
-          ...component.preset,
-          defaultValue: numberSize,
-        },
-      });
-    },
-    [component, onUpdate],
+  const [size, handleSizeChange] = useNumberFieldState(
+    component.preset?.defaultValue,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            defaultValue: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
   );
 
   const handleEnableSizeInMetersChange = useCallback(
@@ -53,7 +55,7 @@ export const EditorPointImageSizeField: React.FC<BasicFieldProps<"POINT_IMAGE_SI
         <PropertyInlineWrapper label="Image Size">
           <PropertyInputField
             placeholder="Value"
-            value={component.preset?.defaultValue ?? ""}
+            value={size}
             onChange={handleSizeChange}
             type="number"
             InputProps={{

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointSizeField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointSizeField.tsx
@@ -8,24 +8,26 @@ import {
   PropertyInputField,
   PropertyWrapper,
 } from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
 
 export const EditorPointSizeField: React.FC<BasicFieldProps<"POINT_SIZE_FIELD">> = ({
   component,
   onUpdate,
 }) => {
-  const handleSizeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const numberSize = Number(e.target.value);
-      if (isNaN(numberSize)) return;
-      onUpdate({
-        ...component,
-        preset: {
-          ...component.preset,
-          defaultValue: numberSize,
-        },
-      });
-    },
-    [component, onUpdate],
+  const [size, handleSizeChange] = useNumberFieldState(
+    component.preset?.defaultValue,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            defaultValue: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
   );
   return (
     <PropertyWrapper>
@@ -33,7 +35,7 @@ export const EditorPointSizeField: React.FC<BasicFieldProps<"POINT_SIZE_FIELD">>
         <PropertyInlineWrapper label="Point Size">
           <PropertyInputField
             placeholder="Value"
-            value={component.preset?.defaultValue ?? ""}
+            value={size}
             onChange={handleSizeChange}
             type="number"
             InputProps={{

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUse3DModelField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUse3DModelField.tsx
@@ -7,6 +7,7 @@ import {
   PropertyInputField,
   PropertyWrapper,
 } from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
 
 export const EditorPointUse3DModelField: React.FC<BasicFieldProps<"POINT_USE_3D_MODEL">> = ({
   component,
@@ -24,20 +25,23 @@ export const EditorPointUse3DModelField: React.FC<BasicFieldProps<"POINT_USE_3D_
     },
     [component, onUpdate],
   );
-  const handleSizeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const numberSize = Number(e.target.value);
-      if (isNaN(numberSize)) return;
-      onUpdate({
-        ...component,
-        preset: {
-          ...component.preset,
-          size: numberSize,
-        },
-      });
-    },
-    [component, onUpdate],
+
+  const [size, handleSizeChange] = useNumberFieldState(
+    component.preset?.size,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            size: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
   );
+
   return (
     <PropertyWrapper>
       <PropertyBox>
@@ -51,7 +55,7 @@ export const EditorPointUse3DModelField: React.FC<BasicFieldProps<"POINT_USE_3D_
         <PropertyInlineWrapper label="Size">
           <PropertyInputField
             placeholder="Value"
-            value={component.preset?.size ?? ""}
+            value={size}
             onChange={handleSizeChange}
             type="number"
           />

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/polygon/EditorPolygonStrokeWeightField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/polygon/EditorPolygonStrokeWeightField.tsx
@@ -8,23 +8,25 @@ import {
   PropertyInputField,
   PropertyWrapper,
 } from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
 
 export const EditorPolygonStrokeWeightField: React.FC<
   BasicFieldProps<"POLYGON_STROKE_WEIGHT_FIELD">
 > = ({ component, onUpdate }) => {
-  const handleSizeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const numberSize = Number(e.target.value);
-      if (isNaN(numberSize)) return;
-      onUpdate({
-        ...component,
-        preset: {
-          ...component.preset,
-          defaultValue: numberSize,
-        },
-      });
-    },
-    [component, onUpdate],
+  const [value, handleChangeValue] = useNumberFieldState(
+    component.preset?.defaultValue,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            defaultValue: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
   );
   return (
     <PropertyWrapper>
@@ -32,8 +34,8 @@ export const EditorPolygonStrokeWeightField: React.FC<
         <PropertyInlineWrapper label="Stroke Weight">
           <PropertyInputField
             placeholder="Value"
-            value={component.preset?.defaultValue ?? ""}
-            onChange={handleSizeChange}
+            value={value}
+            onChange={handleChangeValue}
             type="number"
             InputProps={{
               endAdornment: <InputAdornment position="end">px</InputAdornment>,

--- a/extension/src/editor/containers/common/fieldComponentEditor/hooksUtils/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/hooksUtils/index.ts
@@ -1,0 +1,1 @@
+export * from "./useNumberFieldState";

--- a/extension/src/editor/containers/common/fieldComponentEditor/hooksUtils/useNumberFieldState.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/hooksUtils/useNumberFieldState.ts
@@ -1,0 +1,17 @@
+import { useCallback, useState } from "react";
+
+export const useNumberFieldState = (
+  initialValue: number | undefined,
+  onUpdate: (value: number) => void,
+): [string, (e: React.ChangeEvent<HTMLInputElement>) => void] => {
+  const [value, setValue] = useState(initialValue ? initialValue.toString() : "");
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValue(e.target.value);
+      onUpdate(Number(e.target.value) ?? 0);
+    },
+    [onUpdate],
+  );
+
+  return [value, handleChange];
+};


### PR DESCRIPTION
I fixed some number field to be empty value. For example, it's just `0` when you remove all text from a number field. And we can't change value. I fixed this issue.

https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/f4902b8a-d817-4abd-9f7a-b5f89cd4827f

