### PR TITLE
fix(extension): use highlightedLayer

### DIFF
--- a/extension/src/editor/containers/dataset/index.tsx
+++ b/extension/src/editor/containers/dataset/index.tsx
@@ -6,6 +6,7 @@ import { cloneDeep } from "lodash-es";
 import { useCallback, useMemo, useState, type FC, useEffect, RefObject } from "react";
 
 import { layerSelectionAtom } from "../../../prototypes/layers";
+import { highlightedLayersAtom } from "../../../prototypes/view-layers";
 import { useSettingsAPI } from "../../../shared/api";
 import { DEFAULT_SETTING_DATA_ID } from "../../../shared/api/constants";
 import { Setting } from "../../../shared/api/types";
@@ -65,7 +66,9 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
   const { settingsAtom, saveSetting } = useSettingsAPI();
   const settings = useAtomValue(settingsAtom);
 
-  const layer = useAtomValue(layerSelectionAtom)?.[0];
+  const highlightedLayer = useAtomValue(highlightedLayersAtom)?.[0];
+  const selectedLayer = useAtomValue(layerSelectionAtom)?.[0];
+  const layer = selectedLayer ?? highlightedLayer;
   const query = useDatasetById(layer?.id ?? "");
 
   const dataset = useMemo(() => {

--- a/extension/src/prototypes/view-layers/ViewLayerListItem.tsx
+++ b/extension/src/prototypes/view-layers/ViewLayerListItem.tsx
@@ -9,7 +9,11 @@ import { removeLayerAtom, type LayerProps, type LayerType } from "../layers";
 import { ColorMapIcon, ColorSetIcon, ImageIconSetIcon, LayerListItem } from "../ui-components";
 
 import { layerTypeIcons } from "./layerTypeIcons";
-import { colorSchemeSelectionAtom, imageSchemeSelectionAtom } from "./states";
+import {
+  colorSchemeSelectionAtom,
+  highlightedLayersAtom,
+  imageSchemeSelectionAtom,
+} from "./states";
 
 function stopPropagation(event: SyntheticEvent): void {
   event.stopPropagation();
@@ -34,12 +38,11 @@ export const ViewLayerListItem: FC<ViewLayerListItemProps> = memo(
     const title = useAtomValue(titleAtom);
     const loading = useAtomValue(loadingAtom);
 
-    // TODO(ReEarth): Support selected feature
-    // const highlightedAtom = useMemo(
-    //   () => atom(get => get(highlightedLayersAtom).some(layer => layer.id === id)),
-    //   [id],
-    // );
-    // const highlighted = useAtomValue(highlightedAtom);
+    const highlightedAtom = useMemo(
+      () => atom(get => get(highlightedLayersAtom).some(layer => layer.id === id)),
+      [id],
+    );
+    const highlighted = useAtomValue(highlightedAtom);
 
     const findRootLayer = useSetAtom(findRootLayerAtom);
     const rootLayer = findRootLayer(props.id);
@@ -124,7 +127,7 @@ export const ViewLayerListItem: FC<ViewLayerListItemProps> = memo(
         {...itemProps}
         title={title ?? undefined}
         iconComponent={layerTypeIcons[type]}
-        // highlighted={highlighted}
+        highlighted={highlighted}
         selected={selected}
         loading={loading}
         hidden={hidden}


### PR DESCRIPTION
I improved to use `highlightedLayer` in `LayerList` and `Editor`.
- In `LayerList`, the item should be highlighted when feature is selected.
- In `Editor`, the dataset editor should open when feature is selected.

![Screenshot 2023-12-19 at 17 11 15](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/c6fea940-80d0-4bcd-9ec5-9e671ef7893c)
