### PR TITLE
feat(extension): point use label field

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -50,6 +50,7 @@ import { EditorPointStyleField } from "./point/EditorPointStyleField";
 import { EditorPointUse3DModelField } from "./point/EditorPointUse3DModelField";
 import { EditorPointUseImageConditionField } from "./point/EditorPointUseImageConditionField";
 import { EditorPointUseImageValueField } from "./point/EditorPointUseImageValueField";
+import { EditorPointUseLabelField } from "./point/EditorPointUseLabelField";
 import { EditorPolygonStrokeColorField } from "./polygon/EditorPolygonStrokeColorField";
 import { EditorPolygonStrokeWeightField } from "./polygon/EditorPolygonStrokeWeightField";
 import { EditorPolylineStrokeWeightField } from "./polyline/EditorPolygonStrokeWeightField";
@@ -179,6 +180,11 @@ export const fields: {
     category: FIELD_CATEGORY_POINT,
     name: "Use 3D Model",
     Component: EditorPointUse3DModelField,
+  },
+  POINT_USE_LABEL_FIELD: {
+    category: FIELD_CATEGORY_POINT,
+    name: "Use Label",
+    Component: EditorPointUseLabelField,
   },
   POINT_CONVERT_FROM_CSV: {
     category: FIELD_CATEGORY_POINT,

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseLabelField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseLabelField.tsx
@@ -1,0 +1,183 @@
+import { InputAdornment } from "@mui/material";
+import { useCallback } from "react";
+
+import { BasicFieldProps } from "..";
+import {
+  PropertyBox,
+  PropertyColorField,
+  PropertyInlineWrapper,
+  PropertyInputField,
+  PropertySwitchField,
+  PropertyWrapper,
+} from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
+
+export type PointUseLabelFieldPreset = {
+  textExpression?: string;
+  fontSize?: number;
+  fontColor?: string;
+  height?: number;
+  extruded?: boolean;
+  background?: boolean;
+  backgroundColor?: string;
+};
+
+export const EditorPointUseLabelField: React.FC<BasicFieldProps<"POINT_USE_LABEL_FIELD">> = ({
+  component,
+  onUpdate,
+}) => {
+  const handleTextExpressionChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          textExpression: e.target.value,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const [fontSize, handleFontSizeChange] = useNumberFieldState(
+    component.preset?.fontSize,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            fontSize: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
+  );
+
+  const handleFontColorChange = useCallback(
+    (fontColor: string) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          fontColor,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const [height, handleHeightChange] = useNumberFieldState(
+    component.preset?.height,
+    useCallback(
+      v => {
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            height: v,
+          },
+        });
+      },
+      [component, onUpdate],
+    ),
+  );
+
+  const handleExtrudedChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          extruded: !!e.target.checked,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const handleBackgroundChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          background: !!e.target.checked,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const handleBackgroundColorChange = useCallback(
+    (backgroundColor: string) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          backgroundColor,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  return (
+    <PropertyWrapper>
+      <PropertyBox>
+        <PropertyInlineWrapper label="Text Expression">
+          <PropertyInputField
+            placeholder="Expression"
+            value={component.preset?.textExpression ?? ""}
+            onChange={handleTextExpressionChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Font Size">
+          <PropertyInputField
+            value={fontSize}
+            onChange={handleFontSizeChange}
+            type="number"
+            InputProps={{
+              endAdornment: <InputAdornment position="end">px</InputAdornment>,
+            }}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Font Color">
+          <PropertyColorField
+            value={component.preset?.fontColor}
+            onChange={handleFontColorChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Background">
+          <PropertySwitchField
+            checked={!!component.preset?.background}
+            onChange={handleBackgroundChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Background Color">
+          <PropertyColorField
+            value={component.preset?.backgroundColor}
+            onChange={handleBackgroundColorChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Point Height">
+          <PropertyInputField
+            value={height}
+            onChange={handleHeightChange}
+            type="number"
+            InputProps={{
+              endAdornment: <InputAdornment position="end">px</InputAdornment>,
+            }}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Point Extruded">
+          <PropertySwitchField
+            checked={!!component.preset?.extruded}
+            onChange={handleExtrudedChange}
+          />
+        </PropertyInlineWrapper>
+      </PropertyBox>
+    </PropertyWrapper>
+  );
+};

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -25,6 +25,7 @@ import {
   POINT_IMAGE_SIZE_FIELD,
   POINT_USE_3D_MODEL,
   POINT_VISIBILITY_CONDITION_FIELD,
+  POINT_USE_LABEL_FIELD,
 } from "../../types/fieldComponents/point";
 import {
   POLYGON_FILL_COLOR_CONDITION_FIELD,
@@ -355,6 +356,9 @@ export const useEvaluateGeneralAppearance = ({
   const pointModel = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], POINT_USE_3D_MODEL),
   );
+  const pointLabel = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], POINT_USE_LABEL_FIELD),
+  );
 
   // Polyline
   const polylineColor = useOptionalAtomValue(
@@ -433,6 +437,18 @@ export const useEvaluateGeneralAppearance = ({
           show:
             makeVisibilityFilterExpression(pointVisibilityFilter) ??
             makeVisibilityConditionExpression(pointVisibilityCondition),
+          label: pointLabel?.preset?.textExpression ? true : undefined,
+          labelText: pointLabel?.preset?.textExpression
+            ? { expression: pointLabel.preset.textExpression }
+            : undefined,
+          labelTypography: {
+            fontSize: pointLabel?.preset?.fontSize,
+            color: pointLabel?.preset?.fontColor,
+          },
+          labelBackground: pointLabel?.preset?.background,
+          labelBackgroundColor: pointLabel?.preset?.backgroundColor,
+          height: pointLabel?.preset?.height,
+          extrude: pointLabel?.preset?.extruded,
         },
         polyline: {
           strokeColor:
@@ -480,6 +496,7 @@ export const useEvaluateGeneralAppearance = ({
       pointImageCondition,
       pointImageSize,
       pointModel,
+      pointLabel,
       // Polyline
       polylineColor,
       polylineFillColorCondition,

--- a/extension/src/shared/types/fieldComponents/point.ts
+++ b/extension/src/shared/types/fieldComponents/point.ts
@@ -6,6 +6,7 @@ import { VisibilityFilterFieldPreset } from "../../../editor/containers/common/f
 import { PointConvertFromCSVFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointConvertFromCSVField";
 import { PointUseImageConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageConditionField";
 import { PointUseImageValueFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageValueField";
+import { PointUseLabelFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseLabelField";
 
 import { FieldBase } from "./base";
 import {
@@ -104,6 +105,12 @@ export type PointConvertFromCSVField = FieldBase<{
   preset?: PointConvertFromCSVFieldPreset;
 }>;
 
+export const POINT_USE_LABEL_FIELD = "POINT_USE_LABEL_FIELD";
+export type PointUseLabelField = FieldBase<{
+  type: typeof POINT_USE_LABEL_FIELD;
+  preset?: PointUseLabelFieldPreset;
+}>;
+
 export type PointFields =
   | PointStyleField
   | PointSizeField
@@ -116,4 +123,5 @@ export type PointFields =
   | PointUseImageConditionField
   | PointImageSizeField
   | PointUse3DModelField
-  | PointConvertFromCSVField;
+  | PointConvertFromCSVField
+  | PointUseLabelField;

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -118,6 +118,7 @@ export const fieldSettings: {
   POINT_IMAGE_SIZE_FIELD: {},
   POINT_USE_3D_MODEL: {},
   POINT_CONVERT_FROM_CSV: {},
+  POINT_USE_LABEL_FIELD: {},
   // Polygon
   POLYGON_FILL_COLOR_VALUE_FIELD: {
     value: {


### PR DESCRIPTION
## Overview

This PR adds point use label field.

## Note

Need [this](https://github.com/reearth/reearth/pull/834) to display the extrude line.

## Screen shot

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/a98f3376-68ce-4c3c-89f4-78e5dde56be1)

## Test

You can still use `避難施設情報（中央区）` to test