### PR TITLE
fix(extension): style code color for general layer

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/ComponentItem.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/ComponentItem.tsx
@@ -6,7 +6,7 @@ import {
   EditorPopper,
   EditorPopperList,
   EditorPopperListItemButton,
-  FieldComponentNotFound,
+  PropertyInfo,
 } from "../../ui-components";
 import { EditorClickAwayListener } from "../EditorClickAwayListener";
 
@@ -90,7 +90,7 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
         onMoreClick={handleMoreClick}
         highlight={moving}>
         {componentNotFound ? (
-          <FieldComponentNotFound />
+          <PropertyInfo preset="field-not-found" />
         ) : (
           <FieldComponent component={component} onUpdate={onComponentUpdate} />
         )}

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelColorField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelColorField.tsx
@@ -1,8 +1,8 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetBuildingModelColorField: React.FC<
   BasicFieldProps<"TILESET_BUILDING_MODEL_COLOR">
 > = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelFilterField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelFilterField.tsx
@@ -1,8 +1,8 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetBuildingModelFilterField: React.FC<
   BasicFieldProps<"TILESET_BUILDING_MODEL_FILTER">
 > = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetClippingField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetClippingField.tsx
@@ -1,6 +1,6 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetClippingField: React.FC<BasicFieldProps<"TILESET_CLIPPING">> = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodModelColorField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodModelColorField.tsx
@@ -1,8 +1,8 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetFloodModelColorField: React.FC<
   BasicFieldProps<"TILESET_FLOOD_MODEL_COLOR">
 > = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodModelFilterField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodModelFilterField.tsx
@@ -1,8 +1,8 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetFloodModelFilterField: React.FC<
   BasicFieldProps<"TILESET_FLOOD_MODEL_FILTER">
 > = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetWireframeField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetWireframeField.tsx
@@ -1,6 +1,6 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorTilesetWireframeField: React.FC<BasicFieldProps<"TILESET_WIREFRAME">> = () => {
-  return <PropertyNoSettings />;
+  return <PropertyInfo preset="no-settings" />;
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorOpacityField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorOpacityField.tsx
@@ -1,6 +1,10 @@
 import { BasicFieldProps } from "..";
-import { PropertyNoSettings } from "../../../../ui-components";
+import { PropertyInfo } from "../../../../ui-components";
 
 export const EditorOpacityField: React.FC<BasicFieldProps<"OPACITY_FIELD">> = () => {
-  return <PropertyNoSettings />;
+  return (
+    <PropertyInfo>
+      Attention: This component will override the color settings from Style Code component.
+    </PropertyInfo>
+  );
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineMonthField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineMonthField.tsx
@@ -1,11 +1,11 @@
 import { BasicFieldProps } from "..";
-import { PropertyBox, PropertyNoSettings, PropertyWrapper } from "../../../../ui-components";
+import { PropertyBox, PropertyInfo, PropertyWrapper } from "../../../../ui-components";
 
 export const EditorTimelineMonthField: React.FC<BasicFieldProps<"TIMELINE_MONTH_FIELD">> = () => {
   return (
     <PropertyWrapper>
       <PropertyBox>
-        <PropertyNoSettings />
+        <PropertyInfo preset="no-settings" />;
       </PropertyBox>
     </PropertyWrapper>
   );

--- a/extension/src/editor/containers/ui-components/property/PropertyInfo.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertyInfo.tsx
@@ -1,24 +1,27 @@
+import { ReactNode } from "react";
+
 import { PropertyPlaceHolder } from "./PropertyPlaceHolder";
 import { PropertyBox, PropertyWrapper } from "./PropertyWrapper";
 
 export const NO_SETTINGS_FOR_THIS_COMPONNET = "No custom settings for this component";
 export const FIELD_COMPONENT_NOT_FOUND = "Field component not found";
 
-export const PropertyNoSettings: React.FC = () => {
-  return (
-    <PropertyWrapper>
-      <PropertyBox>
-        <PropertyPlaceHolder>{NO_SETTINGS_FOR_THIS_COMPONNET}</PropertyPlaceHolder>
-      </PropertyBox>
-    </PropertyWrapper>
-  );
+type PropertyInfoProps = {
+  preset?: "no-settings" | "field-not-found";
+  children?: ReactNode;
 };
 
-export const FieldComponentNotFound: React.FC = () => {
+export const PropertyInfo: React.FC<PropertyInfoProps> = ({ preset, children }) => {
   return (
     <PropertyWrapper>
       <PropertyBox>
-        <PropertyPlaceHolder>{FIELD_COMPONENT_NOT_FOUND}</PropertyPlaceHolder>
+        {preset === "no-settings" && (
+          <PropertyPlaceHolder>{NO_SETTINGS_FOR_THIS_COMPONNET}</PropertyPlaceHolder>
+        )}
+        {preset === "field-not-found" && (
+          <PropertyPlaceHolder>{FIELD_COMPONENT_NOT_FOUND}</PropertyPlaceHolder>
+        )}
+        {children && <PropertyPlaceHolder>{children}</PropertyPlaceHolder>}
       </PropertyBox>
     </PropertyWrapper>
   );

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -193,13 +193,16 @@ export const useEvaluateGeneralAppearance = ({
             makeGradientExpression(pointFillGradientColor, opacity?.value) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           pointSize: pointSize?.preset?.defaultValue,
-          pointOutlineColor: makeSimpleColorWithOpacity(opacity, pointStroke?.preset?.color),
+          pointOutlineColor:
+            makeSimpleColorWithOpacity(opacity, pointStroke?.preset?.color) ??
+            pointStroke?.preset?.color,
           pointOutlineWidth: pointStroke?.preset?.width,
           image:
             pointImageValue?.preset?.imageURL ??
             makeConditionalImageExpression(pointImageCondition),
           imageColor:
             makeSimpleColorWithOpacity(opacity, pointImageValue?.preset?.imageColor) ??
+            pointImageValue?.preset?.imageColor ??
             makeConditionalImageColorExpression(pointImageCondition, opacity?.value),
           imageSize: pointImageSize?.preset?.defaultValue,
           imageSizeInMeters: pointImageSize?.preset?.enableSizeInMeters,
@@ -210,13 +213,14 @@ export const useEvaluateGeneralAppearance = ({
           labelText: makeLabelTextExpression(pointLabel),
           labelTypography: {
             fontSize: pointLabel?.preset?.fontSize,
-            color: makeSimpleColorWithOpacity(opacity, pointLabel?.preset?.fontColor),
+            color:
+              makeSimpleColorWithOpacity(opacity, pointLabel?.preset?.fontColor) ??
+              pointLabel?.preset?.fontColor,
           },
           labelBackground: pointLabel?.preset?.background,
-          labelBackgroundColor: makeSimpleColorWithOpacity(
-            opacity,
+          labelBackgroundColor:
+            makeSimpleColorWithOpacity(opacity, pointLabel?.preset?.backgroundColor) ??
             pointLabel?.preset?.backgroundColor,
-          ),
           height: pointLabel?.preset?.height,
           extrude: pointLabel?.preset?.extruded,
           heightReference: pointHeightReference?.preset?.defaultValue,

--- a/extension/src/shared/layerContainers/utils/value.ts
+++ b/extension/src/shared/layerContainers/utils/value.ts
@@ -246,7 +246,7 @@ export const makeSimpleColorWithOpacity = (
   comp: Component<typeof OPACITY_FIELD> | undefined,
   originColor: string | undefined,
 ) => {
-  if (!comp || !originColor) return originColor;
+  if (!comp || !originColor) return;
   return {
     expression: {
       conditions: [["true", color(originColor, comp.value ?? 1)]],


### PR DESCRIPTION
## Overview

`makeSimpleColorWithOpacity` should not generate a default color when transparency component not exists.

NOTE:
Currently opacity value can't be mixed into style code. Therefore the color realted value in style code will be override when a transparency field component been added.