### PR TITLE
feat(extension): flood color field

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodColorField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodColorField.tsx
@@ -1,0 +1,180 @@
+import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
+import { useCallback, ReactElement, useMemo, useState } from "react";
+
+import { BasicFieldProps } from "..";
+import { generateID } from "../../../../../../shared/utils/id";
+import {
+  PropertyBox,
+  PropertyCard,
+  PropertyInputField,
+  PropertyColorField,
+  PropertyButton,
+  PropertyWrapper,
+  PropertyLineWrapper,
+} from "../../../../ui-components";
+import { useNumberFieldState } from "../../hooksUtils";
+
+type TilesetFloodColorFieldPresetCondition = {
+  id: string;
+  rank?: number;
+  color?: string;
+  legendName?: string;
+};
+
+export type TilesetFloodColorFieldPreset = {
+  conditions?: TilesetFloodColorFieldPresetCondition[];
+};
+
+export const EditorTilesetFloodColorField = ({
+  component,
+  onUpdate,
+}: BasicFieldProps<"TILESET_FLOOD_COLOR_FIELD">): ReactElement | null => {
+  const [movingId, setMovingId] = useState<string>();
+
+  const conditions = useMemo(() => component.preset?.conditions ?? [], [component]);
+  const handleConditionCreate = useCallback(() => {
+    const newCondition = {
+      id: generateID(),
+    };
+    onUpdate?.({
+      ...component,
+      preset: {
+        ...component?.preset,
+        conditions: [...(conditions ?? []), newCondition],
+      },
+    });
+  }, [component, conditions, onUpdate]);
+
+  const handleConditionUpdate = useCallback(
+    (condition: TilesetFloodColorFieldPresetCondition) => {
+      onUpdate?.({
+        ...component,
+        preset: {
+          ...component?.preset,
+          conditions: conditions?.map(c => (c.id === condition.id ? condition : c)),
+        },
+      });
+    },
+    [component, conditions, onUpdate],
+  );
+
+  const handleConditionMove = useCallback(
+    (id: string, direction: "up" | "down") => {
+      if (!conditions) return;
+      const index = conditions?.findIndex(c => c.id === id);
+      if (index === -1) return;
+      setMovingId(id);
+      const newIndex = direction === "up" ? index - 1 : index + 1;
+      if (newIndex < 0 || newIndex >= conditions.length) return;
+      const newConditions = [...conditions];
+      newConditions.splice(index, 1);
+      newConditions.splice(newIndex, 0, conditions[index]);
+      onUpdate?.({
+        ...component,
+        preset: {
+          ...component?.preset,
+          conditions: newConditions,
+        },
+      });
+    },
+    [component, onUpdate, conditions],
+  );
+
+  const handleConditionRemove = useCallback(
+    (id: string) => {
+      if (!conditions) return;
+      onUpdate?.({
+        ...component,
+        preset: {
+          ...component?.preset,
+          conditions: conditions?.filter(c => c.id !== id),
+        },
+      });
+    },
+    [component, conditions, onUpdate],
+  );
+
+  return (
+    <PropertyWrapper>
+      <PropertyBox>
+        {component.preset?.conditions?.map((condition, index) => (
+          <PropertyCard
+            key={condition.id}
+            id={condition.id}
+            movingId={movingId}
+            moveUpDisabled={index === 0}
+            moveDownDisabled={index === conditions.length - 1}
+            onMove={handleConditionMove}
+            onRemove={handleConditionRemove}
+            mainPanel={
+              <ConditionMainPanel condition={condition} onConditionUpdate={handleConditionUpdate} />
+            }
+            legendPanel={
+              <ConditionLegendPanel
+                condition={condition}
+                onConditionUpdate={handleConditionUpdate}
+              />
+            }
+          />
+        ))}
+        <PropertyButton onClick={handleConditionCreate}>
+          <AddOutlinedIcon /> Rank
+        </PropertyButton>
+      </PropertyBox>
+    </PropertyWrapper>
+  );
+};
+
+type ConditionPanelProps = {
+  condition: TilesetFloodColorFieldPresetCondition;
+  onConditionUpdate: (condition: TilesetFloodColorFieldPresetCondition) => void;
+};
+
+const ConditionMainPanel: React.FC<ConditionPanelProps> = ({ condition, onConditionUpdate }) => {
+  const handleColorChange = useCallback(
+    (color: string) => {
+      onConditionUpdate({
+        ...condition,
+        color,
+      });
+    },
+    [condition, onConditionUpdate],
+  );
+
+  const [value, handleRankChange] = useNumberFieldState(condition.rank, rank => {
+    onConditionUpdate({
+      ...condition,
+      rank,
+    });
+  });
+
+  return (
+    <>
+      <PropertyLineWrapper>
+        Rank
+        <PropertyInputField value={value} onChange={handleRankChange} />
+      </PropertyLineWrapper>
+      <PropertyColorField value={condition.color} onChange={handleColorChange} />
+    </>
+  );
+};
+
+const ConditionLegendPanel: React.FC<ConditionPanelProps> = ({ condition, onConditionUpdate }) => {
+  const handleLegendNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onConditionUpdate({
+        ...condition,
+        legendName: e.target.value,
+      });
+    },
+    [condition, onConditionUpdate],
+  );
+
+  return (
+    <PropertyInputField
+      placeholder="Legend Name"
+      value={condition.legendName ?? ""}
+      onChange={handleLegendNameChange}
+    />
+  );
+};

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -4,6 +4,7 @@ import { ComponentBase } from "../../../../../shared/types/fieldComponents";
 import { EditorTilesetBuildingModelColorField } from "./3dtiles/EditorTilesetBuildingModelColorField";
 import { EditorTilesetBuildingModelFilterField } from "./3dtiles/EditorTilesetBuildingModelFilterField";
 import { EditorTilesetClippingField } from "./3dtiles/EditorTilesetClippingField";
+import { EditorTilesetFloodColorField } from "./3dtiles/EditorTilesetFloodColorField";
 import { EditorTilesetFloodModelColorField } from "./3dtiles/EditorTilesetFloodModelColorField";
 import { EditorTilesetFloodModelFilterField } from "./3dtiles/EditorTilesetFloodModelFilterField";
 import { EditorTilesetWireframeField } from "./3dtiles/EditorTilesetWireframeField";
@@ -330,6 +331,12 @@ export const fields: {
     group: FIELD_GROUP_THREE_D_TILES_FILL_COLOR,
     name: "Flood model",
     Component: EditorTilesetFloodModelColorField,
+  },
+  TILESET_FLOOD_COLOR_FIELD: {
+    category: FIELD_CATEGORY_THREE_D_TILES,
+    group: FIELD_GROUP_THREE_D_TILES_FILL_COLOR,
+    name: "Flood color",
+    Component: EditorTilesetFloodColorField,
   },
   TILESET_FILL_COLOR_CONDITION_FIELD: {
     category: FIELD_CATEGORY_THREE_D_TILES,

--- a/extension/src/prototypes/datasets/atomsWithQualitativeColorSet.ts
+++ b/extension/src/prototypes/datasets/atomsWithQualitativeColorSet.ts
@@ -13,6 +13,7 @@ export interface QualitativeColor {
 }
 
 export interface QualitativeColorSet {
+  id?: string;
   type: "qualitative";
   name: string;
   colorsAtom: PrimitiveAtom<QualitativeColor[]>;
@@ -20,22 +21,25 @@ export interface QualitativeColorSet {
 }
 
 export interface QualitativeColorSetOptions {
+  id?: string;
   name: string;
   colors: readonly QualitativeColor[];
 }
 
 export function atomsWithQualitativeColorSet({
+  id,
   name,
   colors,
 }: QualitativeColorSetOptions): QualitativeColorSet {
-  const id = `COLOR_SET_${name}`;
+  const shareId = `COLOR_SET_${id}`;
   const colorsAtom = sharedStoreAtomWrapper(
-    id,
-    storageStoreAtomWrapper(id, atom([...colors]), true),
+    shareId,
+    storageStoreAtomWrapper(shareId, atom([...colors]), true),
     { shouldInitialize: true },
   );
   const colorAtomsAtom = splitAtom(colorsAtom);
   return {
+    id,
     type: "qualitative",
     name,
     colorsAtom,

--- a/extension/src/prototypes/datasets/colorSets/floodRankColorSet.ts
+++ b/extension/src/prototypes/datasets/colorSets/floodRankColorSet.ts
@@ -2,14 +2,16 @@ import chroma from "chroma-js";
 
 import { atomsWithQualitativeColorSet } from "../atomsWithQualitativeColorSet";
 
+export const FLOOD_RANK_COLORS = [
+  { value: 6, color: chroma.rgb(220, 122, 220).hex(), name: "6: 20m〜" },
+  { value: 5, color: chroma.rgb(242, 133, 201).hex(), name: "5: 10m〜20m" },
+  { value: 4, color: chroma.rgb(255, 145, 145).hex(), name: "4: 5m〜10m" },
+  { value: 3, color: chroma.rgb(255, 183, 183).hex(), name: "3: 3m〜5m" },
+  { value: 2, color: chroma.rgb(255, 216, 192).hex(), name: "2: 0.5m〜3m" },
+  { value: 1, color: chroma.rgb(247, 245, 169).hex(), name: "1: 〜0.5m" },
+];
+
 export const floodRankColorSet = atomsWithQualitativeColorSet({
   name: "浸水ランク",
-  colors: [
-    { value: 6, color: chroma.rgb(220, 122, 220).hex(), name: "6: 20m〜" },
-    { value: 5, color: chroma.rgb(242, 133, 201).hex(), name: "5: 10m〜20m" },
-    { value: 4, color: chroma.rgb(255, 145, 145).hex(), name: "4: 5m〜10m" },
-    { value: 3, color: chroma.rgb(255, 183, 183).hex(), name: "3: 3m〜5m" },
-    { value: 2, color: chroma.rgb(255, 216, 192).hex(), name: "2: 0.5m〜3m" },
-    { value: 1, color: chroma.rgb(247, 245, 169).hex(), name: "1: 〜0.5m" },
-  ],
+  colors: FLOOD_RANK_COLORS,
 });

--- a/extension/src/shared/types/fieldComponents/3dtiles.ts
+++ b/extension/src/shared/types/fieldComponents/3dtiles.ts
@@ -1,3 +1,4 @@
+import { TilesetFloodColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodColorField";
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillGradientColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField";
 
@@ -12,6 +13,12 @@ export type TilesetBuildingModelColorField = FieldBase<{
 export const TILESET_FLOOD_MODEL_COLOR = "TILESET_FLOOD_MODEL_COLOR";
 export type TilesetFloodModelColorField = FieldBase<{
   type: typeof TILESET_FLOOD_MODEL_COLOR;
+}>;
+
+export const TILESET_FLOOD_COLOR_FIELD = "TILESET_FLOOD_COLOR_FIELD";
+export type TilesetFloodColorField = FieldBase<{
+  type: typeof TILESET_FLOOD_COLOR_FIELD;
+  preset?: TilesetFloodColorFieldPreset;
 }>;
 
 export const TILESET_FILL_COLOR_CONDITION_FIELD = "TILESET_FILL_COLOR_CONDITION_FIELD";
@@ -82,6 +89,7 @@ export type TilesetFields =
   | TilesetFloodModelColorField
   | TilesetFillColorConditionField
   | TilesetFillGradientColorField
+  | TilesetFloodColorField
   | TilesetClippingField
   | TilesetBuildingModelFilterField
   | TilesetFloodModelFilterField

--- a/extension/src/shared/types/fieldComponents/colorScheme.ts
+++ b/extension/src/shared/types/fieldComponents/colorScheme.ts
@@ -18,6 +18,15 @@ export type ConditionalColorSchemeValue = {
   useDefault: boolean; // Whether use first rule as default rule or not. Otherwise default will be "none".
 };
 
+export const FLOOD_COLOR_SCHEME = "FLOOD_COLOR_SCHEME";
+export type FloodColorSchemeValue = {
+  type: typeof FLOOD_COLOR_SCHEME;
+  overrideConditions: {
+    conditionId: string;
+    color: string;
+  }[];
+};
+
 export const GRADIENT_COLOR_SCHEME = "GRADIENT_COLOR_SCHEME";
 export type GradientColorSchemeValue = {
   type: typeof GRADIENT_COLOR_SCHEME;

--- a/extension/src/shared/view/fields/Fields.tsx
+++ b/extension/src/shared/view/fields/Fields.tsx
@@ -10,6 +10,7 @@ import {
   TILESET_CLIPPING,
   TILESET_FILL_COLOR_CONDITION_FIELD,
   TILESET_FILL_COLOR_GRADIENT_FIELD,
+  TILESET_FLOOD_COLOR_FIELD,
   TILESET_FLOOD_MODEL_COLOR,
   TILESET_FLOOD_MODEL_FILTER,
   TILESET_WIREFRAME,
@@ -200,7 +201,8 @@ export const Fields: FC<Props> = ({ layers, type, atoms }) => {
     }
     // Tileset
     case TILESET_BUILDING_MODEL_COLOR:
-    case TILESET_FLOOD_MODEL_COLOR: {
+    case TILESET_FLOOD_MODEL_COLOR:
+    case TILESET_FLOOD_COLOR_FIELD: {
       component = <BuildingLayerColorSection layers={layers as PrototypeLayerModel[]} />;
       break;
     }

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -185,6 +185,7 @@ export const fieldSettings: {
   // 3dtiles
   TILESET_BUILDING_MODEL_COLOR: {},
   TILESET_FLOOD_MODEL_COLOR: {},
+  TILESET_FLOOD_COLOR_FIELD: {},
   TILESET_FILL_COLOR_CONDITION_FIELD: {
     value: {
       type: CONDITIONAL_COLOR_SCHEME,

--- a/extension/src/shared/view/hooks/useIsMultipleSelectableField.ts
+++ b/extension/src/shared/view/hooks/useIsMultipleSelectableField.ts
@@ -3,6 +3,7 @@ import { BUILDING_LAYER, HEATMAP_LAYER } from "../../../prototypes/view-layers";
 import { ComponentBase } from "../../types/fieldComponents";
 import {
   TILESET_BUILDING_MODEL_COLOR,
+  TILESET_FLOOD_COLOR_FIELD,
   TILESET_FLOOD_MODEL_COLOR,
 } from "../../types/fieldComponents/3dtiles";
 import { OPACITY_FIELD } from "../../types/fieldComponents/general";
@@ -12,6 +13,7 @@ import { ComponentAtom } from "../../view-layers/component";
 export const MULTIPLE_SELECTABLE_FIELDS: ComponentBase["type"][] = [
   TILESET_BUILDING_MODEL_COLOR,
   TILESET_FLOOD_MODEL_COLOR,
+  TILESET_FLOOD_COLOR_FIELD,
   OPACITY_FIELD,
 ];
 export const MULTIPLE_SELECTABLE_TYPES: LayerType[] = [


### PR DESCRIPTION
I added FloodColor field to customize the rank, the legend and the color. We need to customize these thing(rank, legend and color), but we need to decide the attribute in runtime due to there is a case to need to check tileset.json. So we can't customize the expression by this field.

## Test
You can use `Test-kya/flood-color` template in the flood model like `洪水浸水想定区域モデル`.

![Screenshot 2024-02-08 at 19 09 14](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/b55782c4-3e6d-4db7-9bf8-10b15ac14c69)
