### PR TITLE
feat(extension): daytime panel

### DIFF
--- a/extension/src/prototypes/ui-components/DateControl.tsx
+++ b/extension/src/prototypes/ui-components/DateControl.tsx
@@ -1,4 +1,12 @@
-import { Stack, styled } from "@mui/material";
+import {
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  styled,
+  selectClasses,
+  svgIconClasses,
+} from "@mui/material";
 import { endOfYear, format, set, startOfDay, startOfYear } from "date-fns";
 import { omit } from "lodash";
 import {
@@ -8,6 +16,7 @@ import {
   type ComponentPropsWithRef,
   type MouseEvent,
   type SyntheticEvent,
+  useMemo,
 } from "react";
 import invariant from "tiny-invariant";
 
@@ -20,6 +29,20 @@ const Root = styled("div")(({ theme }) => ({
   padding: theme.spacing(3),
   paddingRight: theme.spacing(6),
   paddingBottom: theme.spacing(5),
+}));
+
+const DateWrapper = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center",
+}));
+
+const SelectWrapper = styled("div")(({ theme }) => ({
+  [`& .${selectClasses.select}`]: {
+    padding: `${theme.spacing(0, 0.5)} !important`,
+  },
+  [`& .${svgIconClasses.root}`]: {
+    display: "none",
+  },
 }));
 
 const DateText = styled("div")(({ theme }) => ({
@@ -89,12 +112,46 @@ export const DateControl = forwardRef<HTMLDivElement, DateControlProps>(
       [onChange],
     );
 
+    const handleYearChange = useCallback(
+      (event: SelectChangeEvent) => {
+        onChange?.(event, set(dateRef.current, { year: Number(event.target.value) }));
+      },
+      [onChange],
+    );
+
+    const year = useMemo(() => `${date.getFullYear()}`, [date]);
+    const yearOptions = useMemo(() => {
+      const currentYear = date.getFullYear();
+      const years = [];
+      for (let i = currentYear; i >= 1900; i -= 1) {
+        years.push(i);
+      }
+      return years;
+    }, [date]);
+
     return (
       <Root ref={ref} {...props}>
         <Stack direction="row" spacing={3} width="100%">
           <Stack spacing={2} width={200}>
             <Stack spacing={0.5}>
-              <DateText>{format(date, "yyyy'年'M'月'd'日'")}</DateText>
+              <DateWrapper>
+                <SelectWrapper>
+                  <Select
+                    value={year}
+                    size="small"
+                    autoWidth
+                    MenuProps={{ sx: { maxHeight: 330 } }}
+                    onChange={handleYearChange}>
+                    {yearOptions.map(year => (
+                      <MenuItem key={year} value={`${year}`}>
+                        {year}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </SelectWrapper>
+                <DateText>{format(date, "年M'月'd'日'")}</DateText>
+              </DateWrapper>
+
               <TimeText>{format(date, "H:mm")}</TimeText>
             </Stack>
             <DateControlList

--- a/extension/src/prototypes/view/ui-containers/DateControlButton.tsx
+++ b/extension/src/prototypes/view/ui-containers/DateControlButton.tsx
@@ -19,7 +19,6 @@ export const DateControlButton: FC = () => {
         title="日時"
         selected={popoverProps.open}
         disableTooltip={popoverProps.open}
-        disabled
         {...bindTrigger(popupState)}>
         <ClockIcon />
       </AppIconButton>

--- a/extension/src/shared/reearth/hooks/useCamera.ts
+++ b/extension/src/shared/reearth/hooks/useCamera.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { CameraOptions, CameraPosition } from "../types";
+import { CameraOptions, CameraPosition, LatLngHeight } from "../types";
 
 export interface CameraZoom {
   zoomIn: () => void;
@@ -24,6 +24,12 @@ export function useCameraZoom(): CameraZoom {
 export function useCamera(): {
   flyTo: (camera: CameraPosition) => void;
   getCameraPosition: () => CameraPosition | undefined;
+  getCameraFovInfo: (options?: { withTerrain?: boolean; calcViewSize?: boolean }) =>
+    | {
+        center?: LatLngHeight;
+        viewSize?: number;
+      }
+    | undefined;
 } {
   const getCameraPosition = useCallback(() => {
     return window.reearth?.camera?.position;
@@ -33,8 +39,26 @@ export function useCamera(): {
     window.reearth?.camera?.flyTo(camera, options ?? { duration: 2 });
   }, []);
 
+  const getCameraFovInfo = useCallback(
+    (
+      options:
+        | {
+            withTerrain?: boolean;
+            calcViewSize?: boolean;
+          }
+        | undefined,
+    ) => {
+      return window.reearth?.camera?.getFovInfo({
+        withTerrain: options?.withTerrain ?? true,
+        calcViewSize: options?.calcViewSize ?? false,
+      });
+    },
+    [],
+  );
+
   return {
     flyTo,
     getCameraPosition,
+    getCameraFovInfo,
   };
 }

--- a/extension/src/shared/reearth/hooks/useTimeline.ts
+++ b/extension/src/shared/reearth/hooks/useTimeline.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect } from "react";
 
 export const useTimeline = () => {
+  const getTimeline = useCallback(() => {
+    return window.reearth?.clock;
+  }, []);
+
   const handleTimelinePlay = useCallback(
     ({
       start,
@@ -81,6 +85,7 @@ export const useTimeline = () => {
   }, []);
 
   return {
+    getTimeline,
     handleTimelinePlay,
     handleTimelinePlayReverse,
     handleTimelinePause,

--- a/extension/src/toolbar/containers/InitializeApp.tsx
+++ b/extension/src/toolbar/containers/InitializeApp.tsx
@@ -1,7 +1,8 @@
 import { useSetAtom } from "jotai";
-import { FC, useEffect } from "react";
+import { FC, useEffect, useLayoutEffect } from "react";
 
 import { useSettingClient, useTemplateClient } from "../../shared/api/hooks";
+import { useTimeline } from "../../shared/reearth/hooks/useTimeline";
 import { updateAllSettingAtom } from "../../shared/states/setting";
 import { updateAllTemplateAtom } from "../../shared/states/template";
 
@@ -26,6 +27,15 @@ export const InitializeApp: FC = () => {
     };
     fetch();
   }, [templateClient, updateAllTemplate]);
+
+  // Initialze clock to 10am JST of current date
+  const { handleTimelineJump } = useTimeline();
+  useLayoutEffect(() => {
+    const timezone = 9; // JST
+    const now = new Date();
+    now.setUTCHours(10 - timezone, 0, 0, 0);
+    handleTimelineJump({ start: now, stop: now, current: now });
+  }, [handleTimelineJump]);
 
   return null;
 };


### PR DESCRIPTION
## Overview

This PR adds daytime panel.
Also set default time to 10 a.m. JST of current date when initialize app.

Features:
- Should always follow reearth time.
- Should keep updating while dataset timeline playing.
- Should interrupt dataset timeline play if do any act on daytime panel.
- Should always display time with JST.
- Year is selectable on UI.

## Screenshot

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/878d7d2a-e37c-46b6-96c5-3e77b7e9d7ed)


## Test

You can play with dataset `東日本大震災時の帰宅困難者（東京駅周辺）` to test.

