### PR TITLE
fix(extension): editor field component card option menu can't work

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/ComponentItem.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/ComponentItem.tsx
@@ -8,6 +8,7 @@ import {
   EditorPopperListItemButton,
   PropertyInfo,
 } from "../../ui-components";
+import { EditorClickAwayListener } from "../EditorClickAwayListener";
 
 import { BasicFieldProps, FieldType, fields } from "./fields";
 import { FieldGroupTypes, fieldGroupTitles } from "./fields/constants";
@@ -81,13 +82,12 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
   );
 
   return (
-    <>
+    <EditorClickAwayListener onClickAway={handleClickAway}>
       <ComponentCard
         title={title}
         moreButtonRef={anchorRef}
         error={componentNotFound}
         onMoreClick={handleMoreClick}
-        onClickAway={handleClickAway}
         highlight={moving}>
         {componentNotFound ? (
           <PropertyInfo preset="field-not-found" />
@@ -111,6 +111,6 @@ export const ComponentItem: React.FC<ComponentItemProps> = ({
           </EditorPopperListItemButton>
         </EditorPopperList>
       </EditorPopper>
-    </>
+    </EditorClickAwayListener>
   );
 };

--- a/extension/src/editor/containers/ui-components/component/ComponentCard.tsx
+++ b/extension/src/editor/containers/ui-components/component/ComponentCard.tsx
@@ -3,15 +3,12 @@ import MoreVertOutlinedIcon from "@mui/icons-material/MoreVertOutlined";
 import { styled, Paper, Collapse, Divider, Button, buttonClasses } from "@mui/material";
 import { useState, useCallback, MouseEventHandler } from "react";
 
-import { EditorClickAwayListener } from "../../common/EditorClickAwayListener";
-
 type ComponentCardProps = {
   title: string;
   moreButtonRef?: React.RefObject<HTMLButtonElement>;
   highlight?: boolean;
   error?: boolean;
   onMoreClick?: () => void;
-  onClickAway?: () => void;
   children?: React.ReactNode;
 };
 
@@ -21,7 +18,6 @@ export const ComponentCard: React.FC<ComponentCardProps> = ({
   highlight,
   error,
   onMoreClick,
-  onClickAway,
   children,
 }) => {
   const [expanded, setExpanded] = useState(true);
@@ -45,11 +41,9 @@ export const ComponentCard: React.FC<ComponentCardProps> = ({
           <StyledIcon expanded={expanded ? 1 : 0} />
           {title}
         </ComponentTitle>
-        <EditorClickAwayListener onClickAway={onClickAway}>
-          <StyledButton variant="contained" ref={moreButtonRef} onClick={handleMoreClick}>
-            <MoreVertOutlinedIcon fontSize="small" />
-          </StyledButton>
-        </EditorClickAwayListener>
+        <StyledButton variant="contained" ref={moreButtonRef} onClick={handleMoreClick}>
+          <MoreVertOutlinedIcon fontSize="small" />
+        </StyledButton>
       </TitleBar>
       <StyledCollapse in={expanded}>
         <Divider />


### PR DESCRIPTION
## Overview

Click away event listener stopped the menu event. It's from my last refactor moving it inside, so i put it outside again in this fix PR.