### PR TITLE
feat(extension): add height reference and classification type field

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorClassificationTypeField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorClassificationTypeField.tsx
@@ -1,0 +1,62 @@
+import { ChangeEvent, useCallback } from "react";
+
+import { BasicFieldProps } from "..";
+import {
+  PropertyBox,
+  PropertyInlineWrapper,
+  PropertySelectField,
+  PropertyWrapper,
+} from "../../../../ui-components";
+
+export type ClassificationTypeFieldPreset = {
+  defaultValue: "both" | "3dtiles" | "terrain";
+};
+
+const OPTIONS = [
+  {
+    label: "BOTH",
+    value: "both",
+  },
+  {
+    label: "CESIUM_3D_TILE",
+    value: "3dtiles",
+  },
+  {
+    label: "TERRAIN",
+    value: "terrain",
+  },
+];
+
+type SupportedFieldTypes =
+  | "POLYLINE_CLASSIFICATION_TYPE_FIELD"
+  | "POLYGON_CLASSIFICATION_TYPE_FIELD";
+
+export const EditorCLassificationTypeField: React.FC<BasicFieldProps<SupportedFieldTypes>> = ({
+  component,
+  onUpdate,
+}) => {
+  const handleValueChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          defaultValue: e.target.value as ClassificationTypeFieldPreset["defaultValue"],
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+  return (
+    <PropertyWrapper>
+      <PropertyBox>
+        <PropertyInlineWrapper label="Classfication Type">
+          <PropertySelectField
+            options={OPTIONS}
+            value={component.preset?.defaultValue || "both"}
+            onChange={handleValueChange}
+          />
+        </PropertyInlineWrapper>
+      </PropertyBox>
+    </PropertyWrapper>
+  );
+};

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorHeightReferenceField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorHeightReferenceField.tsx
@@ -1,0 +1,63 @@
+import { ChangeEvent, useCallback } from "react";
+
+import { BasicFieldProps } from "..";
+import {
+  PropertyBox,
+  PropertyInlineWrapper,
+  PropertySelectField,
+  PropertyWrapper,
+} from "../../../../ui-components";
+
+export type HeightReferenceFieldPreset = {
+  defaultValue: "clamp" | "relative" | "none";
+};
+
+const OPTIONS = [
+  {
+    label: "Clamp to ground",
+    value: "clamp",
+  },
+  {
+    label: "Relative to ground",
+    value: "relative",
+  },
+  {
+    label: "None",
+    value: "none",
+  },
+];
+
+type SupportedFieldTypes =
+  | "POINT_HEIGHT_REFERENCE_FIELD"
+  | "POLYLINE_HEIGHT_REFERENCE_FIELD"
+  | "POLYGON_HEIGHT_REFERENCE_FIELD";
+
+export const EditorHeightReferenceField: React.FC<BasicFieldProps<SupportedFieldTypes>> = ({
+  component,
+  onUpdate,
+}) => {
+  const handleValueChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          defaultValue: e.target.value as HeightReferenceFieldPreset["defaultValue"],
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+  return (
+    <PropertyWrapper>
+      <PropertyBox>
+        <PropertyInlineWrapper label="Height Reference">
+          <PropertySelectField
+            options={OPTIONS}
+            value={component.preset?.defaultValue || "clamp"}
+            onChange={handleValueChange}
+          />
+        </PropertyInlineWrapper>
+      </PropertyBox>
+    </PropertyWrapper>
+  );
+};

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -12,9 +12,11 @@ import { EditorTilesetBuildingModelFilterField } from "./3dtiles/EditorTilesetBu
 import { EditorTilesetClippingField } from "./3dtiles/EditorTilesetClippingField";
 import { EditorTilesetFloodModelColorField } from "./3dtiles/EditorTilesetFloodModelColorField";
 import { EditorTilesetFloodModelFilterField } from "./3dtiles/EditorTilesetFloodModelFilterField";
+import { EditorCLassificationTypeField } from "./common/EditorClassificationTypeField";
 import { EditorFillColorConditionField } from "./common/EditorFillColorConditionField";
 import { EditorFillColorGradientField } from "./common/EditorFillColorGradientField";
 import { EditorFillColorValueField } from "./common/EditorFillColorValueField";
+import { EditorHeightReferenceField } from "./common/EditorHeightReferenceField";
 import { EditorVisibilityConditionField } from "./common/EditorVisibilityConditionField";
 import { EditorVisibilityFilterField } from "./common/EditorVisibilityFilterField";
 import {
@@ -185,6 +187,13 @@ export const fields: {
     name: "Convert from CSV",
     Component: EditorPointConvertFromCSVField,
   },
+  POINT_HEIGHT_REFERENCE_FIELD: {
+    category: FIELD_CATEGORY_POINT,
+    name: "Height Reference",
+    Component: EditorHeightReferenceField as React.FC<
+      BasicFieldProps<"POINT_HEIGHT_REFERENCE_FIELD">
+    >,
+  },
   // Polyline
   POLYLINE_STROKE_WEIGHT_FIELD: {
     category: FIELD_CATEGORY_POLYLINE,
@@ -221,6 +230,20 @@ export const fields: {
     name: "Filter",
     Component: EditorVisibilityFilterField as React.FC<
       BasicFieldProps<"POLYLINE_VISIBILITY_FILTER_FIELD">
+    >,
+  },
+  POLYLINE_HEIGHT_REFERENCE_FIELD: {
+    category: FIELD_CATEGORY_POLYLINE,
+    name: "Height Reference",
+    Component: EditorHeightReferenceField as React.FC<
+      BasicFieldProps<"POLYLINE_HEIGHT_REFERENCE_FIELD">
+    >,
+  },
+  POLYLINE_CLASSIFICATION_TYPE_FIELD: {
+    category: FIELD_CATEGORY_POLYLINE,
+    name: "Classification Type",
+    Component: EditorCLassificationTypeField as React.FC<
+      BasicFieldProps<"POLYLINE_CLASSIFICATION_TYPE_FIELD">
     >,
   },
   // Polygon
@@ -264,6 +287,20 @@ export const fields: {
     name: "Condition",
     Component: EditorVisibilityConditionField as React.FC<
       BasicFieldProps<"POLYGON_VISIBILITY_CONDITION_FIELD">
+    >,
+  },
+  POLYGON_HEIGHT_REFERENCE_FIELD: {
+    category: FIELD_CATEGORY_POLYGON,
+    name: "Height Reference",
+    Component: EditorHeightReferenceField as React.FC<
+      BasicFieldProps<"POLYGON_HEIGHT_REFERENCE_FIELD">
+    >,
+  },
+  POLYGON_CLASSIFICATION_TYPE_FIELD: {
+    category: FIELD_CATEGORY_POLYGON,
+    name: "Classification Type",
+    Component: EditorCLassificationTypeField as React.FC<
+      BasicFieldProps<"POLYGON_CLASSIFICATION_TYPE_FIELD">
     >,
   },
   // 3dtiles

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -25,18 +25,23 @@ import {
   POINT_IMAGE_SIZE_FIELD,
   POINT_USE_3D_MODEL,
   POINT_VISIBILITY_CONDITION_FIELD,
+  POINT_HEIGHT_REFERENCE_FIELD,
 } from "../../types/fieldComponents/point";
 import {
+  POLYGON_CLASSIFICATION_TYPE_FIELD,
   POLYGON_FILL_COLOR_CONDITION_FIELD,
   POLYGON_FILL_COLOR_VALUE_FIELD,
+  POLYGON_HEIGHT_REFERENCE_FIELD,
   POLYGON_STROKE_COLOR_FIELD,
   POLYGON_STROKE_WEIGHT_FIELD,
   POLYGON_VISIBILITY_CONDITION_FIELD,
   POLYGON_VISIBILITY_FILTER_FIELD,
 } from "../../types/fieldComponents/polygon";
 import {
+  POLYLINE_CLASSIFICATION_TYPE_FIELD,
   POLYLINE_FILL_COLOR_CONDITION_FIELD,
   POLYLINE_FILL_COLOR_VALUE_FIELD,
+  POLYLINE_HEIGHT_REFERENCE_FIELD,
   POLYLINE_STROKE_WEIGHT_FIELD,
   POLYLINE_VISIBILITY_CONDITION_FIELD,
   POLYLINE_VISIBILITY_FILTER_FIELD,
@@ -355,6 +360,9 @@ export const useEvaluateGeneralAppearance = ({
   const pointModel = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], POINT_USE_3D_MODEL),
   );
+  const pointHeightReference = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POINT_HEIGHT_REFERENCE_FIELD),
+  );
 
   // Polyline
   const polylineColor = useOptionalAtomValue(
@@ -371,6 +379,12 @@ export const useEvaluateGeneralAppearance = ({
   );
   const polylineVisibilityFilter = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], POLYLINE_VISIBILITY_FILTER_FIELD),
+  );
+  const polylineHeightReference = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POLYLINE_HEIGHT_REFERENCE_FIELD),
+  );
+  const polylineClassificationType = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POLYLINE_CLASSIFICATION_TYPE_FIELD),
   );
 
   // Polygon
@@ -391,6 +405,12 @@ export const useEvaluateGeneralAppearance = ({
   );
   const polygonVisibilityFilter = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], POLYGON_VISIBILITY_FILTER_FIELD),
+  );
+  const polygonHeightReference = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POLYGON_HEIGHT_REFERENCE_FIELD),
+  );
+  const polygonClassificationType = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POLYGON_CLASSIFICATION_TYPE_FIELD),
   );
 
   // Tileset
@@ -433,6 +453,7 @@ export const useEvaluateGeneralAppearance = ({
           show:
             makeVisibilityFilterExpression(pointVisibilityFilter) ??
             makeVisibilityConditionExpression(pointVisibilityCondition),
+          heightReference: pointHeightReference?.preset?.defaultValue,
         },
         polyline: {
           strokeColor:
@@ -441,6 +462,10 @@ export const useEvaluateGeneralAppearance = ({
           show:
             makeVisibilityFilterExpression(polylineVisibilityFilter) ??
             makeVisibilityConditionExpression(polylineVisibilityCondition),
+          clampToGround: polylineHeightReference?.preset?.defaultValue
+            ? polylineHeightReference.preset.defaultValue === "clamp"
+            : undefined,
+          classificationType: polylineClassificationType?.preset?.defaultValue,
         },
         polygon: {
           fillColor:
@@ -451,6 +476,8 @@ export const useEvaluateGeneralAppearance = ({
           show:
             makeVisibilityFilterExpression(polygonVisibilityFilter) ??
             makeVisibilityConditionExpression(polygonVisibilityCondition),
+          heightReference: polygonHeightReference?.preset?.defaultValue,
+          classificationType: polygonClassificationType?.preset?.defaultValue,
         },
         model: pointModel?.preset
           ? {
@@ -480,12 +507,15 @@ export const useEvaluateGeneralAppearance = ({
       pointImageCondition,
       pointImageSize,
       pointModel,
+      pointHeightReference,
       // Polyline
       polylineColor,
       polylineFillColorCondition,
       polylineStrokeWeight,
       polylineVisibilityCondition,
       polylineVisibilityFilter,
+      polylineHeightReference,
+      polylineClassificationType,
       // Polygon
       polygonColor,
       polygonFillColorCondition,
@@ -493,6 +523,8 @@ export const useEvaluateGeneralAppearance = ({
       polygonStrokeWeight,
       polygonVisibilityCondition,
       polygonVisibilityFilter,
+      polygonHeightReference,
+      polygonClassificationType,
       // Tileset
       tilesetFillColorCondition,
       tilesetFillGradientColor,

--- a/extension/src/shared/types/fieldComponents/point.ts
+++ b/extension/src/shared/types/fieldComponents/point.ts
@@ -1,6 +1,7 @@
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillGradientColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField";
 import { FillColorValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorValueField";
+import { HeightReferenceFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorHeightReferenceField";
 import { VisibilityConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityConditionField";
 import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField";
 import { PointConvertFromCSVFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointConvertFromCSVField";
@@ -104,6 +105,12 @@ export type PointConvertFromCSVField = FieldBase<{
   preset?: PointConvertFromCSVFieldPreset;
 }>;
 
+export const POINT_HEIGHT_REFERENCE_FIELD = "POINT_HEIGHT_REFERENCE_FIELD";
+export type PointHeightReferenceField = FieldBase<{
+  type: typeof POINT_HEIGHT_REFERENCE_FIELD;
+  preset?: HeightReferenceFieldPreset;
+}>;
+
 export type PointFields =
   | PointStyleField
   | PointSizeField
@@ -116,4 +123,5 @@ export type PointFields =
   | PointUseImageConditionField
   | PointImageSizeField
   | PointUse3DModelField
-  | PointConvertFromCSVField;
+  | PointConvertFromCSVField
+  | PointHeightReferenceField;

--- a/extension/src/shared/types/fieldComponents/polygon.ts
+++ b/extension/src/shared/types/fieldComponents/polygon.ts
@@ -1,5 +1,7 @@
+import { ClassificationTypeFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorClassificationTypeField";
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillColorValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorValueField";
+import { HeightReferenceFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorHeightReferenceField";
 import { VisibilityConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityConditionField";
 import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField";
 
@@ -49,10 +51,24 @@ export type PolygonVisibilityFilterField = FieldBase<{
   preset?: VisibilityFilterFieldPreset;
 }>;
 
+export const POLYGON_HEIGHT_REFERENCE_FIELD = "POLYGON_HEIGHT_REFERENCE_FIELD";
+export type PolygonHeightReferenceField = FieldBase<{
+  type: typeof POLYGON_HEIGHT_REFERENCE_FIELD;
+  preset?: HeightReferenceFieldPreset;
+}>;
+
+export const POLYGON_CLASSIFICATION_TYPE_FIELD = "POLYGON_CLASSIFICATION_TYPE_FIELD";
+export type PolygonClassificationTypeField = FieldBase<{
+  type: typeof POLYGON_CLASSIFICATION_TYPE_FIELD;
+  preset?: ClassificationTypeFieldPreset;
+}>;
+
 export type PolygonFields =
   | PolygonStrokeColorField
   | PolygonStrokeWeightField
   | PolygonFillColorConditionField
   | PolygonFillColorValueField
   | PolygonVisibilityConditionField
-  | PolygonVisibilityFilterField;
+  | PolygonVisibilityFilterField
+  | PolygonHeightReferenceField
+  | PolygonClassificationTypeField;

--- a/extension/src/shared/types/fieldComponents/polyline.ts
+++ b/extension/src/shared/types/fieldComponents/polyline.ts
@@ -1,5 +1,7 @@
+import { ClassificationTypeFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorClassificationTypeField";
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillColorValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorValueField";
+import { HeightReferenceFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorHeightReferenceField";
 import { VisibilityConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityConditionField";
 import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorVisibilityFilterField";
 
@@ -41,9 +43,23 @@ export type PolylineVisibilityFilterField = FieldBase<{
   preset?: VisibilityFilterFieldPreset;
 }>;
 
+export const POLYLINE_HEIGHT_REFERENCE_FIELD = "POLYLINE_HEIGHT_REFERENCE_FIELD";
+export type PolylineHeightReferenceField = FieldBase<{
+  type: typeof POLYLINE_HEIGHT_REFERENCE_FIELD;
+  preset?: HeightReferenceFieldPreset;
+}>;
+
+export const POLYLINE_CLASSIFICATION_TYPE_FIELD = "POLYLINE_CLASSIFICATION_TYPE_FIELD";
+export type PolylineClassificationTypeField = FieldBase<{
+  type: typeof POLYLINE_CLASSIFICATION_TYPE_FIELD;
+  preset?: ClassificationTypeFieldPreset;
+}>;
+
 export type PolylineFields =
   | PolylineStrokeWeightField
   | PolylineFillColorConditionField
   | PolylineFillColorValueField
   | PolylineVisibilityConditionField
-  | PolylineVisibilityFilterField;
+  | PolylineVisibilityFilterField
+  | PolylineHeightReferenceField
+  | PolylineClassificationTypeField;

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -118,6 +118,7 @@ export const fieldSettings: {
   POINT_IMAGE_SIZE_FIELD: {},
   POINT_USE_3D_MODEL: {},
   POINT_CONVERT_FROM_CSV: {},
+  POINT_HEIGHT_REFERENCE_FIELD: {},
   // Polygon
   POLYGON_FILL_COLOR_VALUE_FIELD: {
     value: {
@@ -146,6 +147,8 @@ export const fieldSettings: {
     defaultValue: "",
     hasLayerUI: true,
   },
+  POLYLINE_HEIGHT_REFERENCE_FIELD: {},
+  POLYLINE_CLASSIFICATION_TYPE_FIELD: {},
   // Polygon
   POLYLINE_FILL_COLOR_VALUE_FIELD: {
     value: {
@@ -173,6 +176,8 @@ export const fieldSettings: {
     defaultValue: "",
     hasLayerUI: true,
   },
+  POLYGON_HEIGHT_REFERENCE_FIELD: {},
+  POLYGON_CLASSIFICATION_TYPE_FIELD: {},
   // 3dtiles
   TILESET_BUILDING_MODEL_COLOR: {},
   TILESET_FLOOD_MODEL_COLOR: {},


### PR DESCRIPTION
You can use `緊急輸送道路情報（東京都23区）` to test this PR.

The different part of the following images is the part of the drawn circle.

|Classification: both|Classification: terrain|
|:--:|:--:|
|![Screenshot 2023-11-24 at 10 41 30](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/7407dbf3-cb16-4df9-8744-62b48f06ecd5)|![Screenshot 2023-11-24 at 10 40 32](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/7b114055-113a-4bfd-b5ae-c35053b585d8)|