### PR TITLE
fix(extension): auto feature inspector type & support emphasis property from dataset editor

### DIFF
--- a/extension/src/shared/view-layers/rootLayer.ts
+++ b/extension/src/shared/view-layers/rootLayer.ts
@@ -8,7 +8,7 @@ import { DEFAULT_SETTING_DATA_ID } from "../api/constants";
 import {
   ComponentGroup,
   ComponentTemplate,
-  EmphasisPropertyTemplate,
+  EmphasisProperty,
   FeatureInspectorSettings,
   GeneralSetting,
   Setting,
@@ -104,16 +104,16 @@ const findComponentTemplate = (
   return template?.type === "component" ? template : undefined;
 };
 
-const findEmphasisPropertyTemplate = (
+const findEmphasisProperties = (
   featureInspector: FeatureInspectorSettings | undefined,
   templates: Template[],
-): EmphasisPropertyTemplate | undefined => {
-  const { useTemplate, templateId } = featureInspector?.emphasisProperty ?? {};
-  if (!useTemplate || !templateId) return;
+): EmphasisProperty[] | undefined => {
+  const { useTemplate, templateId, properties } = featureInspector?.emphasisProperty ?? {};
+  if (!useTemplate || !templateId) return properties;
 
   const template = templates.find(t => t.id === templateId);
 
-  return template?.type === "emphasis" ? template : undefined;
+  return template?.type === "emphasis" ? template.properties : undefined;
 };
 
 const findData = (dataList: DatasetItem[], currentDataId: string | undefined) =>
@@ -174,10 +174,7 @@ const createRootLayer = ({
   const setting = findSetting(settings, currentDataId);
   const data = findData(dataList, currentDataId);
   const componentTemplate = findComponentTemplate(setting, templates);
-  const emphasisPropertyTemplate = findEmphasisPropertyTemplate(
-    setting?.featureInspector,
-    templates,
-  );
+  const emphasisProperties = findEmphasisProperties(setting?.featureInspector, templates);
   const componentGroup = findComponentGroup(setting, componentTemplate, currentGroupId);
 
   return {
@@ -188,7 +185,7 @@ const createRootLayer = ({
           ...setting.featureInspector,
           emphasisProperty: {
             ...(setting.featureInspector.emphasisProperty ?? {}),
-            properties: emphasisPropertyTemplate?.properties,
+            properties: emphasisProperties,
           },
         }
       : undefined,

--- a/extension/src/shared/view/selection/GeneralFeatureContent.tsx
+++ b/extension/src/shared/view/selection/GeneralFeatureContent.tsx
@@ -30,16 +30,13 @@ export type GeneralFeatureContentProps = {
 export const getGeneralFeatureInformation = ({ rootLayer, values }: GeneralFeatureContentProps) => {
   const firstFeature = window.reearth?.layers?.findFeatureById?.(values[0].layerId, values[0].key);
 
-  const hasProperties = !!firstFeature?.properties;
   const hasDescription = !!firstFeature?.metaData?.description;
   const displayType =
     !rootLayer.featureInspector?.basic?.displayType ||
     rootLayer.featureInspector?.basic?.displayType === "auto"
       ? hasDescription
         ? "CZMLDescription"
-        : hasProperties
-        ? "propertyList"
-        : undefined
+        : "propertyList"
       : rootLayer.featureInspector?.basic?.displayType;
   return { scrollable: displayType !== "CZMLDescription", firstFeature, displayType };
 };


### PR DESCRIPTION
- Fixed the issue that property list is not displayed when display type is `auto` in feature inspector setting.
- Fixed to use emphasis property which is set directly from feature inspector section in dataset editor.

## Test
- To display feature inspector for MVT when display type is `auto`.
- To display emphasis property which is set from dataset editor.