### PR TITLE
feat: add CI for PLATEAU View Tiles

### DIFF
--- a/.github/workflows/build-tiles.yml
+++ b/.github/workflows/build-tiles.yml
@@ -1,0 +1,37 @@
+name: build-tiles
+on:
+  workflow_call:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/eukarya-inc/reearth-plateauview/plateauview-tiles:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and load docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./tiles
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.IMAGE_NAME }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: false
+      - name: Save docker image
+        run: docker save ${{ env.IMAGE_NAME }} | gzip > plateauview-tiles.tar.gz
+      - name: Save image to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plateauview-tiles
+          path: plateauview-tiles.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci-tiles.yml
+++ b/.github/workflows/ci-tiles.yml
@@ -1,0 +1,33 @@
+name: ci-tiles
+on:
+  workflow_call:
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tiles
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        run: yarn install --ignore-scripts # Need --ignore-script option due to @maplibre/maplibre-gl-native causes error in post process.
+      - name: eslint
+        run: yarn run lint
+      - name: test
+        run: yarn run test
+      - name: build
+        run: yarn run build

--- a/.github/workflows/ci-tiles.yml
+++ b/.github/workflows/ci-tiles.yml
@@ -25,8 +25,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install
         run: yarn install --ignore-scripts # Need --ignore-script option due to @maplibre/maplibre-gl-native causes error in post process.
-      - name: eslint
-        run: yarn run lint
       - name: test
         run: yarn run test
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           event-type: deploy-geo-dev
 
   build-tiles:
-    needs: ci-geo
+    needs: ci-tiles
     if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
     uses: ./.github/workflows/build-tiles.yml
   deploy-tiles-dev:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       action_type:
-        description: 'Action type'
+        description: "Action type"
         required: true
 jobs:
   prepare:
@@ -57,6 +57,17 @@ jobs:
             .github/workflows/build-geo.yml
             .github/workflows/deploy-geo-dev.yml
             .github/workflows/deploy-geo-prod.yml
+      - name: changed files for tiles
+        id: tiles
+        uses: tj-actions/changed-files@v36
+        with:
+          files: |
+            tiles
+            .github/workflows/ci-tiles.yml
+            .github/workflows/build-tiles.yml
+            .github/workflows/deploy-tiles-dev.yml
+            .github/workflows/deploy-tiles-prod.yml
+
   # ci-extension-version-update:
   #   needs: prepare
   #   if: ${{ !failure() && needs.prepare.outputs.extension == 'true' && github.event_name == 'push' && github.ref_name == 'main' }}
@@ -83,6 +94,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.geo == 'true' || github.event.inputs.action_type == 'geo'
     uses: ./.github/workflows/ci-geo.yml
+  ci-tiles:
+    needs: prepare
+    if: needs.prepare.outputs.geo == 'true' || github.event.inputs.action_type == 'tiles'
+    uses: ./.github/workflows/ci-tiles.yml
   ci:
     runs-on: ubuntu-latest
     needs:
@@ -90,7 +105,8 @@ jobs:
       - ci-server
       - ci-tools
       - ci-geo
-    if: '!failure()'
+      - ci-tiles
+    if: "!failure()"
     steps:
       - run: echo OK
   deploy-extension-dev:
@@ -126,3 +142,16 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: deploy-geo-dev
+
+  build-tiles:
+    needs: ci-geo
+    if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
+    uses: ./.github/workflows/build-tiles.yml
+  deploy-tiles-dev:
+    needs: build-tiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: deploy-tiles-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       extension: ${{ steps.extension.outputs.any_changed }}
       server: ${{ steps.server.outputs.any_changed }}
       geo: ${{ steps.geo.outputs.any_changed }}
+      tiles: ${{ steps.tiles.outputs.any_changed }}
       tools: ${{ steps.tools.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v3
@@ -96,7 +97,7 @@ jobs:
     uses: ./.github/workflows/ci-geo.yml
   ci-tiles:
     needs: prepare
-    if: needs.prepare.outputs.geo == 'true' || github.event.inputs.action_type == 'tiles'
+    if: needs.prepare.outputs.tiles == 'true' || github.event.inputs.action_type == 'tiles'
     uses: ./.github/workflows/ci-tiles.yml
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-tiles-dev.yml
+++ b/.github/workflows/deploy-tiles-dev.yml
@@ -1,0 +1,51 @@
+name: ⭐️ Deploy PLATEAU Tiles dev
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [deploy-tiles-dev]
+env:
+  IMAGE: ghcr.io/eukarya-inc/reearth-plateauview/plateauview-tiles:latest
+  IMAGE_GCP: asia.gcr.io/reearth-plateau-dev/plateauview-tiles:latest
+  GCP_SERVICE_ACCOUNT: github-cicd-oidc@reearth-plateau-dev.iam.gserviceaccount.com
+  GCP_WORKLOAD_IDENTITY_PROVIDER: projects/383489516390/locations/global/workloadIdentityPools/github-actions-oidc/providers/github-provider
+  GCP_REGION: asia-northeast1
+jobs:
+  deploy_tiles:
+    runs-on: ubuntu-latest
+    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+      - name: Configure docker
+        run: gcloud auth configure-docker --quiet
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download tiles artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ci.yml
+          workflow_conclusion: success
+          branch: main
+          name: plateauview-tiles
+          check_artifacts: true
+      - name: Unpack docker image
+        run: docker load < plateauview-tiles.tar.gz
+      - name: docker push
+        run: |
+          docker tag $IMAGE $IMAGE_GCP && \
+          docker push $IMAGE &&
+          docker push $IMAGE_GCP

--- a/.github/workflows/deploy-tiles-prod.yml
+++ b/.github/workflows/deploy-tiles-prod.yml
@@ -1,0 +1,61 @@
+name: ⭐️ Deploy PLATEAU Tiles production
+on:
+  workflow_dispatch:
+env:
+  IMAGE: ghcr.io/eukarya-inc/reearth-plateauview/plateauview-tiles:latest
+  IMAGE_GCP: asia.gcr.io/reearth-plateau/plateauview-tiles:latest
+  IMAGE_HUB: eukarya/plateauview-tiles:latest
+  GCP_SERVICE_ACCOUNT: github-cicd-oidc@reearth-plateau.iam.gserviceaccount.com
+  GCP_WORKLOAD_IDENTITY_PROVIDER: projects/232353765693/locations/global/workloadIdentityPools/github-actions-oidc/providers/github-provider
+  GCP_REGION: asia-northeast1
+jobs:
+  deploy_tiles:
+    runs-on: ubuntu-latest
+    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+      - name: Configure docker
+        run: gcloud auth configure-docker --quiet
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull docker image from GHCR
+        run: docker pull $IMAGE
+      - name: docker push
+        run: |
+          docker tag $IMAGE $IMAGE_GCP
+          docker push $IMAGE_GCP
+
+  push_hub:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull image
+        run: docker pull $IMAGE
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Push image
+        run: docker tag $IMAGE $IMAGE_HUB && docker push $IMAGE_HUB

--- a/tiles/README.md
+++ b/tiles/README.md
@@ -5,7 +5,7 @@ This app refers [takram-design-engineering/plateau-view](https://github.com/takr
 ## Installation
 
 ```bash
-$ yarn install
+yarn install
 ```
 
 ## Running the app


### PR DESCRIPTION
## Why

Because there are no CIs yet.

> [!NOTE]
> The workload is GCE (because it uses GPU) and therefore, can't be deployed like the Cloud Run easily.  Thus, "deploy" here means to build a Docker artifact.