### PR TITLE
fix(extention): dataset info title and style

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
@@ -7,6 +7,7 @@ import {
   listItemSecondaryActionClasses,
   styled,
   type DialogProps,
+  listItemTextClasses,
 } from "@mui/material";
 import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, type FC } from "react";
@@ -29,9 +30,16 @@ import { datasetTypeLayers } from "../constants/datasetTypeLayers";
 import { PlateauDatasetType } from "../constants/plateau";
 
 const StyledEntityTitle = styled(EntityTitle)(({ theme }) => ({
-  minHeight: theme.spacing(6),
+  minHeight: theme.spacing(7),
   [`& .${listItemSecondaryActionClasses.root}`]: {
     right: 4,
+  },
+  [`& .${listItemTextClasses.primary}`]: {
+    fontSize: theme.typography.h6.fontSize,
+    fontWeight: "bold",
+  },
+  [`& .${listItemTextClasses.secondary}`]: {
+    fontSize: theme.typography.h6.fontSize,
   },
 }));
 
@@ -104,15 +112,15 @@ export const DatasetDialog: FC<DatasetDialogProps> = ({ dataset, municipalityCod
   ]);
 
   return (
-    <Dialog {...props}>
+    <Dialog maxWidth="mobile" {...props}>
       <StyledEntityTitle
         iconComponent={datasetTypeIcons[dataset.type.code as PlateauDatasetType] ?? UseCaseIcon}
         title={{
           primary: [
-            dataset.type.name,
+            dataset.name,
             dataset.__typename === "PlateauDataset" ? dataset.subname ?? "" : "",
           ].join(" "),
-          secondary: dataset?.city?.name,
+          secondary: dataset?.prefecture?.name,
         }}
         secondaryAction={
           <StyledButton


### PR DESCRIPTION
## Overview

In this PR:
- Update the title of dataset info panel.
  - Primary title: `dataset.type.name` -> `dataset.name`
  - Secondary title: `dataset.city.name` -> `dataset.prefecture.name`
- Update the title style, enlarge font size and bold the primary title.
- Set max width of the panel to device max width.


## Screenshot

| Before | After |
| -- | -- |
| ![reearth plateau dev reearth io_dashboard_01habs59h8wcdbj60mqe0syrek(Desktop 1920)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/a0b393a8-143c-4ee2-9e39-b06e3b41fde0) | ![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (16)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/b28609b2-318d-4845-9efd-2aec14e0e148) |