### PR TITLE
refactor(extension): support condition property name

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillAndStrokeColorConditionField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillAndStrokeColorConditionField.tsx
@@ -25,6 +25,7 @@ export type FillAndStrokeColorConditionFieldPresetRule = {
 
 type FillAndStrokeColorConditionFieldPresetRuleCondition = {
   id: string;
+  propertyName?: string;
   operation?: OperationValue;
   value?: string;
   color?: string;

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField.tsx
@@ -25,6 +25,7 @@ export type FillColorConditionFieldPresetRule = {
 
 type FillColorConditionFieldPresetRuleCondition = {
   id: string;
+  propertyName?: string;
   operation?: OperationValue;
   value?: string;
   color?: string;

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageConditionField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/point/EditorPointUseImageConditionField.tsx
@@ -26,6 +26,7 @@ type PointUseImageConditionFieldPresetRule = {
 
 type PointUseImageConditionFieldPresetRuleCondition = {
   id: string;
+  propertyName?: string;
   operation?: OperationValue;
   value?: string;
   imageURL?: string;

--- a/extension/src/editor/containers/ui-components/property/PropertyConditionField.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertyConditionField.tsx
@@ -5,6 +5,7 @@ import { OperationValue, PropertyOperationSelectField } from "./PropertyOperatio
 import { PropertyLineWrapper } from "./PropertyWrapper";
 
 export type CommonCondition = {
+  propertyName?: string;
   operation?: OperationValue;
   value?: string;
 };
@@ -38,9 +39,25 @@ export const PropertyConditionField: React.FC<PropertyConditionFieldProps> = ({
     [condition, onConditionChange],
   );
 
+  const handlePropertyNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onConditionChange({
+        ...condition,
+        propertyName: e.target.value,
+      });
+    },
+    [condition, onConditionChange],
+  );
+
   return (
     <PropertyLineWrapper>
       IF
+      <PropertyInputField
+        placeholder="Property name"
+        value={condition.propertyName ?? ""}
+        title="Left empty to use rule's property name"
+        onChange={handlePropertyNameChange}
+      />
       <PropertyOperationSelectField
         operation={condition.operation}
         onChange={handleOperationChange}

--- a/extension/src/editor/containers/ui-components/property/PropertyOperationSelectField.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertyOperationSelectField.tsx
@@ -37,7 +37,7 @@ export const PropertyOperationSelectField: React.FC<PropertyOperationSelectField
   return (
     <PropertySelectField
       placeholder="Operation"
-      sx={{ width: "100px" }}
+      sx={{ width: "45px", flexShrink: 0 }}
       options={operationOptions as unknown as { value: string; label: string }[]}
       value={operation ?? ""}
       onChange={handleOperationChange}

--- a/extension/src/editor/containers/ui-components/property/PropertyWrapper.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertyWrapper.tsx
@@ -9,7 +9,7 @@ export const PropertyWrapper = styled("div")(() => ({
 export const PropertyBox = styled("div")<{ asMenu?: boolean; halfWidth?: boolean }>(
   ({ theme, asMenu, halfWidth }) => ({
     position: "relative",
-    width: halfWidth ? "50%" : asMenu ? "130px" : "100%",
+    width: halfWidth ? "50%" : asMenu ? "120px" : "100%",
     display: "flex",
     padding: theme.spacing(0.5),
     flexDirection: "column",
@@ -48,7 +48,7 @@ const InlineWrapper = styled("div")(({ theme }) => ({
 }));
 
 const InlineLabel = styled("div")(({ theme }) => ({
-  width: "130px",
+  width: "120px",
   flex: "0 0 auto",
   padding: theme.spacing(0, 0.5),
 }));

--- a/extension/src/shared/layerContainers/utils/value.ts
+++ b/extension/src/shared/layerContainers/utils/value.ts
@@ -114,20 +114,21 @@ export const makeConditionalExpression = (
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);
               const colorValue = overriddenCondition?.color || cond.color;
-              if (!rule.propertyName || !cond.value || !colorValue) return;
+              const propertyName = cond.propertyName || rule.propertyName;
+              if (!propertyName || !cond.value || !colorValue) return;
               const stringCondition = conditionWithOperation(
-                variable(rule.propertyName),
+                variable(propertyName),
                 string(cond.value),
                 cond.operation,
               );
               const numberCondition = !isNaN(Number(cond.value))
                 ? conditionWithOperation(
-                    defaultConditionalNumber(rule.propertyName),
+                    defaultConditionalNumber(propertyName),
                     number(Number(cond.value)),
                     cond.operation,
                   )
                 : undefined;
-              return rule.propertyName && cond.value && colorValue
+              return propertyName && cond.value && colorValue
                 ? ([
                     numberCondition ? numberCondition : stringCondition,
                     color(colorValue, opacity),
@@ -162,20 +163,21 @@ export const makeStrokeColorConditionalExpression = (
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);
               const colorValue = overriddenCondition?.strokeColor || cond.strokeColor;
-              if (!rule.propertyName || !cond.value || !colorValue) return;
+              const propertyName = cond.propertyName || rule.propertyName;
+              if (!propertyName || !cond.value || !colorValue) return;
               const stringCondition = conditionWithOperation(
-                variable(rule.propertyName),
+                variable(propertyName),
                 string(cond.value),
                 cond.operation,
               );
               const numberCondition = !isNaN(Number(cond.value))
                 ? conditionWithOperation(
-                    defaultConditionalNumber(rule.propertyName),
+                    defaultConditionalNumber(propertyName),
                     number(Number(cond.value)),
                     cond.operation,
                   )
                 : undefined;
-              return rule.propertyName && cond.value && colorValue
+              return propertyName && cond.value && colorValue
                 ? ([
                     numberCondition ? numberCondition : stringCondition,
                     color(colorValue, opacity),
@@ -347,20 +349,21 @@ export const makeConditionalImageExpression = (
             return rule.conditions?.map(cond => {
               const overriddenCondition = overriddenRules?.find(r => r.conditionId === cond.id);
               const imageURLValue = overriddenCondition?.imageURL || cond.imageURL;
-              if (!rule.propertyName || !cond.value || !imageURLValue) return;
+              const propertyName = cond.propertyName || rule.propertyName;
+              if (!propertyName || !cond.value || !imageURLValue) return;
               const stringCondition = conditionWithOperation(
-                variable(rule.propertyName),
+                variable(propertyName),
                 string(cond.value),
                 cond.operation,
               );
               const numberCondition = !isNaN(Number(cond.value))
                 ? conditionWithOperation(
-                    defaultConditionalNumber(rule.propertyName),
+                    defaultConditionalNumber(propertyName),
                     number(Number(cond.value)),
                     cond.operation,
                   )
                 : undefined;
-              return rule.propertyName && cond.value && imageURLValue
+              return propertyName && cond.value && imageURLValue
                 ? ([
                     numberCondition ? `${numberCondition} || ${stringCondition}` : stringCondition,
                     `"${imageURLValue}"`,
@@ -393,20 +396,21 @@ export const makeConditionalImageColorExpression = (
                 overriddenCondition?.imageColor || cond.imageColor,
                 opacity,
               );
-              if (!rule.propertyName || !cond.value || !imageColorValue) return;
+              const propertyName = cond.propertyName || rule.propertyName;
+              if (!propertyName || !cond.value || !imageColorValue) return;
               const stringCondition = conditionWithOperation(
-                variable(rule.propertyName),
+                variable(propertyName),
                 string(cond.value),
                 cond.operation,
               );
               const numberCondition = !isNaN(Number(cond.value))
                 ? conditionWithOperation(
-                    defaultConditionalNumber(rule.propertyName),
+                    defaultConditionalNumber(propertyName),
                     number(Number(cond.value)),
                     cond.operation,
                   )
                 : undefined;
-              return rule.propertyName && cond.value && imageColorValue
+              return propertyName && cond.value && imageColorValue
                 ? ([
                     numberCondition ? `${numberCondition} || ${stringCondition}` : stringCondition,
                     `color("${imageColorValue}")`,

--- a/extension/src/shared/view/selection/ColorSchemeSectionForComponentField.tsx
+++ b/extension/src/shared/view/selection/ColorSchemeSectionForComponentField.tsx
@@ -93,7 +93,7 @@ export const ColorSchemeSectionForComponentField: FC<ColorSchemeSectionForCompon
                 ) {
                   useNone = !componentValue.value?.useDefault;
                   return componentValue.preset?.rules?.map(rule =>
-                    rule.propertyName ? rule : undefined,
+                    rule.propertyName || rule.legendName ? rule : undefined,
                   );
                 }
               })

--- a/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
+++ b/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
@@ -73,7 +73,7 @@ export const ImageSchemeSectionForComponentField: FC<ImageSchemeSectionForCompon
                 const componentValue = get(c.atom);
                 if (isConditionalImageSchemeComponent(componentValue)) {
                   return componentValue.preset?.rules?.map(rule =>
-                    rule.propertyName ? rule : undefined,
+                    rule.propertyName || rule.legendName ? rule : undefined,
                   );
                 }
               })


### PR DESCRIPTION
## Overview

There's a requirement to set the propertyName for each condition.

Before: we are assuming all conditions in one rule will base on one single property (set in rule's `propertyName`).
After: conditions could set its own `propertyName`. If not set it will still use rule's `propertyName`.

# Screenshots

![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (13)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/d6aa3b1c-a50a-47c4-9fe7-8c6d9ae15ae4)
![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (14)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/8c602659-5e90-4692-8f8f-b1c405c775a7)
![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (15)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/ee517250-926d-4018-9d68-70ec38109321)
