### PR TITLE
refactor(extension): support display datasets who has prefecture but no city in area list and type list

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
@@ -162,9 +162,9 @@ const PrefectureItem: FC<{
       {areas.map(municipality => (
         <MunicipalityItem key={municipality.code} municipality={municipality} />
       ))}
-      {groups?.map(({ groupId, datasets }) => {
-        return <DatasetGroup key={groupId} groupId={groupId} datasets={datasets} />;
-      })}
+      {groups?.map(({ groupId, datasets }) => (
+        <DatasetGroup key={groupId} groupId={groupId} datasets={datasets} />
+      ))}
     </DatasetTreeItem>
   );
 };

--- a/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
@@ -77,7 +77,16 @@ const PrefectureItem: FC<{
     parentCode: prefecture.code,
     datasetTypes: [datasetType],
   });
-  if (query.data?.areas?.length === 1) {
+
+  // Handle the datasets belongs to this perfecture but no municipality
+  const prefectureDatasetQuery = useAreaDatasets(prefecture.code);
+  const prefectureDatasets = useMemo(
+    () => prefectureDatasetQuery.data?.area?.datasets?.filter(d => !d.cityCode) ?? [],
+    [prefectureDatasetQuery.data?.area?.datasets],
+  );
+  const isGenericDataset = isGenericDatasetType(datasetType);
+
+  if (query.data?.areas?.length === 1 && prefectureDatasets.length === 0) {
     return (
       <MunicipalityItem
         datasetType={datasetType}
@@ -100,6 +109,22 @@ const PrefectureItem: FC<{
           municipality={municipality}
         />
       ))}
+      {isGenericDataset ? (
+        <DatasetFolderList
+          folderId={`${datasetType}:prefecture:direct`}
+          datasets={prefectureDatasets}
+        />
+      ) : (
+        prefectureDatasets.map(dataset => (
+          <DatasetListItem
+            key={dataset.id}
+            municipalityCode={"direct"}
+            dataset={dataset}
+            label={dataset.name}
+            title={dataset.name}
+          />
+        ))
+      )}
     </DatasetTreeItem>
   );
 };


### PR DESCRIPTION
## Overview

There're some datasets (almost all use case i guess) only have prefecture code but no city code, therefore they can't be displayed in area list and type list.

This PR adds query for these datasets and display them below the normal MunicipalityItems.

## Screenshot

![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (45)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/ef10fd2c-057a-4b00-8e29-24b75a1341b5)

![localhost_3000_scene_01hnyhekfpzjhh81qhg61vveg5_widgets(Desktop 1920) (46)](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/d9fbf710-0a91-461b-adbd-8e8717cc8a2e)

