### PR TITLE
refactor(extension): update UI of layer title & dataset dialog title

### DIFF
--- a/extension/src/prototypes/ui-components/EntityTitle.tsx
+++ b/extension/src/prototypes/ui-components/EntityTitle.tsx
@@ -18,6 +18,7 @@ const StyledListItem = styled(ListItem)(({ theme }) => ({
     position: "relative",
     transform: "none",
     flexGrow: 0,
+    marginLeft: theme.spacing(1),
   },
 })) as unknown as typeof ListItem; // For generics
 

--- a/extension/src/prototypes/ui-components/EntityTitle.tsx
+++ b/extension/src/prototypes/ui-components/EntityTitle.tsx
@@ -28,7 +28,7 @@ export const EntityTitleIcon = styled("div")(({ theme }) => ({
   },
 }));
 
-export const EntityTitleText = styled(ListItemText)({
+export const EntityTitleText = styled(ListItemText)<{ allowWrap?: boolean }>(({ allowWrap }) => ({
   flexGrow: 1,
   marginTop: 4,
   marginBottom: 4,
@@ -44,7 +44,12 @@ export const EntityTitleText = styled(ListItemText)({
   [`& .${listItemTextClasses.primary} + .${listItemTextClasses.secondary}`]: {
     marginLeft: "1em",
   },
-});
+  ...(allowWrap && {
+    whiteSpace: "normal",
+    overflow: "visible",
+    textOverflow: "unset",
+  }),
+}));
 
 export interface EntityTitleProps extends Omit<ListItemProps<"div">, "title"> {
   title?:
@@ -55,10 +60,11 @@ export interface EntityTitleProps extends Omit<ListItemProps<"div">, "title"> {
       };
   iconComponent?: ComponentType<SvgIconProps>;
   icon?: ReactNode;
+  allowWrap?: boolean;
 }
 
 export const EntityTitle = forwardRef<HTMLDivElement, EntityTitleProps>(
-  ({ title, iconComponent, icon, children, ...props }, ref) => {
+  ({ title, iconComponent, icon, children, allowWrap, ...props }, ref) => {
     const Icon = iconComponent;
     return (
       <StyledListItem ref={ref} {...props} component="div">
@@ -84,6 +90,7 @@ export const EntityTitle = forwardRef<HTMLDivElement, EntityTitleProps>(
           secondaryTypographyProps={{
             variant: "body2",
           }}
+          allowWrap={allowWrap}
         />
         {children}
       </StyledListItem>

--- a/extension/src/prototypes/ui-components/EntityTitleButton.tsx
+++ b/extension/src/prototypes/ui-components/EntityTitleButton.tsx
@@ -141,6 +141,7 @@ export const EntityTitleButton = forwardRef<HTMLDivElement, EntityTitleButtonPro
           secondaryTypographyProps={{
             variant: "body2",
           }}
+          title={typeof title === "object" ? title?.primary : title}
         />
         {children}
       </StyledListItemButton>

--- a/extension/src/prototypes/view/ui-containers/CensusDatasetListItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/CensusDatasetListItem.tsx
@@ -45,6 +45,7 @@ export const CensusDatasetListItem: FC<CensusDatasetListItemProps> = ({
     <DatasetTreeItem
       nodeId={`${dataset.name}:${data.name}`}
       label={data.name}
+      title={data.name}
       icon={<DatasetIcon />}
       onClick={handleClick}
       {...props}

--- a/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
@@ -29,6 +29,7 @@ const DatasetGroup: FC<{
             municipalityCode={dataset.wardCode ?? dataset.cityCode ?? dataset.prefectureCode}
             dataset={dataset}
             label={dataset.name}
+            title={dataset.name}
           />
         ))}
       </DatasetTreeItem>
@@ -39,6 +40,7 @@ const DatasetGroup: FC<{
       dataset={datasets[0]}
       municipalityCode={datasets[0].wardCode ?? datasets[0].cityCode ?? datasets[0].prefectureCode}
       label={datasets[0].type.name}
+      title={datasets[0].type.name}
     />
   );
 };
@@ -55,6 +57,7 @@ const GlobalItem: FC<{}> = () => {
           dataset={dataset}
           municipalityCode={dataset.wardCode ?? dataset.cityCode ?? dataset.prefectureCode}
           label={dataset.name}
+          title={dataset.name}
         />
       ))}
     </DatasetTreeItem>

--- a/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
@@ -138,6 +138,7 @@ export const DatasetDialog: FC<DatasetDialogProps> = ({ dataset, municipalityCod
             {layer == null ? "追加" : "追加済み"}
           </StyledButton>
         }
+        allowWrap
       />
       <Divider />
       <DialogContent>

--- a/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
@@ -107,7 +107,7 @@ const DatasetTypeItem: FC<{ datasetType: PlateauDatasetType; name: string }> = (
     includeParents: true,
   });
   return (
-    <DatasetTreeItem nodeId={datasetType} label={name} loading={query.loading}>
+    <DatasetTreeItem nodeId={datasetType} label={name} title={name} loading={query.loading}>
       {datasetType === PlateauDatasetType.UseCase && <GlobalItem />}
       {query.data?.areas.map(
         prefecture =>


### PR DESCRIPTION
## Overview

This PR:
- Adds `title` to layers item so that user can get the full name with mouse hover. (Sometimes the name is too long to display but user want to check the full name). The items includes:
  - Layers item.
  - Search result item.
  - Items under 検索 都道府県 カテゴリー

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/a34fba38-c552-47bf-913c-e59383873b0c)

- Adds support of wrap for EntityTitle and used in DatasetDialog so that it can display the full name of the dataset.

![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (20)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/5ca03287-3802-4f0f-9c4c-17b35a11f3fa)

