### PR TITLE
refactor(extension): support set speed amount and unit independently for timeline component

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineMonthField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineMonthField.tsx
@@ -5,7 +5,7 @@ export const EditorTimelineMonthField: React.FC<BasicFieldProps<"TIMELINE_MONTH_
   return (
     <PropertyWrapper>
       <PropertyBox>
-        <PropertyInfo preset="no-settings" />;
+        <PropertyInfo preset="no-settings" />
       </PropertyBox>
     </PropertyWrapper>
   );

--- a/extension/src/shared/ui-components/TimelineParameterItem.tsx
+++ b/extension/src/shared/ui-components/TimelineParameterItem.tsx
@@ -76,22 +76,37 @@ const CurrentTime = styled("div")(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
 }));
 
-const speedOptions = [
+const speedUnitOptions = [
   {
-    value: 60,
-    label: "1分 / 秒",
+    value: 1,
+    label: "秒",
   },
   {
-    value: 1800,
-    label: "30分 / 秒",
+    value: 60,
+    label: "分",
   },
   {
     value: 3600,
-    label: "1時間 / 秒",
+    label: "時間",
+  },
+];
+
+const speedAmountOptions = [
+  {
+    value: 1,
+    label: "1",
   },
   {
-    value: 36000,
-    label: "10時間 / 秒",
+    value: 5,
+    label: "5",
+  },
+  {
+    value: 10,
+    label: "10",
+  },
+  {
+    value: 30,
+    label: "30",
   },
 ];
 
@@ -123,16 +138,25 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
   const isActive = useRef(false);
   const [playState, setPlayState] = useState<"play" | "pause" | "reverse" | undefined>(undefined);
 
-  const [speed, setSpeed] = useState(speedOptions[0].value);
-
-  const handleSpeedChange = useCallback(
+  const [speedAmount, setSpeedAmount] = useState(speedAmountOptions[0].value);
+  const [speedUnit, setSpeedUnit] = useState(speedUnitOptions[1].value);
+  const handleSpeedAmountChange = useCallback(
     (event: SelectChangeEvent<number>) => {
-      setSpeed(Number(event.target.value));
+      setSpeedAmount(Number(event.target.value));
       if (playState === "play" || playState === "reverse") {
-        onSetSpeed?.((playState === "reverse" ? -1 : 1) * Number(event.target.value));
+        onSetSpeed?.((playState === "reverse" ? -1 : 1) * Number(event.target.value) * speedUnit);
       }
     },
-    [playState, onSetSpeed],
+    [playState, speedUnit, onSetSpeed],
+  );
+  const handleSpeedUnitChange = useCallback(
+    (event: SelectChangeEvent<number>) => {
+      setSpeedUnit(Number(event.target.value));
+      if (playState === "play" || playState === "reverse") {
+        onSetSpeed?.((playState === "reverse" ? -1 : 1) * Number(event.target.value) * speedAmount);
+      }
+    },
+    [playState, speedAmount, onSetSpeed],
   );
 
   const handlePlay = useCallback(() => {
@@ -144,9 +168,18 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
       start: startDate,
       stop: endDate,
       current: currentDate,
-      speed,
+      speed: speedAmount * speedUnit,
     });
-  }, [startDate, endDate, currentDate, speed, id, onPlay, setActiveTimelineComponentId]);
+  }, [
+    startDate,
+    endDate,
+    currentDate,
+    speedAmount,
+    speedUnit,
+    id,
+    onPlay,
+    setActiveTimelineComponentId,
+  ]);
 
   const handlePause = useCallback(() => {
     setActiveTimelineComponentId(id);
@@ -164,9 +197,18 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
       start: startDate,
       stop: endDate,
       current: currentDate,
-      speed,
+      speed: speedAmount * speedUnit,
     });
-  }, [startDate, endDate, currentDate, speed, id, onPlayReverse, setActiveTimelineComponentId]);
+  }, [
+    startDate,
+    endDate,
+    currentDate,
+    speedAmount,
+    speedUnit,
+    id,
+    onPlayReverse,
+    setActiveTimelineComponentId,
+  ]);
 
   const handleJumpTime = useCallback(
     (_: Event, value: number | number[]) => {
@@ -241,13 +283,25 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
           </ButtonWrapper>
         </ButtonsWrapper>
         <SelectWrapper>
-          <Select size="small" variant="filled" value={speed} onChange={handleSpeedChange}>
-            {speedOptions.map(option => (
+          <Select
+            size="small"
+            variant="filled"
+            value={speedAmount}
+            onChange={handleSpeedAmountChange}>
+            {speedAmountOptions.map(option => (
               <SelectItem key={option.value} value={option.value}>
                 <Typography variant="body2">{option.label}</Typography>
               </SelectItem>
             ))}
           </Select>
+          <Select size="small" variant="filled" value={speedUnit} onChange={handleSpeedUnitChange}>
+            {speedUnitOptions.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                <Typography variant="body2">{option.label}</Typography>
+              </SelectItem>
+            ))}
+          </Select>
+          <SpeedTick>/秒</SpeedTick>
         </SelectWrapper>
       </Controls>
       <TimelineBar
@@ -279,3 +333,7 @@ const formatDateWithTimezone = (date: Date, timezone: string) => {
     HH < 10 ? "0" + HH : HH
   }:${MM < 10 ? "0" + MM : MM}:${SS < 10 ? "0" + SS : SS} (UTC${timezone})`;
 };
+
+const SpeedTick = styled("span")(({ theme }) => ({
+  fontSize: theme.typography.body2.fontSize,
+}));

--- a/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
+++ b/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
@@ -27,15 +27,23 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
     handleTimelineOnTickEventRemove,
   } = useTimeline();
 
-  return component.preset ? (
+  const start = useMemo(
+    () => component.preset?.start ?? new Date().toISOString(),
+    [component.preset],
+  );
+  const current = useMemo(() => component.preset?.current ?? start, [component.preset, start]);
+  const end = useMemo(() => component.preset?.end ?? start, [component.preset, start]);
+  const timezone = useMemo(() => component.preset?.timezone ?? "+9", [component.preset]);
+
+  return start && current && end && timezone !== undefined ? (
     <ParameterList>
       <ParameterItem label="タイムライン">
         <TimelineParameterItem
           id={id}
-          start={component.preset.start}
-          current={component.preset.current}
-          end={component.preset.end}
-          timezone={component.preset.timezone}
+          start={start}
+          current={current}
+          end={end}
+          timezone={timezone}
           activeIdAtom={activeTimelineComponentIdAtom}
           onPlay={handleTimelinePlay}
           onPlayReverse={handleTimelinePlayReverse}


### PR DESCRIPTION
## Overview

This PR refactor the `TimelineParameterItem` to support set speed by amount and unit independently.

## Screenshot

![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (42)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/69680b8f-dcbd-401c-b2f2-6a0bf3ceb94b)
