### PR TITLE
fix(extension): remove secondary title from dataset dialog

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetDialog.tsx
@@ -120,7 +120,6 @@ export const DatasetDialog: FC<DatasetDialogProps> = ({ dataset, municipalityCod
             dataset.name,
             dataset.__typename === "PlateauDataset" ? dataset.subname ?? "" : "",
           ].join(" "),
-          secondary: dataset?.prefecture?.name,
         }}
         secondaryAction={
           <StyledButton


### PR DESCRIPTION
## Overview

Since we have updated the primary title before there's no need to display the secondary title now, some info are duplicated. (Request from feedback)