### PR TITLE
fix(extension): search logic

### DIFF
--- a/extension/src/prototypes/view/hooks/useSearchOptions.ts
+++ b/extension/src/prototypes/view/hooks/useSearchOptions.ts
@@ -51,9 +51,9 @@ function useDatasetSearchOptions({
     () => areas?.filter(area => area.type === "municipality").map(area => area.code) ?? [],
     [areas],
   );
-  const tokens = useMemo(() => inputValue?.split(/ |\u3000/), [inputValue]);
+  const tokens = useMemo(() => inputValue?.split(/\s+/).filter(Boolean), [inputValue]);
   const query = useDatasets(
-    tokens
+    tokens?.length
       ? {
           searchTokens: tokens,
         }

--- a/extension/src/prototypes/view/ui-containers/SearchAutocompletePanel.tsx
+++ b/extension/src/prototypes/view/ui-containers/SearchAutocompletePanel.tsx
@@ -1,6 +1,7 @@
 import {
   ClickAwayListener,
   Divider,
+  FilterOptionsState,
   styled,
   Tab,
   tabClasses,
@@ -60,6 +61,16 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
     minHeight: theme.spacing(5),
   },
 }));
+
+function filterOptions(
+  options: SearchOption[],
+  state: FilterOptionsState<SearchOption>,
+): SearchOption[] {
+  const tokens = state.inputValue.split(/\s+/).filter(value => value.length > 0);
+  return tokens.length > 0
+    ? options.filter(option => tokens.some(token => state.getOptionLabel(option).includes(token)))
+    : options;
+}
 
 export interface SearchAutocompletePanelProps {
   children?: ReactNode;
@@ -172,6 +183,7 @@ export const SearchAutocompletePanel: FC<SearchAutocompletePanelProps> = ({ chil
           inputRef={textFieldRef}
           placeholder="データセット、建築物、住所を検索"
           options={options}
+          filterOptions={filterOptions}
           filters={filters}
           maxHeight={maxMainHeight}
           onFocus={handleFocus}


### PR DESCRIPTION
I fixed two issue around search panel.
- Fix to be able to search in some keywords like `東京 建物`
<img width="500" alt="Screenshot 2023-12-20 at 16 43 46" src="https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/2d6b2b79-f869-41b4-8b4e-b395f2749ed4">

- Fix to show the dataset around camera position.(It means the dataset should be changed by camera position)
<img width="500" alt="Screenshot 2023-12-20 at 16 43 28" src="https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/e01eed63-0d75-4c4e-835b-8f210a0799a7">
