### PR TITLE
fix(extension): point use label expression

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseLabelField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseLabelField.tsx
@@ -167,7 +167,7 @@ export const EditorPointUseLabelField: React.FC<BasicFieldProps<"POINT_USE_LABEL
             onChange={handleHeightChange}
             type="number"
             InputProps={{
-              endAdornment: <InputAdornment position="end">px</InputAdornment>,
+              endAdornment: <InputAdornment position="end">meter</InputAdornment>,
             }}
           />
         </PropertyInlineWrapper>

--- a/extension/src/shared/api/hooks/settings.ts
+++ b/extension/src/shared/api/hooks/settings.ts
@@ -15,12 +15,20 @@ export default () => {
   const saveSetting = useCallback(
     async (setting: Setting) => {
       setIsSaving(true);
+
+      const settings = await client.findAll();
+      const existSetting = settings.find(
+        s => s.datasetId === setting.datasetId && s.dataId === setting.dataId,
+      );
+
       const nextSetting = await (async () => {
+        if (existSetting) {
+          return await client.update(existSetting.id, setting);
+        }
         if (setting.id) {
           return await client.update(setting.id, setting);
-        } else {
-          return await client.save(setting);
         }
+        return await client.save(setting);
       })();
 
       updateSetting(nextSetting);

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -325,6 +325,19 @@ export const makeConditionalImageColorExpression = (
   };
 };
 
+export const makeLabelTextExpression = (
+  comp: Component<typeof POINT_USE_LABEL_FIELD> | undefined,
+): ExpressionContainer | string | undefined => {
+  if (!comp) return;
+  const textExpression = comp.preset?.textExpression;
+  if (!textExpression?.startsWith("=")) return textExpression;
+  return {
+    expression: {
+      conditions: [["true", textExpression.substring(1)]],
+    },
+  };
+};
+
 export const useEvaluateGeneralAppearance = ({
   componentAtoms,
 }: {
@@ -461,9 +474,7 @@ export const useEvaluateGeneralAppearance = ({
             makeVisibilityFilterExpression(pointVisibilityFilter) ??
             makeVisibilityConditionExpression(pointVisibilityCondition),
           label: pointLabel?.preset?.textExpression ? true : undefined,
-          labelText: pointLabel?.preset?.textExpression
-            ? { expression: pointLabel.preset.textExpression }
-            : undefined,
+          labelText: makeLabelTextExpression(pointLabel),
           labelTypography: {
             fontSize: pointLabel?.preset?.fontSize,
             color: pointLabel?.preset?.fontColor,


### PR DESCRIPTION
## Overview

This PR fixes the expression of point label text. 
- Now it matches the logic of View 2.0.
When use expression user should input start with `=`, like `=${名称}`. otherwise input will be treated as a simple text.
- Fix the unit of height in UI. It should be `meter` not `px`.
- Fix settings save logic. Check for exist setting item before save. 

## Screenshot
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/255bb149-4fc0-48b9-ac3d-fbe6fc70dd42)

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/c0d55a01-09d5-4054-9d73-1f6a58e2221f)

## Test

Test with `リアルタイムデータ/西武バス バス関連リアルタイム`