### PR TITLE
refactor(extension): style code contribute appearance

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -1,11 +1,5 @@
 import { SettingComponent } from "../../../../../shared/api/types";
 import { ComponentBase } from "../../../../../shared/types/fieldComponents";
-import {
-  POINT_FILL_COLOR_CONDITION_FIELD,
-  POINT_FILL_COLOR_GRADIENT_FIELD,
-  POINT_FILL_COLOR_VALUE_FIELD,
-  POINT_SIZE_FIELD,
-} from "../../../../../shared/types/fieldComponents/point";
 
 import { EditorTilesetBuildingModelColorField } from "./3dtiles/EditorTilesetBuildingModelColorField";
 import { EditorTilesetBuildingModelFilterField } from "./3dtiles/EditorTilesetBuildingModelFilterField";
@@ -362,12 +356,3 @@ export const getFiledComponentTree = () => {
 
   return tree;
 };
-
-// Specal rule for style code field
-// Style code field is conflict with these fields
-export const AppearanceFields = [
-  POINT_FILL_COLOR_VALUE_FIELD,
-  POINT_FILL_COLOR_CONDITION_FIELD,
-  POINT_FILL_COLOR_GRADIENT_FIELD,
-  POINT_SIZE_FIELD,
-];

--- a/extension/src/editor/containers/ui-components/component/ComponentSelector.tsx
+++ b/extension/src/editor/containers/ui-components/component/ComponentSelector.tsx
@@ -4,9 +4,7 @@ import RadioButtonUncheckedOutlinedIcon from "@mui/icons-material/RadioButtonUnc
 import { styled, List, ListItemButton, svgIconClasses } from "@mui/material";
 import { useCallback, useState, useMemo, useEffect } from "react";
 
-import { STYLE_CODE_FIELD } from "../../../../shared/types/fieldComponents/general";
 import {
-  AppearanceFields,
   FieldComponentTree,
   FieldComponentTreeItem,
 } from "../../common/fieldComponentEditor/fields";
@@ -103,8 +101,7 @@ export const ComponentSelector: React.FC<ComponentSelectorProps> = ({
             selected={fieldOrGroup.value === selectedGroupOrField?.value}
             disabled={
               existFields?.includes(fieldOrGroup.value) ||
-              !!(fieldOrGroup.group && existFieldGroups?.includes(fieldOrGroup.group)) ||
-              isConflictWithStyleCode(fieldOrGroup.value, existFields)
+              !!(fieldOrGroup.group && existFieldGroups?.includes(fieldOrGroup.group))
             }>
             <StyledIcon>
               {fieldOrGroup.isFolder ? (
@@ -128,8 +125,7 @@ export const ComponentSelector: React.FC<ComponentSelectorProps> = ({
             selected={field.value === selectedField?.value}
             disabled={
               existFields?.includes(field.value) ||
-              !!(field.group && existFieldGroups?.includes(field.group)) ||
-              isConflictWithStyleCode(field.value, existFields)
+              !!(field.group && existFieldGroups?.includes(field.group))
             }>
             <StyledIcon>
               {existFields?.includes(field.value) ? (
@@ -190,20 +186,3 @@ const StyledIcon = styled("div")(({ theme }) => ({
     width: "16px",
   },
 }));
-
-const isConflictWithStyleCode = (field: string, existFields?: string[]) => {
-  if (!existFields) return false;
-  let isConflict = false;
-  if (field === STYLE_CODE_FIELD) {
-    existFields.forEach(existField => {
-      if (AppearanceFields.includes(existField)) {
-        isConflict = true;
-      }
-    });
-  } else {
-    if (existFields.includes(STYLE_CODE_FIELD) && AppearanceFields.includes(field)) {
-      isConflict = true;
-    }
-  }
-  return isConflict;
-};

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -430,14 +430,14 @@ export const useEvaluateGeneralAppearance = ({
     useFindComponent(componentAtoms ?? [], STYLE_CODE_FIELD),
   )?.preset?.code;
 
-  const appearanceObject = useMemo(
+  const appearanceObjectFromStyleCode = useMemo(
     () => getAppearanceObject(styleCodeString) ?? {},
     [styleCodeString],
   );
 
   const generalAppearances: GeneralAppearances = useMemo(
     () =>
-      merge({}, appearanceObject, {
+      merge({}, appearanceObjectFromStyleCode, {
         marker: {
           style: pointStyle?.preset?.style,
           pointColor:
@@ -497,7 +497,7 @@ export const useEvaluateGeneralAppearance = ({
         box: boxAppearance,
       }),
     [
-      appearanceObject,
+      appearanceObjectFromStyleCode,
       // Point
       pointColor,
       pointSize,

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -1,3 +1,4 @@
+import { merge } from "lodash-es";
 import { useMemo } from "react";
 
 import { isNotNullish } from "../../../prototypes/type-helpers";
@@ -409,11 +410,14 @@ export const useEvaluateGeneralAppearance = ({
     useFindComponent(componentAtoms ?? [], STYLE_CODE_FIELD),
   )?.preset?.code;
 
-  const appearanceObject = useMemo(() => getAppearanceObject(styleCodeString), [styleCodeString]);
+  const appearanceObject = useMemo(
+    () => getAppearanceObject(styleCodeString) ?? {},
+    [styleCodeString],
+  );
 
   const generalAppearances: GeneralAppearances = useMemo(
     () =>
-      appearanceObject ?? {
+      merge({}, appearanceObject, {
         marker: {
           // TODO: Use component for style
           style: pointStyle?.preset?.style,
@@ -465,7 +469,7 @@ export const useEvaluateGeneralAppearance = ({
           experimental_clipping: clippingBox,
         },
         box: boxAppearance,
-      },
+      }),
     [
       appearanceObject,
       // Point

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -419,7 +419,6 @@ export const useEvaluateGeneralAppearance = ({
     () =>
       merge({}, appearanceObject, {
         marker: {
-          // TODO: Use component for style
           style: pointStyle?.preset?.style,
           pointColor:
             makeSimpleValue(pointColor) ??


### PR DESCRIPTION
## Overview

This PR changes the behavior of style code field.

[BEFORE]
- Style code should be conflict with all other appearance field components. (aka user can only choose use style code component OR use other components)

[AFTER]
- Style code is NOT conflict with any other field component.
- Style code will act as a basic appearce object if set. If user adds any other field component, their appearance will be merged and override the style from style code component.

## Screen shot

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/3e89ff49-4b88-46b1-8a59-265f326a36c8)


## Test

You can still use `避難施設情報（中央区）` to test