### PR TITLE
fix(extension): fix layer to initialize without appearance to be resettable

### DIFF
--- a/extension/src/shared/reearth/hooks/useLayer.ts
+++ b/extension/src/shared/reearth/hooks/useLayer.ts
@@ -29,7 +29,6 @@ export const useLayer = ({
       type: "simple",
       data: data,
       events,
-      ...appearances,
     });
 
     layerIdRef.current = layerId;


### PR DESCRIPTION
I fixed layer to initialize without appearance. In NLS, initial appearance should be used as default value when you override the appearance with `undefined`.