### PR TITLE
fix(extension): support legend for simple value field

### DIFF
--- a/extension/src/shared/types/fieldComponents/imageScheme.ts
+++ b/extension/src/shared/types/fieldComponents/imageScheme.ts
@@ -1,3 +1,10 @@
+export const VALUE_IMAGE_SCHEME = "VALUE_IMAGE_SCHEME";
+export type ValueImageSchemeValue = {
+  type: typeof VALUE_IMAGE_SCHEME;
+  imageURL: string | undefined;
+  imageColor: string | undefined;
+};
+
 export const CONDITIONAL_IMAGE_SCHEME = "CONDITIONAL_IMAGE_SCHEME";
 export type ConditionalImageSchemeValue = {
   type: typeof CONDITIONAL_IMAGE_SCHEME;

--- a/extension/src/shared/types/fieldComponents/point.ts
+++ b/extension/src/shared/types/fieldComponents/point.ts
@@ -11,7 +11,7 @@ import {
   GradientColorSchemeValue,
   ValueColorSchemeValue,
 } from "./colorScheme";
-import { ConditionalImageSchemeValue } from "./imageScheme";
+import { ConditionalImageSchemeValue, ValueImageSchemeValue } from "./imageScheme";
 
 export const POINT_STYLE_FIELD = "POINT_STYLE_FIELD";
 export type PointStyleField = FieldBase<{
@@ -61,7 +61,7 @@ export type PointVisibilityFilterField = FieldBase<{
 export const POINT_USE_IMAGE_VALUE_FIELD = "POINT_USE_IMAGE_VALUE_FIELD";
 export type PointUseImageValueField = FieldBase<{
   type: typeof POINT_USE_IMAGE_VALUE_FIELD;
-  value?: string;
+  value?: ValueImageSchemeValue;
   preset?: PointUseImageValueFieldPreset;
 }>;
 

--- a/extension/src/shared/view-layers/componentField.ts
+++ b/extension/src/shared/view-layers/componentField.ts
@@ -3,9 +3,5 @@ import { Component } from "../types/fieldComponents";
 import { fieldSettings } from "../view/fields/fieldSettings";
 
 export const makeComponentFieldValue = (component: SettingComponent): Component["value"] => {
-  return (
-    component.preset?.defaultValue ??
-    fieldSettings[component.type]?.defaultValue ??
-    fieldSettings[component.type]?.value
-  );
+  return fieldSettings[component.type]?.value;
 };

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -4,7 +4,10 @@ import {
   GRADIENT_COLOR_SCHEME,
   VALUE_COLOR_SCHEME,
 } from "../../types/fieldComponents/colorScheme";
-import { CONDITIONAL_IMAGE_SCHEME } from "../../types/fieldComponents/imageScheme";
+import {
+  CONDITIONAL_IMAGE_SCHEME,
+  VALUE_IMAGE_SCHEME,
+} from "../../types/fieldComponents/imageScheme";
 
 // This settings object is used to generate the UI for each field.
 // It will be used in layer inspector and legend panel.
@@ -81,7 +84,11 @@ export const fieldSettings: {
     hasLayerUI: true,
   },
   POINT_USE_IMAGE_VALUE_FIELD: {
-    defaultValue: "",
+    value: {
+      type: VALUE_IMAGE_SCHEME,
+      imageColor: undefined,
+      imageURL: undefined,
+    },
     hasLegendUI: true,
   },
   POINT_USE_IMAGE_CONDITION_FIELD: {

--- a/extension/src/shared/view/state/colorSchemeForComponent.ts
+++ b/extension/src/shared/view/state/colorSchemeForComponent.ts
@@ -214,9 +214,9 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
           ? [
               {
                 id: component.id,
-                value: component.preset.legendName || component.preset.defaultValue,
+                value: component.preset.defaultValue,
                 color: component.value?.color || component.preset.defaultValue,
-                name: component.preset.legendName || component.preset.defaultValue,
+                name: component.preset.legendName ?? "",
               },
             ]
           : [];
@@ -233,12 +233,14 @@ export const makeColorSchemeAtomForComponent = (layers: readonly LayerModel[]) =
             });
           },
         ) as unknown as PrimitiveAtom<QualitativeColor[]>; // For compat
-        return {
-          type: "qualitative" as const,
-          name: get(layer.titleAtom),
-          colorsAtom: colorsAtom,
-          colorAtomsAtom: splitAtom(colorsAtom),
-        } as QualitativeColorSet;
+        return component.preset?.asLegend
+          ? ({
+              type: "qualitative" as const,
+              name: get(layer.titleAtom),
+              colorsAtom: colorsAtom,
+              colorAtomsAtom: splitAtom(colorsAtom),
+            } as QualitativeColorSet)
+          : undefined;
       }
     }
   });

--- a/extension/src/shared/view/state/imageSchemaForComponent.ts
+++ b/extension/src/shared/view/state/imageSchemaForComponent.ts
@@ -9,18 +9,28 @@ import { ComponentBase } from "../../types/fieldComponents";
 import {
   CONDITIONAL_IMAGE_SCHEME,
   ConditionalImageSchemeValue,
+  VALUE_IMAGE_SCHEME,
+  ValueImageSchemeValue,
 } from "../../types/fieldComponents/imageScheme";
 import { LayerModel } from "../../view-layers";
 
 export const isImageSchemeComponent = (
   comp: ComponentBase,
-): comp is Extract<ComponentBase, { value?: ConditionalImageSchemeValue }> =>
+): comp is Extract<
+  ComponentBase,
+  { value?: ValueImageSchemeValue | ConditionalImageSchemeValue }
+> =>
   !!(
     comp.value &&
     typeof comp.value === "object" &&
     "type" in comp.value &&
-    [CONDITIONAL_IMAGE_SCHEME].includes(comp.value.type)
+    [VALUE_IMAGE_SCHEME, CONDITIONAL_IMAGE_SCHEME].includes(comp.value.type)
   );
+
+export const isValueImageSchemeComponent = (
+  comp: ComponentBase,
+): comp is Extract<ComponentBase, { value?: ValueImageSchemeValue }> =>
+  !!(isImageSchemeComponent(comp) && VALUE_IMAGE_SCHEME === comp.value?.type);
 
 export const isConditionalImageSchemeComponent = (
   comp: ComponentBase,
@@ -54,7 +64,7 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
       return;
     }
     const component = get(componentAtom.atom);
-    const imageScheme = component.value as ConditionalImageSchemeValue;
+    const imageScheme = component.value as ValueImageSchemeValue | ConditionalImageSchemeValue;
 
     switch (imageScheme.type) {
       case CONDITIONAL_IMAGE_SCHEME: {
@@ -113,6 +123,43 @@ export const makeImageSchemeAtomForComponent = (layers: readonly LayerModel[]) =
           imageIconsAtom: imageIconsAtom,
           imageIconAtomsAtom: splitAtom(imageIconsAtom),
         } as ImageIconSet;
+      }
+      case VALUE_IMAGE_SCHEME: {
+        if (!isValueImageSchemeComponent(component)) return;
+        const imageIcons = component.preset?.defaultValue
+          ? [
+              {
+                id: component.id,
+                value: component.preset.defaultValue,
+                imageUrl: component.preset.defaultValue,
+                // TODO: Use setting value
+                imageColor: "#ffffff", // color: component.preset.imageColor
+                name: component.preset.legendName ?? "",
+              },
+            ]
+          : [];
+        const imageIconsAtom = atom(
+          () => imageIcons,
+          (_get, set, action: SetStateAction<ImageIcon[]>) => {
+            const update = typeof action === "function" ? action(imageIcons) : action;
+            set(componentAtom.atom, {
+              ...component,
+              value: {
+                ...(component.value ?? {}),
+                imageUrl: update[0].imageUrl,
+                imageColor: update[0].imageColor,
+              } as typeof component.value,
+            });
+          },
+        ) as unknown as PrimitiveAtom<ImageIcon[]>; // For compat
+        return component.preset?.asLegend
+          ? ({
+              type: "imageIcon" as const,
+              name: get(layer.titleAtom),
+              imageIconsAtom: imageIconsAtom,
+              imageIconAtomsAtom: splitAtom(imageIconsAtom),
+            } as ImageIconSet)
+          : undefined;
       }
     }
   });


### PR DESCRIPTION
I fixed legend inspector to display simple value field like FillColorValueField, UseImageValueField.
|color|image|
|:--:|:--:|
|![Screenshot 2023-11-17 at 18 00 07](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/5f35a418-e6a2-4b97-aa75-c94bcaa6b1ae)|![Screenshot 2023-11-17 at 18 03 25](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/807a8dc7-5d5e-4c39-b116-8ea10d7cdb68)|
