### PR TITLE
feat(extension): add building search panel

### DIFF
--- a/extension/src/prototypes/ui-components/InspectorActions.tsx
+++ b/extension/src/prototypes/ui-components/InspectorActions.tsx
@@ -1,5 +1,5 @@
 import { Stack, styled } from "@mui/material";
-import { type FC, type ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 
 const Root = styled(Stack)(({ theme }) => ({
   padding: theme.spacing(0.5),
@@ -9,8 +9,10 @@ export interface InspectorActionsProps {
   children?: ReactNode;
 }
 
-export const InspectorActions: FC<InspectorActionsProps> = ({ children }) => (
-  <Root direction="row" justifyContent="space-evenly">
-    {children}
-  </Root>
+export const InspectorActions = forwardRef<HTMLDivElement, InspectorActionsProps>(
+  ({ children }, ref) => (
+    <Root direction="row" justifyContent="space-evenly" ref={ref}>
+      {children}
+    </Root>
+  ),
 );

--- a/extension/src/prototypes/ui-components/InspectorHeader.tsx
+++ b/extension/src/prototypes/ui-components/InspectorHeader.tsx
@@ -14,6 +14,7 @@ import {
   type FC,
   type MouseEvent,
   type ReactNode,
+  RefObject,
 } from "react";
 import invariant from "tiny-invariant";
 
@@ -32,6 +33,7 @@ const StyledEntityTitle = styled(EntityTitle)(({ theme }) => ({
 
 export interface InspectorHeaderProps extends EntityTitleProps {
   actions?: ReactNode;
+  actionsRef?: RefObject<HTMLDivElement> | ((el: Element | null) => void);
   minInlineWidth?: number;
   onClose?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
@@ -39,6 +41,7 @@ export interface InspectorHeaderProps extends EntityTitleProps {
 export const InspectorHeader: FC<InspectorHeaderProps> = ({
   actions,
   minInlineWidth = 540,
+  actionsRef,
   onClose,
   ...props
 }) => {
@@ -81,7 +84,7 @@ export const InspectorHeader: FC<InspectorHeaderProps> = ({
       {actions != null && !inline && (
         <>
           <Divider />
-          <InspectorActions>{actions}</InspectorActions>
+          <InspectorActions ref={actionsRef}>{actions}</InspectorActions>
         </>
       )}
     </Root>

--- a/extension/src/prototypes/view-layers/states.ts
+++ b/extension/src/prototypes/view-layers/states.ts
@@ -18,6 +18,10 @@ export const tilesetLayersAtom = atom(get =>
   get(rootLayersAtom).filter(layer => get(get(layer.rootLayerAtom).layer)),
 );
 
+export const tilesetLayersLayersAtom = atom(get =>
+  get(rootLayersAtom).map(layer => get(get(layer.rootLayerAtom).layer)),
+);
+
 // export const pedestrianLayersAtom = atom(get =>
 //   get(layersAtom).filter((layer): layer is PedestrianLayerModel => layer.type === PEDESTRIAN_LAYER),
 // );

--- a/extension/src/shared/hooks/useOptionalAtom.ts
+++ b/extension/src/shared/hooks/useOptionalAtom.ts
@@ -1,4 +1,5 @@
-import { Atom, PrimitiveAtom, atom, useAtomValue } from "jotai";
+import { Atom, PrimitiveAtom, SetStateAction, atom, useAtomValue } from "jotai";
+import { isFunction } from "lodash-es";
 import { useMemo } from "react";
 
 export const useOptionalAtom = <V>(valueAtom: Atom<V> | undefined) => {
@@ -26,8 +27,9 @@ export const useOptionalPrimitiveAtom = <V>(valueAtom: PrimitiveAtom<V> | undefi
         }
         return get(valueAtom);
       },
-      (_get, set, update: V) => {
+      (get, set, action: SetStateAction<V>) => {
         if (!valueAtom) return;
+        const update = isFunction(action) ? action(get(valueAtom)) : action;
         set(valueAtom, update);
       },
     );

--- a/extension/src/shared/ui-components/MultipleSelectSearch.story.tsx
+++ b/extension/src/shared/ui-components/MultipleSelectSearch.story.tsx
@@ -1,0 +1,78 @@
+import { type Meta, type StoryObj } from "@storybook/react";
+import { FC } from "react";
+
+import { MultipleSelectSearch } from "./MultipleSelectSearch";
+
+const meta: Meta<typeof MultipleSelectSearch> = {
+  title: "MultipleSelectSearch",
+  component: MultipleSelectSearch,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MultipleSelectSearch>;
+
+const options = [
+  {
+    label: "hello",
+    value: "1",
+  },
+  {
+    label: "hell2",
+    value: "2",
+  },
+  {
+    label: "hello3",
+    value: "3",
+  },
+  {
+    label: "hello4",
+    value: "4",
+  },
+  {
+    label: "hello5",
+    value: "5",
+  },
+  {
+    label: "hello6",
+    value: "6",
+  },
+  {
+    label: "hello7",
+    value: "7",
+  },
+  {
+    label: "hello8",
+    value: "8",
+  },
+  {
+    label: "hello9",
+    value: "9",
+  },
+  {
+    label: "hello10",
+    value: "10",
+  },
+];
+
+const Component: FC<{ position?: "top" | "bottom" }> = ({ position }) => {
+  return (
+    <div style={{ width: 300 }}>
+      <MultipleSelectSearch
+        title="名称"
+        placeholder="Please enter keyword"
+        options={options}
+        position={position}
+        onChange={console.log}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Component />,
+};
+
+export const Top: Story = {
+  render: () => <Component position="top" />,
+};

--- a/extension/src/shared/ui-components/MultipleSelectSearch.tsx
+++ b/extension/src/shared/ui-components/MultipleSelectSearch.tsx
@@ -1,0 +1,195 @@
+import { useAutocomplete, AutocompleteGetTagProps } from "@mui/base/useAutocomplete";
+import { ArrowDropDown } from "@mui/icons-material";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import { Chip } from "@mui/material";
+import { autocompleteClasses } from "@mui/material/Autocomplete";
+import { styled } from "@mui/material/styles";
+import { FC, Fragment, SyntheticEvent } from "react";
+
+import { SearchIcon } from "../../prototypes/ui-components";
+
+const Root = styled("div")(
+  ({ theme }) => `
+  color: ${theme.palette.text.primary};
+  font-size: 12px;
+  position: relative;
+  width: 100%;
+`,
+);
+
+const Label = styled("label")`
+  padding: 0 0 5px;
+  display: inline-block;
+`;
+
+const InputWrapper = styled("div")(
+  ({ theme }) => `
+  width: 100%;
+  border: 1px solid ${theme.palette.divider};
+  background-color: ${theme.palette.background.default};
+  border-radius: 4px;
+  padding: 5px 36px 5px 8px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  box-sizing: border-box;
+  gap: 5px;
+  position: relative;
+
+  &:hover {
+    border-color: ${theme.palette.primary.main};
+  }
+
+  &.focused {
+    border-color: ${theme.palette.primary.main};
+  }
+
+  & input {
+    background-color: ${theme.palette.background.default};
+    color: ${theme.palette.text.primary};
+    box-sizing: border-box;
+    width: 0;
+    min-width: 30px;
+    flex-grow: 1;
+    border: 0;
+    margin: 0;
+    outline: 0;
+    height: 24px;
+  }
+
+  & > svg {
+    position: absolute;
+    right: 6px;
+  }
+`,
+);
+
+interface TagProps extends ReturnType<AutocompleteGetTagProps> {
+  label: string;
+}
+
+const StyledChip = styled(Chip)<TagProps>(({ theme }) => ({ ...theme.typography.body2 }));
+
+const Listbox = styled("ul")<{ position: "top" | "bottom" }>(
+  ({ theme, position }) => `
+  width: 300px;
+  margin: 2px 0 0;
+  padding: 0;
+  position: absolute;
+  list-style: none;
+  background-color: ${theme.palette.background.default};
+  overflow: auto;
+  max-height: 250px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  width: 100%;
+  ${position === "top" ? "bottom: 40px;" : ""}
+
+  & li {
+    padding: 5px 12px;
+    display: flex;
+
+    & span {
+      flex-grow: 1;
+    }
+
+    & svg {
+      color: transparent;
+    }
+  }
+
+  & li[aria-selected='true'] {
+    background-color: ${theme.palette.primary.main}19;
+
+    & svg {
+      color: ${theme.palette.primary.main};
+    }
+  }
+
+  & li[aria-selected='true'].${autocompleteClasses.focused} {
+    background-color: ${theme.palette.primary.main}19;
+  }
+
+  & li.${autocompleteClasses.focused} {
+    background-color: ${theme.palette.grey[100]};
+    cursor: pointer;
+  }
+`,
+);
+
+export type Props = {
+  title: string;
+  position?: "top" | "bottom";
+  placeholder?: string;
+  options: { label: string; value: string }[];
+  onChange?: (e: SyntheticEvent, value: Props["options"]) => void;
+  values?: Props["options"];
+};
+
+export const MultipleSelectSearch: FC<Props> = ({
+  title,
+  options,
+  placeholder,
+  onChange,
+  position = "bottom",
+  values,
+}) => {
+  const {
+    getRootProps,
+    getInputLabelProps,
+    getInputProps,
+    getTagProps,
+    getListboxProps,
+    getOptionProps,
+    groupedOptions,
+    value,
+    focused,
+    setAnchorEl,
+  } = useAutocomplete({
+    multiple: true,
+    options,
+    disableCloseOnSelect: true,
+    openOnFocus: true,
+    getOptionLabel: option => option.label,
+    onChange,
+    value: values,
+  });
+
+  const List =
+    groupedOptions.length > 0 ? (
+      <Listbox {...getListboxProps()} position={position}>
+        {(groupedOptions as typeof options).map((option, index) => (
+          <li key={option.label} {...getOptionProps({ option, index })}>
+            <span>{option.label}</span>
+            <CheckIcon fontSize="small" />
+          </li>
+        ))}
+      </Listbox>
+    ) : null;
+
+  return (
+    <Root>
+      {position === "top" && List}
+      <div {...getRootProps()}>
+        <Label {...getInputLabelProps()}>{title}</Label>
+        <InputWrapper ref={setAnchorEl} className={focused ? "focused" : ""}>
+          {value.map(({ label }, index: number) => (
+            <Fragment key={label}>
+              <StyledChip
+                {...getTagProps({ index })}
+                label={label}
+                size="small"
+                deleteIcon={<CloseIcon />}
+              />
+            </Fragment>
+          ))}
+          <input {...getInputProps()} placeholder={!value.length ? placeholder : undefined} />
+          {focused ? <SearchIcon /> : <ArrowDropDown />}
+        </InputWrapper>
+      </div>
+      {position === "bottom" && List}
+    </Root>
+  );
+};

--- a/extension/src/shared/ui-components/MultipleSelectSearch.tsx
+++ b/extension/src/shared/ui-components/MultipleSelectSearch.tsx
@@ -154,7 +154,7 @@ export const MultipleSelectSearch: FC<Props> = ({
     openOnFocus: true,
     getOptionLabel: option => option.label,
     onChange,
-    value: values,
+    value: values ?? [],
   });
 
   const List =

--- a/extension/src/shared/view-layers/plateau-3dtiles/BuildingLayer.tsx
+++ b/extension/src/shared/view-layers/plateau-3dtiles/BuildingLayer.tsx
@@ -65,6 +65,7 @@ export const BuildingLayer: FC<LayerProps<typeof BUILDING_LAYER>> = ({
   featureIndexAtom,
   selections,
   hiddenFeaturesAtom,
+  searchedFeaturesAtom,
   // hiddenFeaturesAtom,
   propertiesAtom,
   colorPropertyAtom,
@@ -125,6 +126,7 @@ export const BuildingLayer: FC<LayerProps<typeof BUILDING_LAYER>> = ({
         colorSchemeAtom={colorSchemeAtom}
         colorMapAtom={colorMapAtom}
         colorRangeAtom={colorRangeAtom}
+        searchedFeaturesAtom={searchedFeaturesAtom}
         selections={selections as ScreenSpaceSelectionEntry<typeof TILESET_FEATURE>[]}
         // showWireframe={showWireframe}
 

--- a/extension/src/shared/view-layers/plateau-3dtiles/createPlateauTilesetLayerState.ts
+++ b/extension/src/shared/view-layers/plateau-3dtiles/createPlateauTilesetLayerState.ts
@@ -11,10 +11,18 @@ export interface PlateauTilesetLayerStateParams extends Omit<ComponentIdParams, 
   shouldInitializeAtom?: boolean;
 }
 
+export type SearchedFeatures = {
+  features: string[];
+  onlyShow: boolean;
+  highlight: boolean;
+  selectedIndices: number[];
+};
+
 export interface PlateauTilesetLayerState {
   isPlateauTilesetLayer: true;
   featureIndexAtom: PrimitiveAtom<TileFeatureIndex | null>;
   hiddenFeaturesAtom: PrimitiveAtom<readonly string[] | null>;
+  searchedFeaturesAtom: PrimitiveAtom<SearchedFeatures | null>;
   propertiesAtom: PrimitiveAtom<PlateauTilesetProperties | null>;
   colorPropertyAtom: PrimitiveAtom<string | null>;
   colorMapAtom: WritableAtom<ColorMap<ColorMapType>, [SetStateAction<ColorMap>], void>;
@@ -108,6 +116,7 @@ export function createPlateauTilesetLayerState(
   return {
     isPlateauTilesetLayer: true,
     featureIndexAtom: atom<TileFeatureIndex | null>(null),
+    searchedFeaturesAtom: atom<SearchedFeatures | null>(null),
     hiddenFeaturesAtom: atom<readonly string[] | null>(params.hiddenFeatures ?? null),
     propertiesAtom,
     colorPropertyAtom,

--- a/extension/src/shared/view/containers/BuildingSearchPanel.tsx
+++ b/extension/src/shared/view/containers/BuildingSearchPanel.tsx
@@ -116,11 +116,12 @@ export const BuildingSearchPanel: FC<Props> = ({ state, layer, layerId }) => {
     setTab(value);
   }, []);
 
+  const [triggerUpdate, setTriggerUpdate] = useState(0);
   const properties = useOptionalAtomValue(
     useMemo(() => {
       if (layer.type !== BUILDING_LAYER || !("propertiesAtom" in layer)) return;
       return layer.propertiesAtom as PrimitiveAtom<PlateauTilesetProperties | null>;
-    }, [layer]),
+    }, [layer, triggerUpdate]), // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const featureIndex = useOptionalAtomValue(
@@ -240,6 +241,10 @@ export const BuildingSearchPanel: FC<Props> = ({ state, layer, layerId }) => {
   }, [setSearchedFeatures]);
 
   useEffect(() => () => setSearchedFeatures(null), []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setTriggerUpdate(v => v + 1);
+  }, [state]);
 
   if (!allFeatures || !groups) return null;
 

--- a/extension/src/shared/view/containers/BuildingSearchPanel.tsx
+++ b/extension/src/shared/view/containers/BuildingSearchPanel.tsx
@@ -1,0 +1,323 @@
+import {
+  Button,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  Popover,
+  Tab,
+  Tabs,
+  styled,
+  tabClasses,
+} from "@mui/material";
+import { PrimitiveAtom, useAtom } from "jotai";
+import { get, uniq, uniqBy } from "lodash-es";
+import { PopupState, bindPopover } from "material-ui-popup-state/hooks";
+import { FC, useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
+
+import { isNotNullish } from "../../../prototypes/type-helpers";
+import { InspectorHeader, Space } from "../../../prototypes/ui-components";
+import { BUILDING_LAYER } from "../../../prototypes/view-layers";
+import { useOptionalAtomValue, useOptionalPrimitiveAtom } from "../../hooks";
+import { PlateauTilesetProperties, TileFeatureIndex } from "../../plateau";
+import {
+  MultipleSelectSearch,
+  Props as MultipleSelectSearchProps,
+} from "../../ui-components/MultipleSelectSearch";
+import { LayerModel, SearchedFeatures } from "../../view-layers";
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+  minHeight: theme.spacing(5),
+  backgroundColor: theme.palette.background.default,
+  width: "100%",
+  [`& .${tabClasses.root}`]: {
+    minHeight: theme.spacing(5),
+    width: "50%",
+  },
+}));
+
+const Content = styled("div")(() => ({
+  width: 320,
+}));
+
+const SearchContent = styled("div")(() => ({
+  margin: "8px 8px 16px 8px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+}));
+
+const SearchButton = styled(Button)(() => ({
+  color: "#ffffff",
+  fontSize: 12,
+  width: 120,
+  height: 32,
+}));
+
+const SearchConditionList = styled(List)(() => ({
+  width: "100%",
+  listStyle: "none",
+  padding: 0,
+}));
+
+const SearchConditionListItem = styled(ListItem)(() => ({
+  width: "100%",
+}));
+
+const ResultLabel = styled("div")(({ theme }) => ({
+  ...theme.typography.body2,
+  margin: "14px 16px",
+  listStyle: "none",
+  padding: 0,
+}));
+
+const ResultList = styled(List)(() => ({
+  width: "100%",
+  maxHeight: 360,
+  overflowY: "auto",
+}));
+
+const ResultListItem = styled(ListItemButton)(({ theme }) => ({
+  ...theme.typography.body2,
+  width: "100%",
+  maxHeight: 360,
+}));
+
+const ResultButtonList = styled("ul")(() => ({
+  display: "flex",
+  gap: 8,
+  justifyContent: "center",
+  listStyle: "none",
+  padding: 0,
+}));
+
+const ResultButton = styled(Button)(() => ({
+  color: "#232323",
+  width: 120,
+  height: 32,
+  fontSize: 12,
+  "&.MuiButton-containedPrimary": {
+    color: "#ffffff",
+  },
+}));
+
+type Props = {
+  state: PopupState;
+  layer: LayerModel;
+  layerId: string | null;
+};
+
+const EXCLUDE_PROPERTY_NAMES = ["attributes", "gml_id"];
+
+export const BuildingSearchPanel: FC<Props> = ({ state, layer, layerId }) => {
+  const [tab, setTab] = useState(0);
+  const deferredTab = useDeferredValue(tab);
+  const handleTabChange = useCallback((_event: unknown, value: number) => {
+    setTab(value);
+  }, []);
+
+  const properties = useOptionalAtomValue(
+    useMemo(() => {
+      if (layer.type !== BUILDING_LAYER || !("propertiesAtom" in layer)) return;
+      return layer.propertiesAtom as PrimitiveAtom<PlateauTilesetProperties | null>;
+    }, [layer]),
+  );
+
+  const featureIndex = useOptionalAtomValue(
+    useMemo(
+      () =>
+        ("featureIndexAtom" in layer ? layer.featureIndexAtom : undefined) as
+          | PrimitiveAtom<TileFeatureIndex | null>
+          | undefined,
+      [layer],
+    ),
+  );
+  const [searchedFeatures, setSearchedFeatures] = useAtom(
+    useOptionalPrimitiveAtom(
+      useMemo(
+        () =>
+          ("searchedFeaturesAtom" in layer ? layer.searchedFeaturesAtom : undefined) as
+            | PrimitiveAtom<SearchedFeatures | null>
+            | undefined,
+        [layer],
+      ),
+    ),
+  );
+
+  const allFeatures = useMemo(
+    () =>
+      window.reearth?.layers?.findFeaturesByIds?.(layerId ?? "", featureIndex?.featureIds ?? []),
+    [layerId, featureIndex],
+  );
+
+  const groups = useMemo(() => {
+    if (!allFeatures) return;
+
+    return properties?.value
+      ?.map(value => {
+        if (!value) return;
+        if (value.type !== "unknown") return;
+        if (EXCLUDE_PROPERTY_NAMES.includes(value.name)) return;
+
+        return {
+          key: value.name,
+          title: value.name,
+          options: uniqBy(
+            allFeatures
+              .map(f => {
+                const propertyValue = get(f.properties, value.name);
+                return { label: propertyValue, value: propertyValue };
+              })
+              .filter(v => !!v.label && !!v.value),
+            "label",
+          ),
+        };
+      })
+      .filter(isNotNullish);
+  }, [allFeatures, properties]);
+
+  const [conditions, setConditions] = useState<
+    Record<string, MultipleSelectSearchProps["options"]>
+  >({});
+  const handleConditionsChange = useCallback(
+    (key: string, value: MultipleSelectSearchProps["options"]) => {
+      setConditions(p => ({ ...p, [key]: value }));
+    },
+    [],
+  );
+
+  const handleSearchButtonClick = useCallback(() => {
+    if (!allFeatures) return;
+
+    const conditionEntries = Object.entries(conditions).map(([key, value]) => [
+      key,
+      value.map(v => v.label),
+    ]);
+    const hasCondition = conditionEntries.some(([, values]) => !!values.length);
+
+    if (allFeatures && hasCondition) {
+      setSearchedFeatures({
+        features: uniq(
+          allFeatures
+            .filter(f =>
+              conditionEntries.every(
+                ([key, values]) => !values.length || values.includes(get(f.properties, key)),
+              ),
+            )
+            .map(f => f.id),
+        ),
+        highlight: true,
+        onlyShow: false,
+        selectedIndices: [],
+      });
+    }
+    setTab(1);
+  }, [allFeatures, conditions, setSearchedFeatures]);
+
+  // TODO: Handle moving camera to the selected feature in this function.
+  const handleResultItemClick = useCallback(
+    (i: number) => {
+      setSearchedFeatures(p => {
+        const shouldUpdate = p?.selectedIndices.every(v => v !== i);
+        return p
+          ? {
+              ...p,
+              selectedIndices: shouldUpdate ? [i] : p.selectedIndices.filter(v => v !== i),
+              highlight: false,
+            }
+          : p;
+      });
+    },
+    [setSearchedFeatures],
+  );
+
+  const handleHighlightResultButtonClick = useCallback(() => {
+    setSearchedFeatures(p => (p ? { ...p, highlight: !p.highlight, selectedIndices: [] } : p));
+  }, [setSearchedFeatures]);
+
+  const handleShowOnlyResultButtonClick = useCallback(() => {
+    setSearchedFeatures(p => (p ? { ...p, onlyShow: !p.onlyShow } : p));
+  }, [setSearchedFeatures]);
+
+  useEffect(() => () => setSearchedFeatures(null), []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!allFeatures || !groups) return null;
+
+  return (
+    <Popover
+      {...bindPopover(state)}
+      anchorOrigin={{
+        horizontal: "left",
+        vertical: "top",
+      }}
+      transformOrigin={{
+        horizontal: "right",
+        vertical: "top",
+      }}>
+      <InspectorHeader title={"データを検索"} onClose={state.close} />
+      <Divider />
+      <StyledTabs value={deferredTab} onChange={handleTabChange} sx={{ width: 320 }}>
+        <Tab label="条件" />
+        <Tab label="結果" />
+      </StyledTabs>
+      <Content>
+        {tab === 0 && (
+          <SearchContent>
+            <SearchConditionList>
+              {groups.map((group, i) => (
+                <SearchConditionListItem key={group.title}>
+                  <MultipleSelectSearch
+                    title={group.title}
+                    options={group.options}
+                    position={i >= 2 ? "top" : "bottom"}
+                    onChange={(_e, value) => handleConditionsChange(group.key, value)}
+                    values={conditions[group.key]}
+                  />
+                </SearchConditionListItem>
+              ))}
+            </SearchConditionList>
+            <Space size={3} />
+            <SearchButton color="primary" variant="contained" onClick={handleSearchButtonClick}>
+              検索
+            </SearchButton>
+          </SearchContent>
+        )}
+        {tab === 1 && (
+          <div>
+            <ResultLabel>{searchedFeatures?.features.length ?? 0}件見つかりました</ResultLabel>
+            <Divider />
+            <ResultList>
+              {searchedFeatures?.features.map((f, i) => (
+                <ResultListItem
+                  key={f}
+                  selected={searchedFeatures.selectedIndices.includes(i)}
+                  onClick={() => handleResultItemClick(i)}>
+                  {f}
+                </ResultListItem>
+              ))}
+            </ResultList>
+            <Divider />
+            <ResultButtonList>
+              <li>
+                <ResultButton
+                  color={searchedFeatures?.highlight ? "primary" : "secondary"}
+                  variant={searchedFeatures?.highlight ? "contained" : "outlined"}
+                  onClick={handleHighlightResultButtonClick}>
+                  結果をハイライト
+                </ResultButton>
+              </li>
+              <li>
+                <ResultButton
+                  color={searchedFeatures?.onlyShow ? "primary" : "secondary"}
+                  variant={searchedFeatures?.onlyShow ? "contained" : "outlined"}
+                  onClick={handleShowOnlyResultButtonClick}>
+                  結果のみ表示
+                </ResultButton>
+              </li>
+            </ResultButtonList>
+          </div>
+        )}
+      </Content>
+    </Popover>
+  );
+};

--- a/extension/src/toolbar/hooks/useAttachScreenSpaceSelection.tsx
+++ b/extension/src/toolbar/hooks/useAttachScreenSpaceSelection.tsx
@@ -1,11 +1,42 @@
-import { useAtomValue } from "jotai";
-import { useEffect, useMemo } from "react";
+import { atom, useAtomValue } from "jotai";
+import { isEqual } from "lodash-es";
+import { useEffect, useMemo, useRef } from "react";
 
 import { screenSpaceSelectionAtom } from "../../prototypes/screen-space-selection";
+import { isNotNullish } from "../../prototypes/type-helpers";
+import { tilesetLayersLayersAtom } from "../../prototypes/view-layers";
 
 export const useAttachScreenSpaceSelection = () => {
   const selections = useAtomValue(screenSpaceSelectionAtom);
-  const layers = useMemo(
+
+  // Highlight from building search functionality
+  const tilesetLayers = useAtomValue(tilesetLayersLayersAtom);
+  const tilesetLayersSelections = useAtomValue(
+    useMemo(
+      () =>
+        atom(get =>
+          tilesetLayers
+            .map(l => {
+              if (!("searchedFeaturesAtom" in l)) return;
+              const searchedFeatures = get(l.searchedFeaturesAtom);
+              const layerId = get(l.layerIdAtom);
+              return (searchedFeatures?.highlight || !!searchedFeatures?.selectedIndices.length) &&
+                layerId
+                ? {
+                    layerId,
+                    featureId: searchedFeatures.highlight
+                      ? searchedFeatures.features
+                      : searchedFeatures.selectedIndices.map(i => searchedFeatures.features[i]),
+                  }
+                : undefined;
+            })
+            .filter(isNotNullish),
+        ),
+      [tilesetLayers],
+    ),
+  );
+
+  const selectionsLayers = useMemo(
     () =>
       selections.reduce((res, s) => {
         let layerIndex = res.findIndex(v => v.layerId === s.value.layerId);
@@ -21,7 +52,33 @@ export const useAttachScreenSpaceSelection = () => {
       }, [] as { layerId: string; featureId: string[] }[]),
     [selections],
   );
+
+  const layers = useMemo(
+    () =>
+      tilesetLayersSelections.reduce(
+        (res, t) => {
+          let layerIndex = res.findIndex(v => v.layerId === t.layerId);
+          if (layerIndex === -1) {
+            layerIndex =
+              res.push({
+                layerId: t.layerId,
+                featureId: [],
+              }) - 1;
+          }
+          res[layerIndex].featureId = res[layerIndex].featureId.concat(t.featureId);
+          return res;
+        },
+        [...selectionsLayers],
+      ),
+    [tilesetLayersSelections, selectionsLayers],
+  );
+
+  const prevLayersRef = useRef(layers);
   useEffect(() => {
-    window.reearth?.layers?.selectFeatures?.(layers);
+    if (isEqual(prevLayersRef.current, layers)) return;
+    requestAnimationFrame(() => {
+      window.reearth?.layers?.selectFeatures?.(layers);
+      prevLayersRef.current = layers;
+    });
   }, [layers]);
 };


### PR DESCRIPTION
The behavior should be same with VIEW2.0, but there are some different behavior.
- The state of search will be kept until the layer inspector is deleted.
- Due to the above of reason, we can not select feature while searching, because the feature inspector will replace the layer inspector.

https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/d74782e6-6718-4ce9-9667-9b0a1f891585

