### PR TITLE
feat(extension): support load geojson as resource

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorPrioritizePerformanceGeoJSONField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorPrioritizePerformanceGeoJSONField.tsx
@@ -1,0 +1,8 @@
+import { BasicFieldProps } from "..";
+import { PropertyInfo } from "../../../../ui-components";
+
+export const EditorPrioritizePerformanceGeoJSONField: React.FC<
+  BasicFieldProps<"PRIORITIZE_PERFORMANCE_GEOJSON_FIELD">
+> = () => {
+  return <PropertyInfo preset="no-settings" />;
+};

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -43,6 +43,7 @@ import { EditorLayerDescriptionField } from "./general/EditorLayerDescriptionFie
 import { EditorLegendDescriptionField } from "./general/EditorLegendDescriptionField";
 import { EditorLinkButtonField } from "./general/EditorLinkButtonField";
 import { EditorOpacityField } from "./general/EditorOpacityField";
+import { EditorPrioritizePerformanceGeoJSONField } from "./general/EditorPrioritizePerformanceGeoJSONField";
 import { EditorStyleCodeField } from "./general/EditorStyleCodeField";
 import { EditorTimelineCustomizedField } from "./general/EditorTimelineCustomizedField";
 import { EditorTimelineMonthField } from "./general/EditorTimelineMonthField";
@@ -110,6 +111,11 @@ export const fields: {
     group: FILED_GROUP_GENERAL_TIMELINE,
     name: "Month",
     Component: EditorTimelineMonthField,
+  },
+  PRIORITIZE_PERFORMANCE_GEOJSON_FIELD: {
+    category: FIELD_CATEGORY_GENERAL,
+    name: "Prioritize Performance (GeoJSON)",
+    Component: EditorPrioritizePerformanceGeoJSONField,
   },
   LINK_BUTTON_FIELD: {
     category: FIELD_CATEGORY_GENERAL,

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralData.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralData.ts
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 
 import { useOptionalAtomValue } from "../../hooks";
 import { GeneralData } from "../../reearth/layers";
-import { APPLY_TIME_VALUE_FIELD } from "../../types/fieldComponents/general";
+import {
+  APPLY_TIME_VALUE_FIELD,
+  PRIORITIZE_PERFORMANCE_GEOJSON_FIELD,
+} from "../../types/fieldComponents/general";
 import { POINT_CONVERT_FROM_CSV } from "../../types/fieldComponents/point";
 import { ComponentAtom } from "../../view-layers/component";
 import { useFindComponent } from "../../view-layers/hooks";
@@ -22,6 +25,11 @@ export const useEvaluateGeneralData = ({
     useFindComponent(componentAtoms ?? [], POINT_CONVERT_FROM_CSV),
   );
 
+  // GeoJSON
+  const prioritizePerformanceGeoJSON = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], PRIORITIZE_PERFORMANCE_GEOJSON_FIELD),
+  );
+
   const generalData: GeneralData = useMemo(
     () => ({
       time:
@@ -35,8 +43,11 @@ export const useEvaluateGeneralData = ({
             heightColumn: csvProperty.preset.heightColumn,
           }
         : undefined,
+      geojson: {
+        useAsResource: prioritizePerformanceGeoJSON ? true : undefined,
+      },
     }),
-    [timeProperty, csvProperty],
+    [timeProperty, csvProperty, prioritizePerformanceGeoJSON],
   );
 
   return generalData;

--- a/extension/src/shared/types/fieldComponents/general.ts
+++ b/extension/src/shared/types/fieldComponents/general.ts
@@ -63,6 +63,11 @@ export type TimelineMonthField = FieldBase<{
   type: typeof TIMELINE_MONTH_FIELD;
 }>;
 
+export const PRIORITIZE_PERFORMANCE_GEOJSON_FIELD = "PRIORITIZE_PERFORMANCE_GEOJSON_FIELD";
+export type PrioritizePerformanceGeoJSONField = FieldBase<{
+  type: typeof PRIORITIZE_PERFORMANCE_GEOJSON_FIELD;
+}>;
+
 export const LINK_BUTTON_FIELD = "LINK_BUTTON_FIELD";
 export type LinkButtonField = FieldBase<{
   type: typeof LINK_BUTTON_FIELD;
@@ -83,5 +88,6 @@ export type GeneralFields =
   | ApplyTimeValueField
   | TimelineCustomizedField
   | TimelineMonthField
+  | PrioritizePerformanceGeoJSONField
   | LinkButtonField
   | DatasetStoryField;

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -47,6 +47,7 @@ export const fieldSettings: {
   TIMELINE_MONTH_FIELD: {
     hasLayerUI: true,
   },
+  PRIORITIZE_PERFORMANCE_GEOJSON_FIELD: {},
   LINK_BUTTON_FIELD: {},
   DATASET_STORY_FIELD: {},
   // point


### PR DESCRIPTION
## Overview

This PR adds a new field component `EditorPrioritizePerformanceGeoJSONField` to set `data.geojson.useAsResource`

## Screenshot
![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (44)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/8fd23f9a-6be3-40cc-819c-0aa520a33bfa)

## Test

Test with dataset `都市活動/交通情報`
