### PR TITLE
fix(extension): use asLegend to filter using legend

### DIFF
--- a/extension/src/shared/view/state/colorSchemeForComponent.ts
+++ b/extension/src/shared/view/state/colorSchemeForComponent.ts
@@ -159,6 +159,8 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
         if (!rule?.propertyName || !rule.conditions) return;
         const colors = rule?.conditions
           ?.map((c): QualitativeColor | undefined => {
+            if (!c.asLegend) return;
+
             const overriddenCondition = component.value?.overrideRules.find(
               o => o.ruleId === rule.id && o.conditionId === c.id,
             );
@@ -201,12 +203,14 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
             });
           },
         ) as unknown as PrimitiveAtom<QualitativeColor[]>; // For compat
-        return {
-          type: "qualitative" as const,
-          name: rule.legendName || rule.propertyName,
-          colorsAtom: colorsAtom,
-          colorAtomsAtom: splitAtom(colorsAtom),
-        } as QualitativeColorSet;
+        return colors.length
+          ? ({
+              type: "qualitative" as const,
+              name: rule.legendName || rule.propertyName,
+              colorsAtom: colorsAtom,
+              colorAtomsAtom: splitAtom(colorsAtom),
+            } as QualitativeColorSet)
+          : undefined;
       }
       case VALUE_COLOR_SCHEME: {
         if (!isValueColorSchemeComponent(component)) return;

--- a/extension/src/shared/view/state/imageSchemaForComponent.ts
+++ b/extension/src/shared/view/state/imageSchemaForComponent.ts
@@ -64,6 +64,8 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
         if (!rule?.propertyName || !rule.conditions) return;
         const imageIcons = rule?.conditions
           ?.map((c): ImageIcon | undefined => {
+            if (!c.asLegend) return;
+
             const overriddenCondition = component.value?.overrideRules.find(
               o => o.ruleId === rule.id && o.conditionId === c.id,
             );
@@ -107,12 +109,14 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
             });
           },
         ) as unknown as PrimitiveAtom<ImageIcon[]>;
-        return {
-          type: "imageIcon" as const,
-          name: rule.propertyName,
-          imageIconsAtom: imageIconsAtom,
-          imageIconAtomsAtom: splitAtom(imageIconsAtom),
-        } as ImageIconSet;
+        return imageIcons.length
+          ? ({
+              type: "imageIcon" as const,
+              name: rule.propertyName,
+              imageIconsAtom: imageIconsAtom,
+              imageIconAtomsAtom: splitAtom(imageIconsAtom),
+            } as ImageIconSet)
+          : undefined;
       }
     }
   });


### PR DESCRIPTION
I fixed to use `asLegend` to display a legend. Legend should be shown when `asLegend` is enabled.

|asLegend|none|
|:--:|:--:|
|![Screenshot 2023-11-17 at 16 14 21](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/b5d838b0-10b5-4355-b937-39d5f858f686)|![Screenshot 2023-11-17 at 16 14 29](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/e8e00ed6-a091-43ec-b80d-9792f6456273)|