### PR TITLE
fix(extension): don't close popup menu when click on menu parent

### DIFF
--- a/extension/src/prototypes/ui-components/ContextButtonSelect.tsx
+++ b/extension/src/prototypes/ui-components/ContextButtonSelect.tsx
@@ -77,7 +77,10 @@ export const ContextButtonSelect = forwardRef<HTMLDivElement, ContextButtonSelec
       const handler = (event: MouseEvent): void => {
         if (selectRef.current?.contains(event.target as Node) === true) {
           setOpen(true);
-        } else if (menuRef.current?.contains(event.target as Node) !== true) {
+        } else if (
+          menuRef.current?.contains(event.target as Node) !== true &&
+          menuRef.current?.parentElement !== event.target
+        ) {
           setOpen(false);
         }
       };

--- a/extension/src/prototypes/ui-components/ContextSelect.tsx
+++ b/extension/src/prototypes/ui-components/ContextSelect.tsx
@@ -97,7 +97,10 @@ export const ContextSelect = forwardRef<HTMLButtonElement, ContextSelectProps>(
         }
         if (ref.current?.contains(event.target) === true) {
           setOpen(true);
-        } else if (menuRef.current?.contains(event.target) !== true) {
+        } else if (
+          menuRef.current?.contains(event.target) !== true &&
+          menuRef.current?.parentElement !== event.target
+        ) {
           setOpen(false);
         }
       };


### PR DESCRIPTION
## Overview

When there's scroll bar on context select and drag the scroll bar with mouse, the mouse up event will trigger the popup be closed which should not. 