### PR TITLE
refactor(extension): custom timeline & transparency & style code component 

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorOpacityField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorOpacityField.tsx
@@ -1,10 +1,57 @@
-import { BasicFieldProps } from "..";
-import { PropertyInfo } from "../../../../ui-components";
+import { useCallback, useEffect, useState } from "react";
 
-export const EditorOpacityField: React.FC<BasicFieldProps<"OPACITY_FIELD">> = () => {
+import { BasicFieldProps } from "..";
+import {
+  PropertyBox,
+  PropertyInlineWrapper,
+  PropertyInputField,
+  PropertyWrapper,
+} from "../../../../ui-components";
+
+export type OpacityFieldPreset = {
+  defaultValue?: number;
+};
+
+export const EditorOpacityField: React.FC<BasicFieldProps<"OPACITY_FIELD">> = ({
+  component,
+  onUpdate,
+}) => {
+  const [localValue, setLocalValue] = useState(component.preset?.defaultValue ?? "1");
+
+  const handleLocalValueChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalValue(e.target.value);
+  }, []);
+
+  useEffect(() => {
+    const numberValue = Number(localValue);
+    if (
+      isNaN(numberValue) ||
+      numberValue > 1 ||
+      numberValue < 0 ||
+      numberValue === component.preset?.defaultValue
+    )
+      return;
+
+    onUpdate?.({
+      ...component,
+      preset: {
+        ...component.preset,
+        defaultValue: numberValue,
+      },
+    });
+  }, [localValue, component, onUpdate]);
+
   return (
-    <PropertyInfo>
-      Attention: This component will override the color settings from Style Code component.
-    </PropertyInfo>
+    <PropertyWrapper>
+      <PropertyBox>
+        <PropertyInlineWrapper label="Default Opacity">
+          <PropertyInputField
+            value={localValue}
+            placeholder="0 ~ 1"
+            onChange={handleLocalValueChange}
+          />
+        </PropertyInlineWrapper>
+      </PropertyBox>
+    </PropertyWrapper>
   );
 };

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorStyleCodeField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorStyleCodeField.tsx
@@ -10,6 +10,7 @@ import {
   EditorDialog,
   PropertyBox,
   PropertyInlineWrapper,
+  PropertyInputField,
   PropertySwitchField,
   PropertyWrapper,
 } from "../../../../ui-components";
@@ -29,6 +30,7 @@ const options = {
 export type StyleCodeFieldPreset = {
   code?: string;
   enableTransparencySlider?: boolean;
+  defaultOpacity?: number;
 };
 
 export const EditorStyleCodeField: React.FC<BasicFieldProps<"STYLE_CODE_FIELD">> = ({
@@ -72,6 +74,31 @@ export const EditorStyleCodeField: React.FC<BasicFieldProps<"STYLE_CODE_FIELD">>
     },
     [component, onUpdate],
   );
+
+  const [localOpacity, setLocalOpacity] = useState(component.preset?.defaultOpacity ?? "1");
+
+  const handleLocalOpacityChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalOpacity(e.target.value);
+  }, []);
+
+  useEffect(() => {
+    const numberValue = Number(localOpacity);
+    if (
+      isNaN(numberValue) ||
+      numberValue > 1 ||
+      numberValue < 0 ||
+      numberValue === component.preset?.defaultOpacity
+    )
+      return;
+
+    onUpdate?.({
+      ...component,
+      preset: {
+        ...component.preset,
+        defaultOpacity: numberValue,
+      },
+    });
+  }, [localOpacity, component, onUpdate]);
 
   const [fullsizeEditorOpen, setFullsizeEditorOpen] = useState(false);
   const openFullsizeEditor = useCallback(() => {
@@ -122,6 +149,13 @@ export const EditorStyleCodeField: React.FC<BasicFieldProps<"STYLE_CODE_FIELD">>
           <PropertySwitchField
             checked={!!component.preset?.enableTransparencySlider}
             onChange={handleEnableTransparencySliderChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Default Opacity">
+          <PropertyInputField
+            value={localOpacity}
+            placeholder="0 ~ 1"
+            onChange={handleLocalOpacityChange}
           />
         </PropertyInlineWrapper>
       </PropertyBox>

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineCustomizedField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineCustomizedField.tsx
@@ -21,7 +21,43 @@ export type EditorTimelineCustomizedFieldPreset = {
   end?: string;
   current?: string;
   timezone?: string;
+  defaultUnit?: number;
+  defaultAmount?: number;
 };
+
+const speedUnitOptions = [
+  {
+    value: 1,
+    label: "秒",
+  },
+  {
+    value: 60,
+    label: "分",
+  },
+  {
+    value: 3600,
+    label: "時間",
+  },
+];
+
+const speedAmountOptions = [
+  {
+    value: 1,
+    label: "1",
+  },
+  {
+    value: 5,
+    label: "5",
+  },
+  {
+    value: 10,
+    label: "10",
+  },
+  {
+    value: 30,
+    label: "30",
+  },
+];
 
 export const EditorTimelineCustomizedField: React.FC<
   BasicFieldProps<"TIMELINE_CUSTOMIZED_FIELD">
@@ -78,6 +114,32 @@ export const EditorTimelineCustomizedField: React.FC<
     [component, onUpdate],
   );
 
+  const handleDefaultUnitChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          defaultUnit: Number(e.target.value),
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const handleDefaultAmountChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          defaultAmount: Number(e.target.value),
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
   return (
     <PropertyWrapper>
       <PropertyBox>
@@ -107,6 +169,20 @@ export const EditorTimelineCustomizedField: React.FC<
             options={timezoneOptions}
             value={component.preset?.timezone ?? "+9"}
             onChange={handleTimezoneChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Default Value">
+          <PropertySelectField
+            options={speedAmountOptions}
+            value={component.preset?.defaultAmount ?? 1}
+            onChange={handleDefaultAmountChange}
+          />
+        </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Default Unit">
+          <PropertySelectField
+            options={speedUnitOptions}
+            value={component.preset?.defaultUnit ?? 60}
+            onChange={handleDefaultUnitChange}
           />
         </PropertyInlineWrapper>
       </PropertyBox>

--- a/extension/src/editor/containers/ui-components/property/PropertySelectField.tsx
+++ b/extension/src/editor/containers/ui-components/property/PropertySelectField.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 
 export type PropertySelectFieldProps = TextFieldProps & {
-  options: { value: string; label: string }[];
+  options: { value: string | number; label: string }[];
 };
 
 export const PropertySelectField: React.FC<PropertySelectFieldProps> = ({ options, ...props }) => {

--- a/extension/src/prototypes/view/selection/TileFeatureContent.tsx
+++ b/extension/src/prototypes/view/selection/TileFeatureContent.tsx
@@ -103,13 +103,13 @@ export const TileFeatureContent: FC<TileFeatureContentProps> = ({ values }) => {
         title={title}
         iconComponent={Icon}
         actions={
-          isBuildingModel ? (
-            <>
-              <Tooltip title="レイヤーを選択">
-                <IconButton aria-label="レイヤーを選択" onClick={handleSelectLayers}>
-                  <LayerIcon />
-                </IconButton>
-              </Tooltip>
+          <>
+            <Tooltip title="レイヤーを選択">
+              <IconButton aria-label="レイヤーを選択" onClick={handleSelectLayers}>
+                <LayerIcon />
+              </IconButton>
+            </Tooltip>
+            {isBuildingModel && (
               <Tooltip title={hidden ? "表示" : "隠す"}>
                 <IconButton
                   aria-label={hidden ? "表示" : "隠す"}
@@ -117,8 +117,8 @@ export const TileFeatureContent: FC<TileFeatureContentProps> = ({ values }) => {
                   {hidden ? <VisibilityOffIcon /> : <VisibilityOnIcon />}
                 </IconButton>
               </Tooltip>
-            </>
-          ) : undefined
+            )}
+          </>
         }
         onClose={handleClose}
       />

--- a/extension/src/prototypes/view/selection/TileFeaturePropertiesSection.tsx
+++ b/extension/src/prototypes/view/selection/TileFeaturePropertiesSection.tsx
@@ -50,7 +50,7 @@ export const TileFeaturePropertiesSection: FC<TileFeaturePropertiesSectionProps>
   const tilesetLayer = layers[0].layer as BuildingLayerModel | undefined;
   const tilesetProperties = useOptionalAtomValue(tilesetLayer?.propertiesAtom);
 
-  const featureType = useMemo(() => layers[0].features[0].properties["feature_type"], [layers]);
+  const featureType = useMemo(() => layers[0].features[0]?.properties["feature_type"], [layers]);
 
   const properties = useMemo(() => {
     // TODO: Replace properties by JSONPath

--- a/extension/src/shared/layerContainers/buildingModel.tsx
+++ b/extension/src/shared/layerContainers/buildingModel.tsx
@@ -189,7 +189,7 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
   const color = useEvaluateFeatureColor({
     colorProperty: buildingModelColorAtom ? colorProperty ?? undefined : undefined,
     colorScheme: buildingModelColorAtom ? colorScheme ?? undefined : undefined,
-    opacity: opacity?.value,
+    opacity: opacity?.value ?? opacity?.preset?.defaultValue,
     selections,
     defaultColor:
       colorMode === "light" ? { r: 255, g: 255, b: 255, a: 1 } : { r: 68, g: 68, b: 68, a: 1 },
@@ -197,7 +197,9 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
 
   const theme = useTheme();
 
-  const enableShadow = !opacity?.value || opacity.value === 1;
+  const enableShadow =
+    !(opacity?.value ?? opacity?.preset?.defaultValue) ||
+    (opacity.value ?? opacity?.preset?.defaultValue) === 1;
 
   const [interactionMode] = useAtom(interactionModeAtom);
 

--- a/extension/src/shared/layerContainers/floodModel.tsx
+++ b/extension/src/shared/layerContainers/floodModel.tsx
@@ -147,7 +147,7 @@ export const FloodModelLayerContainer: FC<TilesetContainerProps> = ({
   const color = useEvaluateFeatureColor({
     colorProperty: floodModelColorAtom || floodColor ? colorProperty ?? undefined : undefined,
     colorScheme: floodModelColorAtom || floodColor ? colorScheme ?? undefined : undefined,
-    opacity: opacity?.value,
+    opacity: opacity?.value ?? opacity?.preset?.defaultValue,
     selections,
     defaultColor: {
       r: primaryRGB[0],

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -187,7 +187,11 @@ export const useEvaluateGeneralAppearance = ({
   const styleCode = useOptionalAtomValue(useFindComponent(componentAtoms ?? [], STYLE_CODE_FIELD));
 
   const appearanceObjectFromStyleCode = useMemo(
-    () => getAppearanceObject(styleCode?.preset?.code, styleCode?.value?.opacity) ?? {},
+    () =>
+      getAppearanceObject(
+        styleCode?.preset?.code,
+        styleCode?.value?.opacity ?? styleCode?.preset?.defaultOpacity,
+      ) ?? {},
     [styleCode],
   );
 
@@ -197,9 +201,15 @@ export const useEvaluateGeneralAppearance = ({
         marker: {
           style: pointStyle?.preset?.style,
           pointColor:
-            makeSimpleColorValue(pointColor, opacity?.value) ??
-            makeConditionalExpression(pointFillColorCondition, opacity?.value) ??
-            makeGradientExpression(pointFillGradientColor, opacity?.value) ??
+            makeSimpleColorValue(pointColor, opacity?.value ?? opacity?.preset?.defaultValue) ??
+            makeConditionalExpression(
+              pointFillColorCondition,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
+            makeGradientExpression(
+              pointFillGradientColor,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           pointSize: pointSize?.preset?.defaultValue,
           pointOutlineColor:
@@ -212,7 +222,10 @@ export const useEvaluateGeneralAppearance = ({
           imageColor:
             makeSimpleColorWithOpacity(opacity, pointImageValue?.preset?.imageColor) ??
             pointImageValue?.preset?.imageColor ??
-            makeConditionalImageColorExpression(pointImageCondition, opacity?.value),
+            makeConditionalImageColorExpression(
+              pointImageCondition,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ),
           imageSize: pointImageSize?.preset?.defaultValue,
           imageSizeInMeters: pointImageSize?.preset?.enableSizeInMeters,
           show:
@@ -236,8 +249,11 @@ export const useEvaluateGeneralAppearance = ({
         },
         polyline: {
           strokeColor:
-            makeSimpleColorValue(polylineColor, opacity?.value) ??
-            makeConditionalExpression(polylineFillColorCondition, opacity?.value) ??
+            makeSimpleColorValue(polylineColor, opacity?.value ?? opacity?.preset?.defaultValue) ??
+            makeConditionalExpression(
+              polylineFillColorCondition,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           strokeWidth: polylineStrokeWeight?.preset?.defaultValue,
           show:
@@ -252,14 +268,23 @@ export const useEvaluateGeneralAppearance = ({
         },
         polygon: {
           fillColor:
-            makeSimpleColorValue(polygonFillAndStrokeColor, opacity?.value) ??
-            makeConditionalExpression(polygonFillAndStrokeColorCondition, opacity?.value) ??
+            makeSimpleColorValue(
+              polygonFillAndStrokeColor,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
+            makeConditionalExpression(
+              polygonFillAndStrokeColorCondition,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           strokeColor:
-            makeSimpleValueForStrokeColor(polygonFillAndStrokeColor, opacity?.value) ??
+            makeSimpleValueForStrokeColor(
+              polygonFillAndStrokeColor,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
             makeStrokeColorConditionalExpression(
               polygonFillAndStrokeColorCondition,
-              opacity?.value,
+              opacity?.value ?? opacity?.preset?.defaultValue,
             ) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           strokeWidth: polygonStrokeWeight?.preset?.defaultValue,
@@ -279,8 +304,14 @@ export const useEvaluateGeneralAppearance = ({
         "3dtiles": {
           pbr: tilesetDisableDefaultMaterial ? false : undefined,
           color:
-            makeConditionalExpression(tilesetFillColorCondition, opacity?.value) ??
-            makeGradientExpression(tilesetFillGradientColor, opacity?.value) ??
+            makeConditionalExpression(
+              tilesetFillColorCondition,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
+            makeGradientExpression(
+              tilesetFillGradientColor,
+              opacity?.value ?? opacity?.preset?.defaultValue,
+            ) ??
             makeSimpleColorWithOpacity(opacity, DEFAULT_COLOR),
           experimental_clipping: { ...clippingBox, ...drawClipping },
           disableSelection: clippingBox?.disabledSelection,

--- a/extension/src/shared/layerContainers/utils/value.ts
+++ b/extension/src/shared/layerContainers/utils/value.ts
@@ -258,7 +258,7 @@ export const makeSimpleColorWithOpacity = (
   if (!comp || !originColor) return;
   return {
     expression: {
-      conditions: [["true", color(originColor, comp.value ?? 1)]],
+      conditions: [["true", color(originColor, comp.value ?? comp?.preset?.defaultValue ?? 1)]],
     },
   };
 };

--- a/extension/src/shared/ui-components/TimelineParameterItem.tsx
+++ b/extension/src/shared/ui-components/TimelineParameterItem.tsx
@@ -15,6 +15,8 @@ type TimelineParameterItemProps = {
   current?: string;
   end?: string;
   timezone?: string;
+  defaultUnit?: number;
+  defaultAmount?: number;
   activeIdAtom: PrimitiveAtom<string>;
   onPlay?: (props: { start: Date; stop: Date; current: Date; speed: number }) => void;
   onPlayReverse?: (props: { start: Date; stop: Date; current: Date; speed: number }) => void;
@@ -116,6 +118,8 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
   current,
   end,
   timezone = "+9",
+  defaultUnit = 60,
+  defaultAmount = 1,
   activeIdAtom,
   onPlay,
   onPlayReverse,
@@ -138,8 +142,8 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
   const isActive = useRef(false);
   const [playState, setPlayState] = useState<"play" | "pause" | "reverse" | undefined>(undefined);
 
-  const [speedAmount, setSpeedAmount] = useState(speedAmountOptions[0].value);
-  const [speedUnit, setSpeedUnit] = useState(speedUnitOptions[1].value);
+  const [speedAmount, setSpeedAmount] = useState(defaultAmount);
+  const [speedUnit, setSpeedUnit] = useState(defaultUnit);
   const handleSpeedAmountChange = useCallback(
     (event: SelectChangeEvent<number>) => {
       setSpeedAmount(Number(event.target.value));

--- a/extension/src/shared/view/fields/general/LayerOpacityField.tsx
+++ b/extension/src/shared/view/fields/general/LayerOpacityField.tsx
@@ -18,7 +18,7 @@ export const LayerOpacityField: FC<LayerOpacityFieldProps> = ({ atoms }) => {
     () =>
       atoms.map(a =>
         atom(
-          get => get(a).value ?? 1,
+          get => get(a).value ?? get(a).preset?.defaultValue ?? 1,
           (get, set, update: number) => {
             set(a, { ...get(a), value: update });
           },

--- a/extension/src/shared/view/fields/general/LayerStyleCodeField.tsx
+++ b/extension/src/shared/view/fields/general/LayerStyleCodeField.tsx
@@ -18,7 +18,7 @@ export const LayerStyleCodeField: FC<LayerStyleCodeFieldProps> = ({ atoms }) => 
     () =>
       atoms.map(a =>
         atom(
-          get => get(a).value?.opacity ?? 1,
+          get => get(a).value?.opacity ?? get(a).preset?.defaultOpacity ?? 1,
           (get, set, update: number) => {
             set(a, {
               ...get(a),

--- a/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
+++ b/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
@@ -34,6 +34,8 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
   const current = useMemo(() => component.preset?.current ?? start, [component.preset, start]);
   const end = useMemo(() => component.preset?.end ?? start, [component.preset, start]);
   const timezone = useMemo(() => component.preset?.timezone ?? "+9", [component.preset]);
+  const defaultUnit = useMemo(() => component.preset?.defaultUnit, [component.preset]);
+  const defaultAmount = useMemo(() => component.preset?.defaultAmount, [component.preset]);
 
   return start && current && end && timezone !== undefined ? (
     <ParameterList>
@@ -44,6 +46,8 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
           current={current}
           end={end}
           timezone={timezone}
+          defaultUnit={defaultUnit}
+          defaultAmount={defaultAmount}
           activeIdAtom={activeTimelineComponentIdAtom}
           onPlay={handleTimelinePlay}
           onPlayReverse={handleTimelinePlayReverse}

--- a/extension/src/shared/view/selection/GeneralFeaturePropertiesSection.tsx
+++ b/extension/src/shared/view/selection/GeneralFeaturePropertiesSection.tsx
@@ -58,7 +58,7 @@ export const GeneralFeaturePropertiesSection: FC<GeneralFeaturePropertiesSection
     }, [] as { features: Pick<Feature, "properties">[]; layer?: LayerModel; rootLayer: RootLayerForDataset | undefined }[]);
   }, [values, findLayer, findRootLayer, rootLayersLayers]);
 
-  const featureType = useMemo(() => layers[0].features[0].properties["feature_type"], [layers]);
+  const featureType = useMemo(() => layers[0].features[0]?.properties["feature_type"], [layers]);
 
   const properties = useMemo(() => {
     // TODO: Replace properties by JSONPath


### PR DESCRIPTION
## Overview

This PR refactors some on:

- Support set default unit & value for custom timeline component.
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/9f810dd2-f2ec-49b6-aa46-e30011834675)
Test with 菊池川時系列浸水シミュレーション（想定最大規模）/浸水シミュレーション(玉名駅周辺最大水深)

- Support set default opacity value from editor.
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/d7fb80cd-9c23-4a4c-8887-d665515b40ed)

  - Style code test with 建物利用現況（千種区）
  - Building test with 建築物モデル（千代田区）LOD1
  - Flood test with 高潮浸水想定区域モデル 東京都高潮浸水想定（平成30年3月）（千代田区）
  - General test with 避難施設情報（中央区） Group Point Color Condition

- Add select layer button on tile select content
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/086037a8-5951-48a2-8c31-9aeae58dd31c)
