### PR TITLE
refactor(extension): default template for emphasis property template

### DIFF
--- a/extension/src/editor/containers/dataset/FeatureInspectorPage.tsx
+++ b/extension/src/editor/containers/dataset/FeatureInspectorPage.tsx
@@ -1,14 +1,16 @@
 import { FeatureInspectorBasicBlock } from "./blocks/FeatureInspectorBasicBlock";
 import { FeatureInspectorEmphasisPropertyBlock } from "./blocks/FeatureInspectorEmphasisPropertyBlock";
 
-import { DraftSetting, UpdateSetting } from ".";
+import { DraftSetting, EditorDataset, UpdateSetting } from ".";
 
 type FeatureInspectorPageProps = {
+  dataset: EditorDataset;
   setting: DraftSetting;
   updateSetting: UpdateSetting;
 };
 
 export const FeatureInspectorPage: React.FC<FeatureInspectorPageProps> = ({
+  dataset,
   setting,
   updateSetting,
 }) => {
@@ -22,6 +24,7 @@ export const FeatureInspectorPage: React.FC<FeatureInspectorPageProps> = ({
       <FeatureInspectorEmphasisPropertyBlock
         key={`${setting.datasetId}-${setting.dataId}-feature-inspector-emphasis-property`}
         setting={setting}
+        dataset={dataset}
         updateSetting={updateSetting}
       />
     </>

--- a/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
@@ -120,9 +120,12 @@ export const FeatureInspectorEmphasisPropertyBlock: React.FC<
             onChange={handleTemplateIdChange}
           />
         )}
-        {!useTemplate && defaultTemplateName && (
-          <EditorCommonField>Default template detected: {defaultTemplateName}</EditorCommonField>
-        )}
+        {!useTemplate &&
+          defaultTemplateName &&
+          (!setting?.featureInspector?.emphasisProperty?.properties ||
+            setting?.featureInspector?.emphasisProperty?.properties?.length === 0) && (
+            <EditorCommonField>Default template detected: {defaultTemplateName}</EditorCommonField>
+          )}
       </BlockContentWrapper>
       {!useTemplate && (
         <>

--- a/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
@@ -2,7 +2,7 @@ import { Divider } from "@mui/material";
 import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { DraftSetting, UpdateSetting } from "..";
+import { DraftSetting, EditorDataset, UpdateSetting } from "..";
 import { useTemplateAPI } from "../../../../shared/api";
 import { EmphasisProperty, EmphasisPropertyTemplate } from "../../../../shared/api/types";
 import { EmphasisPropertyEditor } from "../../common/emphasisPropertyEditor";
@@ -17,12 +17,13 @@ import {
 
 type FeatureInspectorEmphasisPropertyBlockProps = EditorBlockProps & {
   setting: DraftSetting;
+  dataset: EditorDataset;
   updateSetting: UpdateSetting;
 };
 
 export const FeatureInspectorEmphasisPropertyBlock: React.FC<
   FeatureInspectorEmphasisPropertyBlockProps
-> = ({ setting, updateSetting }) => {
+> = ({ dataset, setting, updateSetting }) => {
   const [useTemplate, setUseTemplate] = useState(
     !!setting?.featureInspector?.emphasisProperty?.useTemplate,
   );
@@ -93,6 +94,17 @@ export const FeatureInspectorEmphasisPropertyBlock: React.FC<
     [updateSetting],
   );
 
+  const defaultTemplateName = useMemo(
+    () =>
+      emphasisPropertyTemplates.find(t =>
+        [
+          dataset.type.name,
+          dataset?.__typename === "PlateauDataset" ? dataset.subname ?? undefined : undefined,
+        ].includes(t.name.split("/").slice(-1)[0]),
+      )?.name,
+    [dataset, emphasisPropertyTemplates],
+  );
+
   return (
     <EditorBlock title="Emphasis Property" expandable>
       <BlockContentWrapper>
@@ -107,6 +119,9 @@ export const FeatureInspectorEmphasisPropertyBlock: React.FC<
             disabled={!useTemplate}
             onChange={handleTemplateIdChange}
           />
+        )}
+        {!useTemplate && defaultTemplateName && (
+          <EditorCommonField>Default template detected: {defaultTemplateName}</EditorCommonField>
         )}
       </BlockContentWrapper>
       {!useTemplate && (

--- a/extension/src/editor/containers/dataset/index.tsx
+++ b/extension/src/editor/containers/dataset/index.tsx
@@ -352,6 +352,7 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
           ) : draftSetting && contentType === "featureInspector" ? (
             <FeatureInspectorPage
               key={`${dataset.id}-${dataId}-featureInspector`}
+              dataset={dataset}
               setting={draftSetting}
               updateSetting={updateDraftSetting}
             />

--- a/extension/src/shared/view-layers/rootLayer.ts
+++ b/extension/src/shared/view-layers/rootLayer.ts
@@ -148,17 +148,13 @@ const findComponentTemplate = (
 ): ComponentTemplate | undefined => {
   const { useTemplate, templateId, groups } = setting?.fieldComponents ?? {};
 
+  // Should not use template if there's component settings
+  if ((!useTemplate || !templateId) && groups?.some(g => !!g.components.length)) return;
+
   // Default template
   const templateWithName = dataName
     ? templates.find(t => [dataName, dataSubName].includes(t.name.split("/").slice(-1)[0]))
     : undefined;
-
-  if (
-    (!useTemplate || !templateId) &&
-    // If there is no group, use the default template
-    (groups?.some(g => !!g.components.length) || !templateWithName)
-  )
-    return;
 
   const template =
     !useTemplate || !templateId ? templateWithName : templates.find(t => t.id === templateId);
@@ -170,17 +166,19 @@ const findEmphasisProperties = (
   featureInspector: FeatureInspectorSettings | undefined,
   templates: Template[],
   dataName: string | undefined,
+  dataSubName: string | undefined,
 ): EmphasisProperty[] | undefined => {
   const { useTemplate, templateId, properties } = featureInspector?.emphasisProperty ?? {};
 
+  if ((!useTemplate || !templateId) && !!properties?.length) return properties;
+
   // Default template
   const templateWithName = dataName
-    ? templates.find(t => t.name.split("/").slice(-1)[0] === dataName)
+    ? templates.find(
+        t =>
+          t.type === "emphasis" && [dataName, dataSubName].includes(t.name.split("/").slice(-1)[0]),
+      )
     : undefined;
-
-  // If there is no emphasis property, use the default template
-  if ((!useTemplate || !templateId) && (!!properties?.length || !templateWithName))
-    return properties;
 
   const template =
     !useTemplate || !templateId ? templateWithName : templates.find(t => t.id === templateId);
@@ -251,6 +249,7 @@ const createRootLayerForDataset = ({
     setting?.featureInspector,
     templates,
     datasetType.name,
+    subName,
   );
   const componentGroup = findComponentGroup(setting, componentTemplate, currentGroupId);
 


### PR DESCRIPTION
## Overview

This PR did some refactor on logic around default template matching for both emphasis property template and field component template. Also added a match info on editor.

## Screenshot
![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (41)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/39d4f08c-dec1-4c36-b6b7-f49eddd888a6)
