### PR TITLE
feat(extension): Add more support for municipalities

### DIFF
--- a/extension/src/editor/containers/dataset/StatusPage.tsx
+++ b/extension/src/editor/containers/dataset/StatusPage.tsx
@@ -1,11 +1,13 @@
 import { StatusBlock } from "./blocks/StatusBlock";
 
-import { EditorDataset } from ".";
+import { DraftSetting, EditorDataset, UpdateSetting } from ".";
 
 type StatusPageProps = {
   dataset?: EditorDataset;
+  setting: DraftSetting;
+  updateSetting?: UpdateSetting;
 };
 
-export const StatusPage: React.FC<StatusPageProps> = ({ dataset }) => {
-  return <StatusBlock dataset={dataset} />;
+export const StatusPage: React.FC<StatusPageProps> = ({ dataset, setting, updateSetting }) => {
+  return <StatusBlock dataset={dataset} setting={setting} updateSetting={updateSetting} />;
 };

--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -1,7 +1,8 @@
-import { styled } from "@mui/material";
+import { Switch, styled } from "@mui/material";
 import { green, red } from "@mui/material/colors";
+import { useCallback, useMemo } from "react";
 
-import { EditorDataset } from "..";
+import { DraftSetting, EditorDataset, UpdateSetting } from "..";
 import {
   BlockContentWrapper,
   EditorBlock,
@@ -12,9 +13,29 @@ import {
 
 type StatusBlockProps = EditorBlockProps & {
   dataset?: EditorDataset;
+  setting: DraftSetting;
+  updateSetting?: UpdateSetting;
 };
 
-export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) => {
+export const StatusBlock: React.FC<StatusBlockProps> = ({
+  dataset,
+  setting,
+  updateSetting,
+  ...props
+}) => {
+  const isDefaultTile = useMemo(
+    () => setting?.status?.isDefaultTile,
+    [setting?.status?.isDefaultTile],
+  );
+
+  const handleSettingsUpdate = useCallback(
+    () =>
+      updateSetting?.(s =>
+        !s ? s : { ...s, status: { ...s.status, isDefaultTile: !isDefaultTile } },
+      ),
+    [isDefaultTile, updateSetting],
+  );
+
   return (
     <EditorBlock title="Status" expandable {...props}>
       <BlockContentWrapper>
@@ -26,6 +47,9 @@ export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) =
         <EditorTextField label="Created At" value={""} disabled />
         <EditorTextField label="Updated At" value={""} disabled />
         <EditorTextField label="CMS URL" value={""} multiline disabled rows={4} />
+        <EditorCommonField label="デフォルトタイル" inline>
+          <Switch checked={isDefaultTile} onChange={handleSettingsUpdate} />
+        </EditorCommonField>
       </BlockContentWrapper>
     </EditorBlock>
   );

--- a/extension/src/shared/api/constants.ts
+++ b/extension/src/shared/api/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_SETTING_DATA_ID = "default";
+export const STATUS_SETTING_DATA_ID = "status";

--- a/extension/src/shared/api/types/setting.ts
+++ b/extension/src/shared/api/types/setting.ts
@@ -28,6 +28,9 @@ export type Setting = {
     groups?: ComponentGroup[];
   };
   featureInspector?: FeatureInspectorSettings;
+  status: {
+    isDefaultTile?: boolean;
+  };
 };
 
 export type FeatureInspectorSettings = {

--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -98,13 +98,7 @@ export const Scene: FC<SceneProps> = ({
   ambientOcclusion,
   shadows,
   antialias,
-  initialCamera = {
-    lng: 139.755,
-    lat: 35.675,
-    height: 1000,
-    heading: Math.PI * 0.4,
-    pitch: -Math.PI * 0.2,
-  },
+  initialCamera,
 }) => {
   useEffect(() => {
     window.reearth?.scene?.overrideProperty({


### PR DESCRIPTION
- Remove hardcoded Tokyo-based default 3d tiles
- Add toggle to manually add a dataset to tiles shown on first load (save to CMS)
- Show defaults on first load