### PR TITLE
fix(extension): display the dataset reference on layer inspector

### DIFF
--- a/extension/src/prototypes/view/hooks/useSearchOptions.ts
+++ b/extension/src/prototypes/view/hooks/useSearchOptions.ts
@@ -181,12 +181,9 @@ export function useSearchOptions(options?: SearchOptionsParams): SearchOptions {
           if (type === BUILDING_LAYER) {
             addLayer(
               createRootLayerAtom({
-                datasetId: dataset.id,
-                type,
-                title: dataset.name,
+                dataset,
                 settings: filteredSettings,
                 templates,
-                dataList: dataset.items,
                 areaCode: municipalityCode,
                 currentDataId: datasetOption.dataset.items[0].id,
               }),
@@ -194,12 +191,9 @@ export function useSearchOptions(options?: SearchOptionsParams): SearchOptions {
           } else {
             addLayer(
               createRootLayerAtom({
-                datasetId: datasetOption.dataset.id,
-                type,
-                title: dataset.name,
+                dataset,
                 settings: filteredSettings,
                 templates,
-                dataList: dataset.items,
                 areaCode: municipalityCode,
                 currentDataId: datasetOption.dataset.items[0].id,
               }),

--- a/extension/src/prototypes/view/selection/LayerContent.tsx
+++ b/extension/src/prototypes/view/selection/LayerContent.tsx
@@ -1,11 +1,11 @@
 import { IconButton, List, Tooltip } from "@mui/material";
 import { atom, useAtom, useAtomValue, useSetAtom, type SetStateAction } from "jotai";
-import { useCallback, useMemo } from "react";
+import { MouseEvent, useCallback, useMemo, useState } from "react";
 import invariant from "tiny-invariant";
 
 import { useOptionalAtomValue } from "../../../shared/hooks";
 import { flyToCamera, flyToLayerId } from "../../../shared/reearth/utils";
-import { findRootLayerAtom } from "../../../shared/states/rootLayer";
+import { findRootLayerAtom, rootLayersAtom } from "../../../shared/states/rootLayer";
 import { Fields } from "../../../shared/view/fields/Fields";
 import { SwitchDataset } from "../../../shared/view/selection/SwitchDatasetSection";
 import { SwitchGroup } from "../../../shared/view/selection/SwitchGroupSection";
@@ -21,8 +21,10 @@ import {
 } from "../../ui-components";
 import { layerTypeIcons, layerTypeNames } from "../../view-layers";
 import { type LAYER_SELECTION, type SelectionGroup } from "../states/selection";
+import { DatasetDialog } from "../ui-containers/DatasetDialog";
 
 // import { LayerHeatmapSection } from "./LayerHeatmapSection";
+
 import { LayerHiddenFeaturesSection } from "./LayerHiddenFeaturesSection";
 // import { LayerShowWireframeSection } from "./LayerShowWireframeSection";
 // import { LayerSketchSection } from "./LayerSketchSection";
@@ -42,6 +44,12 @@ export function LayerContent<T extends LayerType>({
   const type = layer.type;
   const findRootLayer = useSetAtom(findRootLayerAtom);
   const rootLayer = findRootLayer(layer.id);
+
+  const rootLayerConfigs = useAtomValue(rootLayersAtom);
+  const rootLayerConfig = useMemo(
+    () => rootLayerConfigs.find(c => c.id === layer.id),
+    [rootLayerConfigs, layer],
+  );
 
   const setSelection = useSetAtom(layerSelectionAtom);
   const handleClose = useCallback(() => {
@@ -101,56 +109,78 @@ export function LayerContent<T extends LayerType>({
     return Object.entries(result) as [k: ComponentAtom["type"], v: ComponentAtom["atom"][]][];
   }, [values]);
 
+  const [infoOpen, setInfoOpen] = useState(false);
+  const handleInfo = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+    setInfoOpen(true);
+  }, []);
+  const handleInfoClose = useCallback(() => {
+    setInfoOpen(false);
+  }, []);
+
   return (
-    <List disablePadding>
-      <InspectorHeader
-        title={
-          values.length === 1
-            ? `${layerTypeNames[type]}レイヤー`
-            : `${values.length}個の${layerTypeNames[type]}レイヤー`
-        }
-        iconComponent={layerTypeIcons[type]}
-        actions={
-          <>
-            <Tooltip title={hidden ? "表示" : "隠す"}>
-              <IconButton aria-label={hidden ? "表示" : "隠す"} onClick={handleToggleHidden}>
-                {hidden ? <VisibilityOffIcon /> : <VisibilityOnIcon />}
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="移動">
-              <span>
-                <IconButton aria-label="移動" disabled={layerId == null} onClick={handleMove}>
-                  <AddressIcon />
+    <>
+      <List disablePadding>
+        <InspectorHeader
+          title={
+            values.length === 1
+              ? `${layerTypeNames[type]}レイヤー`
+              : `${values.length}個の${layerTypeNames[type]}レイヤー`
+          }
+          iconComponent={layerTypeIcons[type]}
+          actions={
+            <>
+              <Tooltip title={hidden ? "表示" : "隠す"}>
+                <IconButton aria-label={hidden ? "表示" : "隠す"} onClick={handleToggleHidden}>
+                  {hidden ? <VisibilityOffIcon /> : <VisibilityOnIcon />}
                 </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title="出典">
-              <span>
-                <IconButton aria-label="出典" disabled>
-                  <InfoIcon />
+              </Tooltip>
+              <Tooltip title="移動">
+                <span>
+                  <IconButton aria-label="移動" disabled={layerId == null} onClick={handleMove}>
+                    <AddressIcon />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="出典">
+                <span>
+                  <IconButton
+                    aria-label="出典"
+                    onClick={handleInfo}
+                    disabled={!rootLayerConfig || values.length !== 1}>
+                    <InfoIcon />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="削除">
+                <IconButton aria-label="削除" onClick={handleRemove}>
+                  <TrashIcon />
                 </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title="削除">
-              <IconButton aria-label="削除" onClick={handleRemove}>
-                <TrashIcon />
-              </IconButton>
-            </Tooltip>
-          </>
-        }
-        onClose={handleClose}
-      />
-      <LayerHiddenFeaturesSection layers={values} />
-      <SwitchDataset layers={values} />
-      <SwitchGroup layers={values} />
-      {/* <LayerHeatmapSection layers={values} /> */}
-      {components.map(([type, atoms]) => (
-        <Fields key={type} layers={values} type={type} atoms={atoms} />
-      ))}
-      {/* <InspectorItem> */}
-      {/* <LayerShowWireframeSection layers={values} />
+              </Tooltip>
+            </>
+          }
+          onClose={handleClose}
+        />
+        <LayerHiddenFeaturesSection layers={values} />
+        <SwitchDataset layers={values} />
+        <SwitchGroup layers={values} />
+        {/* <LayerHeatmapSection layers={values} /> */}
+        {components.map(([type, atoms]) => (
+          <Fields key={type} layers={values} type={type} atoms={atoms} />
+        ))}
+        {/* <InspectorItem> */}
+        {/* <LayerShowWireframeSection layers={values} />
         <LayerSketchSection layers={values} /> */}
-      {/* </InspectorItem> */}
-    </List>
+        {/* </InspectorItem> */}
+      </List>
+      {rootLayerConfig && (
+        <DatasetDialog
+          open={infoOpen}
+          dataset={rootLayerConfig.rawDataset}
+          municipalityCode={rootLayerConfig.areaCode}
+          onClose={handleInfoClose}
+        />
+      )}
+    </>
   );
 }

--- a/extension/src/prototypes/view/ui-containers/BuildingDatasetButtonSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/BuildingDatasetButtonSelect.tsx
@@ -2,14 +2,13 @@ import { Stack, Typography, type SelectChangeEvent } from "@mui/material";
 import { atom, useAtom, useAtomValue, useSetAtom, type Getter, type SetStateAction } from "jotai";
 import { memo, useCallback, useMemo, type FC } from "react";
 
-import { DatasetFragmentFragment, DatasetItem } from "../../../shared/graphql/types/catalog";
+import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
 import { RootLayerConfig, createRootLayerAtom } from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer } from "../../layers";
 import { ContextButtonSelect, SelectItem } from "../../ui-components";
-import { BUILDING_LAYER } from "../../view-layers";
 import { datasetTypeNames } from "../constants/datasetTypeNames";
 import { PlateauDatasetType } from "../constants/plateau";
 import { showDataFormatsAtom } from "../states/app";
@@ -61,12 +60,9 @@ export const BuildingDatasetButtonSelect: FC<BuildingDatasetButtonSelectProps> =
           const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
           addLayer(
             createRootLayerAtom({
-              type: BUILDING_LAYER,
-              datasetId: dataset.id,
-              title: dataset.name,
+              dataset,
               settings: filteredSettings,
               templates,
-              dataList: dataset.items as DatasetItem[],
               currentDataId: nextParams.id,
               areaCode: municipalityCode,
               // version: nextParams.version ?? undefined,

--- a/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
@@ -12,7 +12,7 @@ import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, type FC } from "react";
 
 import { useDatasetById } from "../../../shared/graphql";
-import { DatasetFragmentFragment, DatasetItem } from "../../../shared/graphql/types/catalog";
+import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
@@ -82,12 +82,9 @@ export const DatasetDialog: FC<DatasetDialogProps> = ({ dataset, municipalityCod
       const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
       addLayer(
         createRootLayerAtom({
-          type: layerType,
-          datasetId: dataset.id,
-          title: dataset.name,
+          dataset,
           settings: filteredSettings,
           templates,
-          dataList: dataset.items as DatasetItem[],
           areaCode: municipalityCode,
         }),
       );

--- a/extension/src/prototypes/view/ui-containers/DatasetListItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetListItem.tsx
@@ -2,7 +2,7 @@ import { IconButton, styled, useMediaQuery, useTheme } from "@mui/material";
 import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useState, type FC, type MouseEvent, type ReactNode } from "react";
 
-import { DatasetFragmentFragment, DatasetItem } from "../../../shared/graphql/types/catalog";
+import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
@@ -63,12 +63,9 @@ export const DatasetListItem: FC<DatasetListItemProps> = ({
       const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
       addLayer(
         createRootLayerAtom({
-          type: layerType,
-          datasetId: dataset.id,
-          title: dataset.name,
+          dataset,
           settings: filteredSettings,
           templates,
-          dataList: dataset.items as DatasetItem[],
           areaCode: municipalityCode,
         }),
         { autoSelect: !smDown },

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetButton.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetButton.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import { memo, useCallback, useMemo, type FC } from "react";
 
-import { DatasetFragmentFragment, DatasetItem } from "../../../shared/graphql/types/catalog";
+import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
@@ -47,12 +47,9 @@ export const DefaultDatasetButton: FC<DefaultDatasetButtonProps> = memo(
         const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
         addLayer(
           createRootLayerAtom({
-            type: layerType,
-            datasetId: dataset.id,
-            title: dataset.name,
+            dataset,
             settings: filteredSettings,
             templates,
-            dataList: dataset.items as DatasetItem[],
             areaCode: municipalityCode,
           }),
         );

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -4,7 +4,7 @@ import { differenceBy } from "lodash";
 import { memo, useCallback, useMemo, type FC } from "react";
 import invariant from "tiny-invariant";
 
-import { DatasetFragmentFragment, DatasetItem } from "../../../shared/graphql/types/catalog";
+import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
@@ -102,15 +102,15 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
           paramsToAdd.forEach(({ datasetId, datumId }) => {
             const dataset = datasets.find(d => d.id === datasetId);
             const filteredSettings = settings.filter(s => s.datasetId === datasetId);
+            if (!dataset) {
+              return;
+            }
             addLayer(
               createRootLayerAtom({
-                type: layerType,
+                dataset,
                 areaCode: municipalityCode,
-                datasetId,
-                title: dataset?.name ?? "",
                 settings: filteredSettings,
                 templates,
-                dataList: dataset?.items as DatasetItem[],
                 currentDataId: datumId,
               }),
             );

--- a/extension/src/shared/view/containers/InitialLayers.tsx
+++ b/extension/src/shared/view/containers/InitialLayers.tsx
@@ -2,7 +2,6 @@ import { useAtomValue } from "jotai";
 import { useEffect, type FC, useMemo, useRef } from "react";
 
 import { useAddLayer } from "../../../prototypes/layers";
-import { datasetTypeLayers } from "../../../prototypes/view/constants/datasetTypeLayers";
 import { PlateauDatasetType } from "../../../prototypes/view/constants/plateau";
 import { useDatasets } from "../../graphql";
 import { DatasetItem, DatasetsInput } from "../../graphql/types/catalog";
@@ -40,11 +39,8 @@ export const InitialLayers: FC = () => {
       const dataList = d.items as DatasetItem[];
       return addLayer(
         createRootLayerAtom({
-          type: datasetTypeLayers[d.type.code as PlateauDatasetType],
-          datasetId: d.id,
-          dataList,
+          dataset: d,
           areaCode: d.wardCode || d.cityCode || d.prefectureCode,
-          title: d.name,
           currentDataId: dataList.find(v => v.name === "LOD2（テクスチャなし）")?.id,
           settings: settingsRef.current.filter(s => s.datasetId === d.id),
           templates: templatesRef.current,


### PR DESCRIPTION
I fixed to display the dataset reference on layer inspector.
It will be displayed only when single layer is selected. (If multiple layers are selected, the icon button will be disabled.)

![Screenshot 2023-11-24 at 12 27 40](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/1e0b4bcc-06e8-4847-8083-656d49e9be12)
![Screenshot 2023-11-24 at 12 27 53](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/a326850e-db3b-48c4-bcce-4ea525c338b1)
