### PR TITLE
fix(extension): dataset story field page content not updated correctly

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorDatasetStoryField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorDatasetStoryField.tsx
@@ -168,7 +168,11 @@ export const EditorDatasetStoryField: React.FC<BasicFieldProps<"DATASET_STORY_FI
               onChange={handleCameraChange}
             />
             <PropertyItemWrapper label="Content">
-              <PropertyTextareaField value={currentPage?.content} onChange={handleContentChange} />
+              <PropertyTextareaField
+                key={currentPage.id}
+                value={currentPage?.content ?? ""}
+                onChange={handleContentChange}
+              />
             </PropertyItemWrapper>
           </>
         )}

--- a/extension/src/editor/containers/ui-components/property/PropertyCameraInput.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertyCameraInput.tsx
@@ -23,12 +23,12 @@ export const PropertyCameraInput: React.FC<PropertyCameraInputProps> = ({ value,
 
   useEffect(() => {
     onChange?.({
-      lat: latitude === "" ? NaN : Number(latitude),
-      lng: longitude === "" ? NaN : Number(longitude),
-      height: altitude === "" ? NaN : Number(altitude),
-      heading: heading === "" ? NaN : Number(heading),
-      pitch: pitch === "" ? NaN : Number(pitch),
-      roll: roll === "" ? NaN : Number(roll),
+      lat: latitude === "" ? undefined : Number(latitude),
+      lng: longitude === "" ? undefined : Number(longitude),
+      height: altitude === "" ? undefined : Number(altitude),
+      heading: heading === "" ? undefined : Number(heading),
+      pitch: pitch === "" ? undefined : Number(pitch),
+      roll: roll === "" ? undefined : Number(roll),
       fov: getCameraPosition()?.fov ?? 1.04,
     });
   }, [latitude, longitude, altitude, heading, pitch, roll, getCameraPosition, onChange]);

--- a/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
+++ b/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
@@ -39,7 +39,7 @@ export const LayerDatasetStoryField: FC<LayerDatasetStoryFieldProps> = ({ atoms 
     if (component?.preset?.pages?.[currentPage]?.camera) {
       flyTo(component.preset.pages[currentPage].camera as CameraPosition);
     }
-  }, [component, component.preset.pages, currentPage, flyTo]);
+  }, [component.preset.pages, currentPage, flyTo]);
 
   return component?.preset?.pages?.length > 0 ? (
     <ParameterList>

--- a/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
+++ b/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
@@ -39,7 +39,7 @@ export const LayerDatasetStoryField: FC<LayerDatasetStoryFieldProps> = ({ atoms 
     if (component?.preset?.pages?.[currentPage]?.camera) {
       flyTo(component.preset.pages[currentPage].camera as CameraPosition);
     }
-  }, [component.preset.pages, currentPage, flyTo]);
+  }, [component, component.preset.pages, currentPage, flyTo]);
 
   return component?.preset?.pages?.length > 0 ? (
     <ParameterList>
@@ -55,7 +55,6 @@ export const LayerDatasetStoryField: FC<LayerDatasetStoryFieldProps> = ({ atoms 
             boundaryCount={1}
             onChange={handleChange}
           />
-          s
         </PaginationWrapper>
       </CommonContentWrapper>
     </ParameterList>


### PR DESCRIPTION
## Overview

This PR fixes the issue that when switch pages on editor dataset story field, the content is not updated if target page's content is undefined.

## Test
Create multple pages and type in some text to one of them. Then switch pages.