### PR TITLE
fix(extension): z-index for WAS

### DIFF
--- a/extension/src/editor/containers/ui-components/editor/EditorNotice.tsx
+++ b/extension/src/editor/containers/ui-components/editor/EditorNotice.tsx
@@ -1,4 +1,4 @@
-import { Alert, Snackbar } from "@mui/material";
+import { Alert, Snackbar, styled } from "@mui/material";
 import { forwardRef, useImperativeHandle, useState } from "react";
 
 export type EditorNoticeRef = {
@@ -7,6 +7,10 @@ export type EditorNoticeRef = {
     message: string;
   }) => void;
 };
+
+const StyledSnackbar = styled(Snackbar)(() => ({
+  position: "absolute",
+}));
 
 export const EditorNotice = forwardRef((_, ref) => {
   const [open, setOpen] = useState(false);
@@ -32,7 +36,7 @@ export const EditorNotice = forwardRef((_, ref) => {
   }));
 
   return (
-    <Snackbar
+    <StyledSnackbar
       open={open}
       autoHideDuration={3000}
       onClose={handleClose}
@@ -40,6 +44,6 @@ export const EditorNotice = forwardRef((_, ref) => {
       <Alert severity={severity} sx={{ width: "100%" }}>
         {message}
       </Alert>
-    </Snackbar>
+    </StyledSnackbar>
   );
 });

--- a/extension/src/prototypes/ui-components/OverlayPopper.tsx
+++ b/extension/src/prototypes/ui-components/OverlayPopper.tsx
@@ -2,6 +2,7 @@ import { ClickAwayListener, Popper, styled, useTheme, type PopperProps } from "@
 import { omit } from "lodash";
 import { useCallback, useState, type FC, type ReactNode } from "react";
 
+import { Z_INDEX_WAS } from "../../shared/reearth/constants/style";
 import { isNotFalse } from "../type-helpers";
 
 const Arrow = styled("div")(({ theme }) => {
@@ -97,7 +98,7 @@ export const OverlayPopper: FC<OverlayPopperProps> = ({
   const theme = useTheme();
   return (
     <Popper
-      style={{ zIndex: 1 }}
+      style={{ zIndex: Z_INDEX_WAS }}
       // WORKAROUND: Accept popover props.
       {...(omit(props, ["anchorPosition", "anchorReference"]) as PopperProps)}
       modifiers={[

--- a/extension/src/shared/reearth/constants/style.ts
+++ b/extension/src/shared/reearth/constants/style.ts
@@ -1,0 +1,2 @@
+// For https://github.com/reearth/reearth/blob/2e8f2267fa541c8fe3ae49256976b86c92709351/web/src/services/theme/reearthTheme/common/zIndex.ts#L3
+export const Z_INDEX_WAS = 300;


### PR DESCRIPTION
I fixed z-index for popover because the z-index of WAS is changed in [this commit](https://github.com/reearth/reearth/pull/751/files#diff-41a2cd990413b37710725ee60028ed47233f13c47d14a107ee33862574465621R3).
