### PR TITLE
fix(extension): click away listener

### DIFF
--- a/extension/src/inspector/Widget.tsx
+++ b/extension/src/inspector/Widget.tsx
@@ -6,10 +6,10 @@ import { PLATEAUVIEW_INSPECTOR_DOM_ID } from "../shared/ui-components/common/Vie
 
 export const Widget = memo(function WidgetPresenter() {
   return (
-    <WidgetContext>
-      <div id={PLATEAUVIEW_INSPECTOR_DOM_ID}>
+    <div id={PLATEAUVIEW_INSPECTOR_DOM_ID}>
+      <WidgetContext>
         <AppOverlay type="aside" width={320} height={0} />
-      </div>
-    </WidgetContext>
+      </WidgetContext>
+    </div>
   );
 });

--- a/extension/src/inspector/Widget.tsx
+++ b/extension/src/inspector/Widget.tsx
@@ -2,11 +2,14 @@ import { memo } from "react";
 
 import { AppOverlay } from "../prototypes/view/ui-containers/AppOverlay";
 import { WidgetContext } from "../shared/context/WidgetContext";
+import { PLATEAUVIEW_INSPECTOR_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 
 export const Widget = memo(function WidgetPresenter() {
   return (
     <WidgetContext>
-      <AppOverlay type="aside" width={320} height={0} />
+      <div id={PLATEAUVIEW_INSPECTOR_DOM_ID}>
+        <AppOverlay type="aside" width={320} height={0} />
+      </div>
     </WidgetContext>
   );
 });

--- a/extension/src/prototypes/view/ui-containers/SearchAutocompletePanel.tsx
+++ b/extension/src/prototypes/view/ui-containers/SearchAutocompletePanel.tsx
@@ -1,5 +1,4 @@
 import {
-  ClickAwayListener,
   Divider,
   FilterOptionsState,
   styled,
@@ -23,6 +22,7 @@ import {
 } from "react";
 
 import { getCesiumCanvas } from "../../../shared/reearth/utils";
+import { ViewClickAwayListener } from "../../../shared/ui-components/common/ViewClickAwayListener";
 import { useWindowEvent } from "../../react-helpers";
 import { platformAtom } from "../../shared-states";
 import {
@@ -177,7 +177,7 @@ export const SearchAutocompletePanel: FC<SearchAutocompletePanelProps> = ({ chil
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
   return (
-    <ClickAwayListener onClickAway={handleClickAway}>
+    <ViewClickAwayListener onClickAway={handleClickAway}>
       <FloatingPanel>
         <SearchAutocomplete
           inputRef={textFieldRef}
@@ -220,6 +220,6 @@ export const SearchAutocompletePanel: FC<SearchAutocompletePanelProps> = ({ chil
           )}
         </SearchAutocomplete>
       </FloatingPanel>
-    </ClickAwayListener>
+    </ViewClickAwayListener>
   );
 };

--- a/extension/src/search/Widget.tsx
+++ b/extension/src/search/Widget.tsx
@@ -10,12 +10,8 @@ export const Widget = memo(function WidgetPresenter() {
   const ready = useAtomValue(readyAtom);
 
   return (
-    <WidgetContext>
-      {ready && (
-        <div id={PLATEAUVIEW_SEARCH_DOM_ID}>
-          <AppOverlay type="main" width={360} height={81} />
-        </div>
-      )}
-    </WidgetContext>
+    <div id={PLATEAUVIEW_SEARCH_DOM_ID}>
+      <WidgetContext>{ready && <AppOverlay type="main" width={360} height={81} />}</WidgetContext>
+    </div>
   );
 });

--- a/extension/src/search/Widget.tsx
+++ b/extension/src/search/Widget.tsx
@@ -4,11 +4,18 @@ import { memo } from "react";
 import { readyAtom } from "../prototypes/view/states/app";
 import { AppOverlay } from "../prototypes/view/ui-containers/AppOverlay";
 import { WidgetContext } from "../shared/context/WidgetContext";
+import { PLATEAUVIEW_SEARCH_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 
 export const Widget = memo(function WidgetPresenter() {
   const ready = useAtomValue(readyAtom);
 
   return (
-    <WidgetContext>{ready && <AppOverlay type="main" width={360} height={81} />}</WidgetContext>
+    <WidgetContext>
+      {ready && (
+        <div id={PLATEAUVIEW_SEARCH_DOM_ID}>
+          <AppOverlay type="main" width={360} height={81} />
+        </div>
+      )}
+    </WidgetContext>
   );
 });

--- a/extension/src/shared/ui-components/common/ViewClickAwayListener.tsx
+++ b/extension/src/shared/ui-components/common/ViewClickAwayListener.tsx
@@ -1,0 +1,50 @@
+import { useRef, useEffect, useCallback } from "react";
+
+type ViewClickAwayListenerProps = {
+  children?: React.ReactNode;
+  onClickAway?: () => void;
+};
+export const PLATEAUVIEW_TOOLBAR_DOM_ID = "__plateauview_toolbar__";
+export const PLATEAUVIEW_SEARCH_DOM_ID = "__plateauview_search__";
+export const PLATEAUVIEW_INSPECTOR_DOM_ID = "__plateauview_inspector__";
+
+export const ViewClickAwayListener: React.FC<ViewClickAwayListenerProps> = ({
+  children,
+  onClickAway,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickAway = useCallback(
+    (e: MouseEvent) => {
+      if (ref.current?.contains(e.target as Node)) {
+        return;
+      }
+      onClickAway?.();
+    },
+    [onClickAway],
+  );
+
+  useEffect(() => {
+    return window.addEventListener("click", handleClickAway);
+  }, [handleClickAway]);
+
+  useEffect(() => {
+    return document
+      .getElementById(PLATEAUVIEW_TOOLBAR_DOM_ID)
+      ?.addEventListener("click", handleClickAway);
+  }, [handleClickAway]);
+
+  useEffect(() => {
+    return document
+      .getElementById(PLATEAUVIEW_SEARCH_DOM_ID)
+      ?.addEventListener("click", handleClickAway);
+  }, [handleClickAway]);
+
+  useEffect(() => {
+    return document
+      .getElementById(PLATEAUVIEW_INSPECTOR_DOM_ID)
+      ?.addEventListener("click", handleClickAway);
+  }, [handleClickAway]);
+
+  return <div ref={ref}>{children}</div>;
+};

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -18,6 +18,7 @@ import { AppHeader } from "../prototypes/view/ui-containers/AppHeader";
 import { Notifications } from "../prototypes/view/ui-containers/Notifications";
 import { WidgetContext } from "../shared/context/WidgetContext";
 import { WidgetProps } from "../shared/types/widget";
+import { PLATEAUVIEW_TOOLBAR_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 import { InitialLayers } from "../shared/view/containers/InitialLayers";
 import FeedBack from "../shared/view/ui-container/Feedback";
 import MyData from "../shared/view/ui-container/MyData";
@@ -55,43 +56,45 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
   useSelectSketchFeature();
 
   return (
-    <WidgetContext
-      geoUrl={widget.property.default.geoURL}
-      gsiTileURL={widget.property.default.gsiTileURL}
-      plateauUrl={widget.property.default.plateauURL}
-      catalogUrl={widget.property.default.catalogURL}
-      catalogURLForAdmin={widget.property.default.catalogURLForAdmin}
-      projectId={widget.property.default.projectName}
-      plateauToken={widget.property.default.plateauAccessToken}
-      googleStreetViewAPIKey={widget.property.default.googleStreetViewAPIKey}
-      inEditor={inEditor}
-      customPrimaryColor={widget.property.appearance?.primaryColor}
-      customLogo={widget.property.appearance?.logo}>
-      <InitializeApp />
-      <AppFrame header={<AppHeader />} />
-      {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}
-      <Loading />
-      {/* <Suspense>
+    <div id={PLATEAUVIEW_TOOLBAR_DOM_ID}>
+      <WidgetContext
+        geoUrl={widget.property.default.geoURL}
+        gsiTileURL={widget.property.default.gsiTileURL}
+        plateauUrl={widget.property.default.plateauURL}
+        catalogUrl={widget.property.default.catalogURL}
+        catalogURLForAdmin={widget.property.default.catalogURLForAdmin}
+        projectId={widget.property.default.projectName}
+        plateauToken={widget.property.default.plateauAccessToken}
+        googleStreetViewAPIKey={widget.property.default.googleStreetViewAPIKey}
+        inEditor={inEditor}
+        customPrimaryColor={widget.property.appearance?.primaryColor}
+        customLogo={widget.property.appearance?.logo}>
+        <InitializeApp />
+        <AppFrame header={<AppHeader />} />
+        {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}
+        <Loading />
+        {/* <Suspense>
         <SuspendUntilTilesLoaded
           initialTileCount={35}
           remainingTileCount={30}
           onComplete={handleTilesLoadComplete}> */}
-      <LayersRenderer components={layerComponents} />
-      {/* </SuspendUntilTilesLoaded>
+        <LayersRenderer components={layerComponents} />
+        {/* </SuspendUntilTilesLoaded>
       </Suspense> */}
-      <Environments />
-      <ToolMachineEvents />
-      <Notifications />
-      <InitialLayers />
-      <SelectionCoordinator />
-      <ScreenSpaceSelection />
-      <HighlightedAreas />
-      <ReverseGeocoding />
-      <PedestrianTool />
-      <SketchTool />
-      <MyData />
-      <AutoRotateCamera />
-      <FeedBack />
-    </WidgetContext>
+        <Environments />
+        <ToolMachineEvents />
+        <Notifications />
+        <InitialLayers />
+        <SelectionCoordinator />
+        <ScreenSpaceSelection />
+        <HighlightedAreas />
+        <ReverseGeocoding />
+        <PedestrianTool />
+        <SketchTool />
+        <MyData />
+        <AutoRotateCamera />
+        <FeedBack />
+      </WidgetContext>
+    </div>
   );
 });


### PR DESCRIPTION
## Overview

Click event on each reearth widget seem been stopped from propagation to body (not sure where did that though). Therefore the ClickAwayListener of mui can't work well.
This PR adds a common ViewClickAwayListener component and hardcoded the DOM id for the main widgets. With this one click away can work well.