### PR TITLE
fix(extension): location bread crumb items count

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -5,14 +5,14 @@ import { memo, useCallback, useMemo, type FC } from "react";
 import invariant from "tiny-invariant";
 
 import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
-import { rootLayersAtom, rootLayersLayersAtom } from "../../../shared/states/rootLayer";
+import { rootLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
 import {
   RootLayerConfigForDataset,
   createRootLayerForDatasetAtom,
 } from "../../../shared/view-layers";
-import { removeLayerAtom, useAddLayer, useFilterLayers } from "../../layers";
+import { removeLayerAtom, useAddLayer } from "../../layers";
 import { isNotNullish } from "../../type-helpers";
 import { ContextSelect, SelectGroupItem, SelectItem } from "../../ui-components";
 import { datasetTypeLayers } from "../constants/datasetTypeLayers";
@@ -53,30 +53,22 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
   ({ datasets, municipalityCode, disabled }) => {
     invariant(datasets.length > 0);
     const rootLayers = useAtomValue(rootLayersAtom);
-    const layers = useAtomValue(rootLayersLayersAtom);
     const settings = useAtomValue(settingsAtom);
     const templates = useAtomValue(templatesAtom);
     // Assume that all the datasets share the same type.
     const layerType =
       datasetTypeLayers[datasets[0].type.code as PlateauDatasetType] ?? datasetTypeLayers.usecase;
+
     invariant(layerType !== "BUILDING_LAYER", "Building layer is not supported.");
-    const filterLayers = useFilterLayers();
-    const filteredLayers = useMemo(
-      () =>
-        layerType != null
-          ? filterLayers(layers, {
-              type: layerType,
-            })
-          : [],
-      [layers, layerType, filterLayers],
-    );
+
+    const datasetIds = useMemo(() => datasets.map(d => d.id), [datasets]);
+
     const filteredRootLayers = useMemo(
       () =>
         rootLayers.filter(
-          (l): l is RootLayerConfigForDataset =>
-            l.type === "dataset" && !!filteredLayers.find(f => l.id === f.id),
+          (l): l is RootLayerConfigForDataset => l.type === "dataset" && datasetIds.includes(l.id),
         ),
-      [rootLayers, filteredLayers],
+      [rootLayers, datasetIds],
     );
 
     const addLayer = useAddLayer();

--- a/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
@@ -34,12 +34,10 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
       groupBy(
         datasets.filter(d =>
           !d.cityCode
-            ? area.code === d.prefectureCode
+            ? d.prefectureCode === area.code
             : !d.wardCode
             ? d.cityCode === area.code
-            : d.wardCode
-            ? d.wardCode === area.code
-            : false,
+            : d.wardCode === area.code,
         ),
         d => d.type.name,
       ),


### PR DESCRIPTION
## Overview

There's some mistake in filtering exist layers on location bread crumb select item, this PR fixs by filtering with dataset id. This should also work with layers added from search result.