### PR TITLE
refactor(extension): separate layer for dataset and custom layer like pedestrian layer, storytelling layer

### DIFF
--- a/extension/src/prototypes/view-layers/states.ts
+++ b/extension/src/prototypes/view-layers/states.ts
@@ -4,6 +4,7 @@ import { fromPairs, uniq, without } from "lodash-es";
 import invariant from "tiny-invariant";
 
 import { rootLayersAtom } from "../../shared/states/rootLayer";
+import { RootLayerAtom } from "../../shared/view-layers";
 import { featureSelectionAtom } from "../datasets";
 import { atomsWithSelection } from "../shared-states";
 import { isNotNullish } from "../type-helpers";
@@ -15,11 +16,11 @@ export const pixelRatioAtom = atom(1);
 
 // TODO(ReEarth): Support selected feature
 export const tilesetLayersAtom = atom(get =>
-  get(rootLayersAtom).filter(layer => get(get(layer.rootLayerAtom).layer)),
+  get(rootLayersAtom).filter(layer => get(get(layer.rootLayerAtom as RootLayerAtom).layer)),
 );
 
 export const tilesetLayersLayersAtom = atom(get =>
-  get(rootLayersAtom).map(layer => get(get(layer.rootLayerAtom).layer)),
+  get(rootLayersAtom).map(layer => get(get(layer.rootLayerAtom as RootLayerAtom).layer)),
 );
 
 // export const pedestrianLayersAtom = atom(get =>
@@ -30,7 +31,7 @@ export const highlightedTilesetLayersAtom = atom(get => {
   const featureKeys = get(featureSelectionAtom).map(({ value }) => value);
   const tilesetLayers = get(tilesetLayersAtom);
   return tilesetLayers.filter(root => {
-    const layer = get(get(root.rootLayerAtom).layer);
+    const layer = get(get(root.rootLayerAtom as RootLayerAtom).layer);
     if (!("featureIndexAtom" in layer)) {
       return;
     }
@@ -59,7 +60,7 @@ export const featureIndicesAtom = atom(get => {
   return fromPairs(
     layers
       .map(root => {
-        const layer = get(get(root.rootLayerAtom).layer);
+        const layer = get(get(root.rootLayerAtom as RootLayerAtom).layer);
         const layerId = get(layer.layerIdAtom);
         if (!("featureIndexAtom" in layer)) {
           return;
@@ -85,7 +86,7 @@ export const featureIndicesAtom = atom(get => {
 export const hideFeaturesAtom = atom(null, (get, set, value: readonly string[] | null) => {
   const layers = get(tilesetLayersAtom);
   layers.forEach(root => {
-    const layer = get(get(root.rootLayerAtom).layer);
+    const layer = get(get(root.rootLayerAtom as RootLayerAtom).layer);
     if (!("hiddenFeaturesAtom" in layer)) {
       return;
     }
@@ -105,7 +106,7 @@ export const hideFeaturesAtom = atom(null, (get, set, value: readonly string[] |
 export const showFeaturesAtom = atom(null, (get, set, value: readonly string[] | null) => {
   const layers = get(tilesetLayersAtom);
   layers.forEach(root => {
-    const layer = get(get(root.rootLayerAtom).layer);
+    const layer = get(get(root.rootLayerAtom as RootLayerAtom).layer);
     if (!("hiddenFeaturesAtom" in layer)) {
       return;
     }
@@ -127,7 +128,7 @@ export const showFeaturesAtom = atom(null, (get, set, value: readonly string[] |
 export const showAllFeaturesAtom = atom(null, (get, set) => {
   const layers = get(tilesetLayersAtom);
   layers.forEach(root => {
-    const layer = get(get(root.rootLayerAtom).layer);
+    const layer = get(get(root.rootLayerAtom as RootLayerAtom).layer);
     if (!("hiddenFeaturesAtom" in layer)) {
       return;
     }

--- a/extension/src/prototypes/view/hooks/useSearchOptions.ts
+++ b/extension/src/prototypes/view/hooks/useSearchOptions.ts
@@ -9,7 +9,7 @@ import { areasAtom } from "../../../shared/states/address";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { createRootLayerAtom } from "../../../shared/view-layers";
+import { createRootLayerForDatasetAtom } from "../../../shared/view-layers";
 import { LayerModel, addLayerAtom, useFindLayer } from "../../layers";
 import { screenSpaceSelectionAtom } from "../../screen-space-selection";
 import { type SearchOption } from "../../ui-components";
@@ -180,7 +180,7 @@ export function useSearchOptions(options?: SearchOptionsParams): SearchOptions {
           const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
           if (type === BUILDING_LAYER) {
             addLayer(
-              createRootLayerAtom({
+              createRootLayerForDatasetAtom({
                 dataset,
                 settings: filteredSettings,
                 templates,
@@ -190,7 +190,7 @@ export function useSearchOptions(options?: SearchOptionsParams): SearchOptions {
             );
           } else {
             addLayer(
-              createRootLayerAtom({
+              createRootLayerForDatasetAtom({
                 dataset,
                 settings: filteredSettings,
                 templates,

--- a/extension/src/prototypes/view/selection/LayerContent.tsx
+++ b/extension/src/prototypes/view/selection/LayerContent.tsx
@@ -11,7 +11,7 @@ import { BuildingSearchPanel } from "../../../shared/view/containers/BuildingSea
 import { Fields } from "../../../shared/view/fields/Fields";
 import { SwitchDataset } from "../../../shared/view/selection/SwitchDatasetSection";
 import { SwitchGroup } from "../../../shared/view/selection/SwitchGroupSection";
-import { BuildingLayerModel } from "../../../shared/view-layers";
+import { BuildingLayerModel, RootLayerConfigForDataset } from "../../../shared/view-layers";
 import { ComponentAtom } from "../../../shared/view-layers/component";
 import { layerSelectionAtom, removeLayerAtom, type LayerType, LayerModel } from "../../layers";
 import {
@@ -54,7 +54,10 @@ export function LayerContent<T extends LayerType>({
 
   const rootLayerConfigs = useAtomValue(rootLayersAtom);
   const rootLayerConfig = useMemo(
-    () => rootLayerConfigs.find(c => c.id === layer.id),
+    () =>
+      rootLayerConfigs.find(
+        (c): c is RootLayerConfigForDataset => c.type === "dataset" && c.id === layer.id,
+      ),
     [rootLayerConfigs, layer],
   );
 

--- a/extension/src/prototypes/view/selection/TileFeatureContent.tsx
+++ b/extension/src/prototypes/view/selection/TileFeatureContent.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState, type FC, useMemo, useEffect } from "react";
 
 import { TILESET_FEATURE } from "../../../shared/reearth/layers";
 import { findRootLayerAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
+import { RootLayerAtom } from "../../../shared/view-layers";
 import { findLayerAtom, layerSelectionAtom } from "../../layers";
 import { screenSpaceSelectionAtom } from "../../screen-space-selection";
 import {
@@ -54,7 +55,7 @@ export const TileFeatureContent: FC<TileFeatureContentProps> = ({ values }) => {
     () =>
       atom(get =>
         tilesetLayers.map(l => {
-          const v = get(get(l.rootLayerAtom).layer);
+          const v = get(get(l.rootLayerAtom as RootLayerAtom).layer);
           return { id: v.id, type: v.type } as const;
         }),
       ),

--- a/extension/src/prototypes/view/selection/TileFeaturePropertiesSection.tsx
+++ b/extension/src/prototypes/view/selection/TileFeaturePropertiesSection.tsx
@@ -6,7 +6,7 @@ import { makePropertyForFeatureInspector } from "../../../shared/plateau/feature
 import { TILESET_FEATURE } from "../../../shared/reearth/layers";
 import { Feature } from "../../../shared/reearth/types/layer";
 import { findRootLayerAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
-import { RootLayer } from "../../../shared/view-layers";
+import { RootLayerForDataset } from "../../../shared/view-layers";
 import { LayerModel, useFindLayer } from "../../layers";
 import { ParameterList, PropertyParameterItem } from "../../ui-components";
 import { type SCREEN_SPACE_SELECTION, type SelectionGroup } from "../states/selection";
@@ -42,7 +42,7 @@ export const TileFeaturePropertiesSection: FC<TileFeaturePropertiesSectionProps>
       const layer = findLayer(rootLayersLayers, l => l.id === datasetId);
       const rootLayer = findRootLayer(datasetId ?? "");
       return res.concat({ features: fs ?? [], layer, rootLayer });
-    }, [] as { features: Pick<Feature, "properties">[]; layer?: LayerModel; rootLayer?: RootLayer }[]);
+    }, [] as { features: Pick<Feature, "properties">[]; layer?: LayerModel; rootLayer?: RootLayerForDataset }[]);
   }, [values, findLayer, findRootLayer, rootLayersLayers]);
 
   const properties = useMemo(() => {

--- a/extension/src/prototypes/view/states/selection.ts
+++ b/extension/src/prototypes/view/states/selection.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import { groupBy } from "lodash";
 
 import { rootLayersAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
+import { RootLayerAtom } from "../../../shared/view-layers";
 import { layerSelectionAtom, type LayerModel, type LayerType } from "../../layers";
 import {
   screenSpaceSelectionAtom,
@@ -49,14 +50,16 @@ export type SelectionType = Selection["type"];
 export const selectionAtom = atom((get): Selection[] => [
   ...get(layerSelectionAtom)
     .map(({ id }): LayerSelection | undefined => {
-      const layer = get(rootLayersAtom).find(l => get(get(l.rootLayerAtom).layer).id === id);
+      const layer = get(rootLayersAtom).find(
+        l => get(get(l.rootLayerAtom as RootLayerAtom).layer).id === id,
+      );
       if (layer == null) {
         console.warn(`Layer does not exit: ${id}`);
       }
       return layer != null
         ? {
             type: LAYER_SELECTION,
-            value: get(get(layer.rootLayerAtom).layer),
+            value: get(get(layer.rootLayerAtom as RootLayerAtom).layer),
           }
         : undefined;
     })

--- a/extension/src/prototypes/view/ui-containers/BuildingDatasetButtonSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/BuildingDatasetButtonSelect.tsx
@@ -6,7 +6,10 @@ import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { RootLayerConfig, createRootLayerAtom } from "../../../shared/view-layers";
+import {
+  RootLayerConfigForDataset,
+  createRootLayerForDatasetAtom,
+} from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer } from "../../layers";
 import { ContextButtonSelect, SelectItem } from "../../ui-components";
 import { datasetTypeNames } from "../constants/datasetTypeNames";
@@ -17,7 +20,7 @@ interface Params {
   id?: string;
 }
 
-function createParams(get: Getter, rootLayer: RootLayerConfig): Params {
+function createParams(get: Getter, rootLayer: RootLayerConfigForDataset): Params {
   return {
     id: get(rootLayer.currentDataIdAtom),
   };
@@ -42,7 +45,10 @@ export const BuildingDatasetButtonSelect: FC<BuildingDatasetButtonSelectProps> =
   ({ dataset, municipalityCode, disabled }) => {
     const rootLayers = useAtomValue(rootLayersAtom);
     const rootLayer = useMemo(
-      () => rootLayers.find(l => l.id === dataset.id),
+      () =>
+        rootLayers.find(
+          (l): l is RootLayerConfigForDataset => l.type === "dataset" && l.id === dataset.id,
+        ),
       [rootLayers, dataset],
     );
     const settings = useAtomValue(settingsAtom);
@@ -59,7 +65,7 @@ export const BuildingDatasetButtonSelect: FC<BuildingDatasetButtonSelectProps> =
           }
           const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
           addLayer(
-            createRootLayerAtom({
+            createRootLayerForDatasetAtom({
               dataset,
               settings: filteredSettings,
               templates,

--- a/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
@@ -16,7 +16,7 @@ import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { createRootLayerAtom } from "../../../shared/view-layers";
+import { createRootLayerForDatasetAtom } from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer } from "../../layers";
 import { EntityTitle, PrefixedAddSmallIcon, PrefixedCheckSmallIcon } from "../../ui-components";
 import { BUILDING_LAYER } from "../../view-layers";
@@ -81,7 +81,7 @@ export const DatasetDialog: FC<DatasetDialogProps> = ({ dataset, municipalityCod
     if (layer == null) {
       const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
       addLayer(
-        createRootLayerAtom({
+        createRootLayerForDatasetAtom({
           dataset,
           settings: filteredSettings,
           templates,

--- a/extension/src/prototypes/view/ui-containers/DatasetListItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetListItem.tsx
@@ -6,7 +6,7 @@ import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { createRootLayerAtom } from "../../../shared/view-layers";
+import { createRootLayerForDatasetAtom } from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer } from "../../layers";
 import { DatasetTreeItem, InfoIcon, type DatasetTreeItemProps } from "../../ui-components";
 import { datasetTypeIcons } from "../constants/datasetTypeIcons";
@@ -62,7 +62,7 @@ export const DatasetListItem: FC<DatasetListItemProps> = ({
     if (layer == null) {
       const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
       addLayer(
-        createRootLayerAtom({
+        createRootLayerForDatasetAtom({
           dataset,
           settings: filteredSettings,
           templates,

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetButton.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetButton.tsx
@@ -5,7 +5,7 @@ import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { createRootLayerAtom } from "../../../shared/view-layers";
+import { createRootLayerForDatasetAtom } from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer, useFindLayer } from "../../layers";
 import { ContextButton } from "../../ui-components";
 import { datasetTypeLayers } from "../constants/datasetTypeLayers";
@@ -46,7 +46,7 @@ export const DefaultDatasetButton: FC<DefaultDatasetButtonProps> = memo(
       if (layer == null) {
         const filteredSettings = settings.filter(s => s.datasetId === dataset.id);
         addLayer(
-          createRootLayerAtom({
+          createRootLayerForDatasetAtom({
             dataset,
             settings: filteredSettings,
             templates,

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -8,7 +8,10 @@ import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
 import { rootLayersAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
-import { RootLayerConfig, createRootLayerAtom } from "../../../shared/view-layers";
+import {
+  RootLayerConfigForDataset,
+  createRootLayerForDatasetAtom,
+} from "../../../shared/view-layers";
 import { removeLayerAtom, useAddLayer, useFilterLayers } from "../../layers";
 import { isNotNullish } from "../../type-helpers";
 import { ContextSelect, SelectGroupItem, SelectItem } from "../../ui-components";
@@ -22,7 +25,7 @@ interface Params {
   datumId: string;
 }
 
-function createParamsArray(get: Getter, layers: readonly RootLayerConfig[]): Params[] {
+function createParamsArray(get: Getter, layers: readonly RootLayerConfigForDataset[]): Params[] {
   return layers
     .map(({ id, currentDataIdAtom }) => {
       const datumId = get(currentDataIdAtom);
@@ -68,8 +71,10 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
     );
     const filteredRootLayers = useMemo(
       () =>
-        rootLayers.filter(l =>
-          filteredLayers.find(f => l.id === f.id && l.areaCode === municipalityCode),
+        rootLayers.filter(
+          (l): l is RootLayerConfigForDataset =>
+            l.type === "dataset" &&
+            !!filteredLayers.find(f => l.id === f.id && l.areaCode === municipalityCode),
         ),
       [rootLayers, filteredLayers, municipalityCode],
     );
@@ -106,7 +111,7 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
               return;
             }
             addLayer(
-              createRootLayerAtom({
+              createRootLayerForDatasetAtom({
                 dataset,
                 areaCode: municipalityCode,
                 settings: filteredSettings,

--- a/extension/src/shared/plateau/featureInspector/utils.ts
+++ b/extension/src/shared/plateau/featureInspector/utils.ts
@@ -6,7 +6,7 @@ import { isNotNullish } from "../../../prototypes/type-helpers";
 import { layerDatasetTypes } from "../../../prototypes/view/constants/datasetTypeLayers";
 import { datasetTypeNames } from "../../../prototypes/view/constants/datasetTypeNames";
 import { Feature } from "../../reearth/types/layer";
-import { RootLayer } from "../../view-layers";
+import { RootLayerForDataset } from "../../view-layers";
 
 import { getAttributeLabel, getAttributes, getRootFields } from "./attributes";
 
@@ -27,7 +27,7 @@ export const makePropertyForFeatureInspector = ({
   layer,
   builtin,
 }: {
-  featureInspector?: RootLayer["featureInspector"];
+  featureInspector?: RootLayerForDataset["featureInspector"];
   layer: LayerModel | undefined;
   features: Pick<Feature, "properties">[];
   builtin?: boolean;

--- a/extension/src/shared/states/rootLayer.ts
+++ b/extension/src/shared/states/rootLayer.ts
@@ -4,7 +4,7 @@ import { atomWithReset } from "jotai/utils";
 import { LayerModel } from "../../prototypes/layers";
 import { Setting } from "../api/types";
 import { sharedAtom, sharedStoreAtom, sharedStoreAtomWrapper } from "../sharedAtoms";
-import { RootLayerConfig } from "../view-layers";
+import { RootLayerAtom, RootLayerConfig, RootLayerConfigForDataset } from "../view-layers";
 
 export const CURRENT_COMPONENT_GROUP_ID = "CURRENT_COMPONENT_GROUP_ID";
 export const CURRENT_DATA_ID = "CURRENT_DATA_ID";
@@ -17,20 +17,22 @@ export const rootLayersBaseAtom = atomWithReset<RootLayerConfig[]>([]);
 export const rootLayersAtom = sharedStoreAtomWrapper("ROOT_LAYERS", rootLayersBaseAtom);
 export const rootLayersLayersAtom = atom<LayerModel[]>(get => {
   return get(rootLayersAtom).map(root => {
-    const rootLayer = get(root.rootLayerAtom);
+    const rootLayer = get(root.rootLayerAtom as RootLayerAtom);
     return get(rootLayer.layer) as LayerModel;
   });
 });
 export const rootLayersLayerAtomsAtom = atom<PrimitiveAtom<LayerModel>[]>(get => {
   return get(rootLayersAtom).map(root => {
-    const rootLayer = get(root.rootLayerAtom);
+    const rootLayer = get(root.rootLayerAtom as RootLayerAtom);
     return rootLayer.layer as PrimitiveAtom<LayerModel>;
   });
 });
 
 export const updateRootLayerBySetting = atom(undefined, (get, set, setting: Setting) => {
   const rootLayers = get(rootLayersAtom);
-  const layer = rootLayers.find(l => l.id === setting.datasetId);
+  const layer = rootLayers.find(
+    (l): l is RootLayerConfigForDataset => l.type === "dataset" && l.id === setting.datasetId,
+  );
   if (!layer) {
     return;
   }
@@ -46,7 +48,7 @@ export const updateRootLayerBySetting = atom(undefined, (get, set, setting: Sett
 
 export const updateRootLayerBySettings = atom(undefined, (get, set, settings: Setting[]) => {
   const rootLayers = get(rootLayersAtom);
-  const layerIds = rootLayers.map(l => l.id);
+  const layerIds = rootLayers.map(l => l.type === "dataset" && l.id);
   const settingsMap = settings.reduce((res, s) => {
     if (layerIds.includes(s.datasetId)) {
       res[s.datasetId] ? res[s.datasetId].push(s) : (res[s.datasetId] = [s]);
@@ -55,6 +57,7 @@ export const updateRootLayerBySettings = atom(undefined, (get, set, settings: Se
   }, {} as Record<string, Setting[]>);
 
   for (const layer of rootLayers) {
+    if (layer.type !== "dataset") continue;
     const settings = settingsMap[layer.id];
     if (settings) {
       set(layer.settingsAtom, settings);
@@ -64,7 +67,9 @@ export const updateRootLayerBySettings = atom(undefined, (get, set, settings: Se
 
 export const removeRootLayerBySetting = atom(undefined, (get, set, setting: Setting) => {
   const rootLayers = get(rootLayersAtom);
-  const layer = rootLayers.find(l => l.id === setting.datasetId);
+  const layer = rootLayers.find(
+    (l): l is RootLayerConfigForDataset => l.type === "dataset" && l.id === setting.datasetId,
+  );
   if (!layer) {
     return;
   }
@@ -77,6 +82,7 @@ export const removeRootLayerBySetting = atom(undefined, (get, set, setting: Sett
 export const forceUpdateRootLayer = atom(undefined, (get, set) => {
   const rootLayers = get(rootLayersAtom);
   for (const layer of rootLayers) {
+    if (layer.type !== "dataset") continue;
     // Force to recreate each root layer to update templates.
     set(layer.settingsAtom, get(layer.settingsAtom));
   }
@@ -84,7 +90,9 @@ export const forceUpdateRootLayer = atom(undefined, (get, set) => {
 
 export const findRootLayerAtom = atom(undefined, (get, _, id: string) => {
   const rootLayers = get(rootLayersAtom);
-  const rootLayerConfig = rootLayers.find(r => r.id === id);
+  const rootLayerConfig = rootLayers.find(
+    (r): r is RootLayerConfigForDataset => r.type === "dataset" && r.id === id,
+  );
   if (!rootLayerConfig) return;
   const rootLayer = get(rootLayerConfig.rootLayerAtom);
   return rootLayer;

--- a/extension/src/shared/view-layers/createViewLayer.ts
+++ b/extension/src/shared/view-layers/createViewLayer.ts
@@ -50,7 +50,7 @@ import { FloodLayerModelParams, createFloodLayer } from "./plateau-3dtiles/Flood
 // import { createUrbanPlanningLayer, type UrbanPlanningLayerModelParams } from "./UrbanPlanningLayer";
 
 // prettier-ignore
-type ViewLayerModelParams<T extends LayerType> =
+export type ViewLayerModelParams<T extends LayerType> =
   T extends typeof HEATMAP_LAYER ? never : // HeatmapLayerModelParams :
   T extends typeof PEDESTRIAN_LAYER ? never : // PedestrianLayerModelParams :
   T extends typeof SKETCH_LAYER ? never : // SketchLayerModelParams :

--- a/extension/src/shared/view-layers/plateau-3dtiles/BuildingLayer.tsx
+++ b/extension/src/shared/view-layers/plateau-3dtiles/BuildingLayer.tsx
@@ -23,7 +23,7 @@ export interface BuildingLayerModelParams extends LayerModelParams, PlateauTiles
   title: string;
   version?: string;
   lod?: number;
-  textured: boolean;
+  textured?: boolean;
 }
 
 export interface BuildingLayerModel extends LayerModel, PlateauTilesetLayerState {
@@ -42,7 +42,7 @@ export function createBuildingLayer(
     ...createViewLayerModel(params),
     ...createPlateauTilesetLayerState(params),
     type: BUILDING_LAYER,
-    textured: params.textured,
+    textured: !!params.textured,
     municipalityCode: params.municipalityCode,
     title: params.title,
     versionAtom: atom(params.version ?? null),

--- a/extension/src/shared/view-layers/rootLayer.ts
+++ b/extension/src/shared/view-layers/rootLayer.ts
@@ -20,11 +20,12 @@ import { CameraPosition } from "../reearth/types";
 import { sharedStoreAtomWrapper } from "../sharedAtoms";
 import { CURRENT_COMPONENT_GROUP_ID, CURRENT_DATA_ID } from "../states/rootLayer";
 import { templatesAtom } from "../states/template";
+import { generateID } from "../utils/id";
 
 import { makeComponentAtoms } from "./component";
 import { createViewLayer } from "./createViewLayer";
 
-export type RootLayerAtomParams = {
+export type RootLayerForDatasetAtomParams = {
   areaCode: string;
   settings: Setting[];
   templates: Template[];
@@ -33,7 +34,7 @@ export type RootLayerAtomParams = {
   dataset: DatasetFragmentFragment;
 };
 
-export type RootLayerParams = {
+export type RootLayerForDatasetParams = {
   datasetId: string;
   type: LayerType;
   title: string;
@@ -46,21 +47,45 @@ export type RootLayerParams = {
   shouldInitialize: boolean;
 };
 
-export type RootLayer = {
+export type RootLayerForLayerAtomParams = {
+  id?: string;
+  type: LayerType;
+  title: string;
+  shareId: string | undefined;
+  shouldInitialize: boolean;
+};
+
+export type RootLayerForDataset = {
+  type: "dataset";
   general: GeneralSetting | undefined;
   featureInspector: FeatureInspectorSettings | undefined; // TODO: Use API definition
   layer: PrimitiveAtom<LayerModel>;
 };
 
-export type RootLayerConfig = {
+export type RootLayerForLayer = {
+  type: "layer";
+  layer: PrimitiveAtom<LayerModel>;
+};
+
+export type RootLayerConfigForDataset = {
+  type: "dataset";
   id: string;
   areaCode: string;
-  rootLayerAtom: PrimitiveAtom<RootLayer>;
+  rootLayerAtom: PrimitiveAtom<RootLayerForDataset>;
   currentGroupIdAtom: WritableAtom<string | undefined, [update: string | undefined], void>;
   currentDataIdAtom: WritableAtom<string | undefined, [update: string | undefined], void>;
   settingsAtom: WritableAtom<Setting[], [settings: Setting[]], void>;
   rawDataset: DatasetFragmentFragment;
 };
+
+export type RootLayerAtom = PrimitiveAtom<RootLayerForDataset | RootLayerForLayer>;
+
+export type RootLayerConfigForLayer = {
+  type: "layer";
+  rootLayerAtom: PrimitiveAtom<RootLayerForLayer>;
+};
+
+export type RootLayerConfig = RootLayerConfigForDataset | RootLayerConfigForLayer;
 
 const findComponentGroup = (
   setting: Setting | undefined,
@@ -158,8 +183,7 @@ const createViewLayerWithComponentGroup = (
   };
 };
 
-// TODO: Get layer from specified dataset
-const createRootLayer = ({
+const createRootLayerForDataset = ({
   datasetId,
   type,
   title,
@@ -170,7 +194,7 @@ const createRootLayer = ({
   currentGroupId,
   shareId,
   shouldInitialize,
-}: RootLayerParams): RootLayer => {
+}: RootLayerForDatasetParams): RootLayerForDataset => {
   const setting = findSetting(settings, currentDataId);
   const data = findData(dataList, currentDataId);
   const componentTemplate = findComponentTemplate(setting, templates);
@@ -178,6 +202,7 @@ const createRootLayer = ({
   const componentGroup = findComponentGroup(setting, componentTemplate, currentGroupId);
 
   return {
+    type: "dataset",
     // TODO: get settings from featureInspectorTemplate
     general: setting?.general,
     featureInspector: setting?.featureInspector
@@ -205,7 +230,9 @@ const createRootLayer = ({
   };
 };
 
-export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfig => {
+export const createRootLayerForDatasetAtom = (
+  params: RootLayerForDatasetAtomParams,
+): RootLayerConfig => {
   const dataset = params.dataset;
   const dataList = dataset.items as DatasetItem[];
   const type = datasetTypeLayers[dataset.type.code as PlateauDatasetType];
@@ -213,8 +240,8 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
   const initialSettings = params.settings;
   const initialTemplates = params.templates;
   const initialCurrentDataId = params.currentDataId ?? dataList[0].id;
-  const rootLayerAtom = atom<RootLayer>(
-    createRootLayer({
+  const rootLayerAtom = atom<RootLayerForDataset>(
+    createRootLayerForDataset({
       datasetId: dataset.id,
       type,
       title: dataset.name,
@@ -238,7 +265,7 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
 
       set(
         rootLayerAtom,
-        createRootLayer({
+        createRootLayerForDataset({
           datasetId: dataset.id,
           type,
           title: dataset.name,
@@ -268,7 +295,7 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
       const currentGroupId = get(currentGroupIdAtom);
       set(
         rootLayerAtom,
-        createRootLayer({
+        createRootLayerForDataset({
           datasetId: dataset.id,
           type,
           title: dataset.name,
@@ -292,6 +319,8 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
       if (currentGroupId === update) return;
 
       const rootLayer = get(rootLayerAtom);
+      if (rootLayer.type !== "dataset") return;
+
       const currentDataId = get(currentDataIdAtom);
       const setting = findSetting(get(settingsPrimitiveAtom), currentDataId);
       const data = findData(dataList, currentDataId);
@@ -333,6 +362,7 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
   );
 
   return {
+    type: "dataset",
     id: dataset.id,
     areaCode: params.areaCode,
     rootLayerAtom: atom(
@@ -343,5 +373,35 @@ export const createRootLayerAtom = (params: RootLayerAtomParams): RootLayerConfi
     currentGroupIdAtom: shareableCurrentGroupIdAtom,
     settingsAtom,
     rawDataset: dataset,
+  };
+};
+
+export const createRootLayerForLayerAtom = ({
+  id,
+  type,
+  title,
+  shareId,
+  shouldInitialize,
+}: RootLayerForLayerAtomParams): RootLayerConfig => {
+  const rootLayer: RootLayerForLayer = {
+    type: "layer",
+    layer: atom({
+      id: id ?? generateID(),
+      ...createViewLayer({
+        type,
+        municipalityCode: "",
+        title,
+        datasetId: undefined,
+        shareId,
+        shouldInitializeAtom: shouldInitialize,
+      }),
+    }),
+  };
+  return {
+    type: "layer",
+    rootLayerAtom: atom(
+      () => rootLayer,
+      () => {}, // readonly
+    ),
   };
 };

--- a/extension/src/shared/view/containers/InitialLayers.tsx
+++ b/extension/src/shared/view/containers/InitialLayers.tsx
@@ -7,7 +7,7 @@ import { useDatasets } from "../../graphql";
 import { DatasetItem, DatasetsInput } from "../../graphql/types/catalog";
 import { settingsAtom } from "../../states/setting";
 import { templatesAtom } from "../../states/template";
-import { createRootLayerAtom } from "../../view-layers/rootLayer";
+import { createRootLayerForDatasetAtom } from "../../view-layers/rootLayer";
 
 export const InitialLayers: FC = () => {
   const addLayer = useAddLayer();
@@ -38,7 +38,7 @@ export const InitialLayers: FC = () => {
     const remove = initialDatasets.map(d => {
       const dataList = d.items as DatasetItem[];
       return addLayer(
-        createRootLayerAtom({
+        createRootLayerForDatasetAtom({
           dataset: d,
           areaCode: d.wardCode || d.cityCode || d.prefectureCode,
           currentDataId: dataList.find(v => v.name === "LOD2（テクスチャなし）")?.id,
@@ -51,7 +51,7 @@ export const InitialLayers: FC = () => {
     });
     // const remove = [
     // addLayer(
-    //   createRootLayerAtom({
+    //   createRootLayerForDatasetAtom({
     //     type: BUILDING_LAYER,
     //     municipalityCode: "13101",
     //     version: "2020",

--- a/extension/src/shared/view/selection/GeneralFeatureContent.tsx
+++ b/extension/src/shared/view/selection/GeneralFeatureContent.tsx
@@ -12,13 +12,13 @@ import { layerTypeIcons, layerTypeNames } from "../../../prototypes/view-layers"
 import { FeatureInspectorSettings } from "../../api/types";
 import { GENERAL_FEATURE } from "../../reearth/layers";
 import { Feature } from "../../reearth/types/layer";
-import { RootLayer } from "../../view-layers";
+import { RootLayerForDataset } from "../../view-layers";
 
 import { DescriptionFeatureContent } from "./DescriptionFeatureContent";
 import { GeneralFeaturePropertiesSection } from "./GeneralFeaturePropertiesSection";
 
 export type GeneralFeatureContentProps = {
-  rootLayer: RootLayer;
+  rootLayer: RootLayerForDataset;
   values: (SelectionGroup & {
     type: typeof SCREEN_SPACE_SELECTION;
     subtype: typeof GENERAL_FEATURE;

--- a/extension/src/shared/view/selection/GeneralFeaturePropertiesSection.tsx
+++ b/extension/src/shared/view/selection/GeneralFeaturePropertiesSection.tsx
@@ -12,7 +12,7 @@ import { makePropertyForFeatureInspector } from "../../plateau/featureInspector"
 import { GENERAL_FEATURE } from "../../reearth/layers";
 import { Feature } from "../../reearth/types/layer";
 import { findRootLayerAtom, rootLayersLayersAtom } from "../../states/rootLayer";
-import { RootLayer } from "../../view-layers";
+import { RootLayerForDataset } from "../../view-layers";
 
 export interface GeneralFeaturePropertiesSectionProps {
   values: (SelectionGroup & {
@@ -55,7 +55,7 @@ export const GeneralFeaturePropertiesSection: FC<GeneralFeaturePropertiesSection
 
       res.push({ features: features ?? [], rootLayer, layer });
       return res;
-    }, [] as { features: Pick<Feature, "properties">[]; layer?: LayerModel; rootLayer: RootLayer | undefined }[]);
+    }, [] as { features: Pick<Feature, "properties">[]; layer?: LayerModel; rootLayer: RootLayerForDataset | undefined }[]);
   }, [values, findLayer, findRootLayer, rootLayersLayers]);
 
   const properties = useMemo(() => {

--- a/extension/src/shared/view/selection/SwitchDatasetSection.tsx
+++ b/extension/src/shared/view/selection/SwitchDatasetSection.tsx
@@ -5,7 +5,7 @@ import { useMemo, type FC, SetStateAction } from "react";
 import { InspectorItem, SelectParameterItem } from "../../../prototypes/ui-components";
 import { useDatasetById } from "../../graphql";
 import { rootLayersAtom } from "../../states/rootLayer";
-import { LayerModel } from "../../view-layers";
+import { LayerModel, RootLayerConfigForDataset } from "../../view-layers";
 
 export interface SwitchDatasetProps {
   layers: readonly LayerModel[];
@@ -17,7 +17,13 @@ export const SwitchDataset: FC<SwitchDatasetProps> = ({ layers }) => {
   const { data } = useDatasetById(layer.id);
   const propertyItems = useMemo(() => data.node?.items.map(item => [item.id, item.name]), [data]);
   const rootLayers = useAtomValue(rootLayersAtom);
-  const rootLayer = useMemo(() => rootLayers.find(r => r.id === layer.id), [rootLayers, layer]);
+  const rootLayer = useMemo(
+    () =>
+      rootLayers.find(
+        (r): r is RootLayerConfigForDataset => r.type === "dataset" && r.id === layer.id,
+      ),
+    [rootLayers, layer],
+  );
 
   const propertyAtoms = useMemo(
     () => [

--- a/extension/src/shared/view/selection/SwitchGroupSection.tsx
+++ b/extension/src/shared/view/selection/SwitchGroupSection.tsx
@@ -4,7 +4,7 @@ import { useMemo, type FC, SetStateAction } from "react";
 
 import { InspectorItem, SelectParameterItem } from "../../../prototypes/ui-components";
 import { rootLayersAtom } from "../../states/rootLayer";
-import { LayerModel } from "../../view-layers";
+import { LayerModel, RootLayerConfigForDataset } from "../../view-layers";
 
 export interface SwitchGroupProps {
   layers: readonly LayerModel[];
@@ -15,7 +15,13 @@ export const SwitchGroup: FC<SwitchGroupProps> = ({ layers }) => {
   const layer = layers[0]; // TODO: Support multiple selection layer if necessary
   const propertyItems = useMemo(() => layer.componentGroups, [layer.componentGroups]);
   const rootLayers = useAtomValue(rootLayersAtom);
-  const rootLayer = useMemo(() => rootLayers.find(r => r.id === layer.id), [rootLayers, layer]);
+  const rootLayer = useMemo(
+    () =>
+      rootLayers.find(
+        (r): r is RootLayerConfigForDataset => r.type === "dataset" && r.id === layer.id,
+      ),
+    [rootLayers, layer],
+  );
 
   const propertyAtoms = useMemo(
     () => [


### PR DESCRIPTION
I did refactor to separate root layer type. Because current RootLayer supports only layer which depends on dataset. So I fixed to be able to have just a layer.

- The `dataset` type of root layer is used for layer which come from dataset.
  - This type of layer has some information like component field.
- The `layer` type of root layer is used for custom layer like pedestrian layer, storyteling layer, etc.
  - This type of layer has only layer related information basically.

By using [createRootLayerForLayerAtom](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/blob/b511a803fd2faeb909f4473ad9de4e57a218b18d/extension/src/shared/view-layers/rootLayer.ts#L379), we can add pedestrian layer, sketch layer, and storytelling layer.