### PR TITLE
fix(extension): the issue which some dataset is not shown in some city

### DIFF
--- a/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
@@ -28,18 +28,15 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
     if (!datasets) {
       return;
     }
-    const isPrefecture = area.code.length === 2;
-    const isCity = area.code.length === 5 && area.code.endsWith("00");
-    const isWard = area.code.length === 5 && !area.code.endsWith("00");
     const groups = Object.entries(
       groupBy(
         datasets.filter(d =>
-          isPrefecture
-            ? !d.cityCode && area.code === d.prefectureCode
-            : isCity
-            ? !d.wardCode && d.cityCode === area.code
-            : isWard
-            ? d.wardCode && d.wardCode === area.code
+          !d.cityCode
+            ? area.code === d.prefectureCode
+            : !d.wardCode
+            ? d.cityCode === area.code
+            : d.wardCode
+            ? d.wardCode === area.code
             : false,
         ),
         d => d.type.code,


### PR DESCRIPTION
## Test
You can check if the breadcrumb shows the datasets in this city.
```
reearth.camera.flyTo({"lng":138.15293058963817,"lat":35.98832778314308,"height":3866.763694033752,"heading":0.9404687882328835,"pitch":-1.4582140824113208,"roll":0.00010674425193712977,"fov":1.0471975511965976,"aspectRatio":1.5610079575596818});
```

<img width="1497" alt="Screenshot 2023-12-20 at 17 08 21" src="https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/4d17a84c-8c06-480a-8ee7-0f7e33cb386c">
