### PR TITLE
refactor(extension): set location as secondary title in search result

### DIFF
--- a/extension/src/prototypes/ui-components/EntityTitleButton.tsx
+++ b/extension/src/prototypes/ui-components/EntityTitleButton.tsx
@@ -121,7 +121,7 @@ export const EntityTitleButton = forwardRef<HTMLDivElement, EntityTitleButtonPro
           secondaryTypographyProps={{
             variant: "body2",
           }}
-          title={typeof title === "object" ? title?.primary : title}
+          title={typeof title === "object" ? `${title?.primary}${title?.secondary}` : title}
         />
         {children}
       </StyledListItemButton>

--- a/extension/src/prototypes/ui-components/SearchAutocomplete.tsx
+++ b/extension/src/prototypes/ui-components/SearchAutocomplete.tsx
@@ -101,6 +101,7 @@ export interface SearchOption {
   id?: string;
   name: string;
   index?: string;
+  displayName?: string | { primary: string; secondary?: string };
 }
 
 const iconComponents: Record<Exclude<SearchOptionType, "filter">, ComponentType> = {
@@ -134,7 +135,7 @@ function renderOption(props: HTMLAttributes<HTMLLIElement>, option: SearchOption
   return (
     // @ts-expect-error TODO
     <EntityTitleButton
-      title={option.name}
+      title={option.displayName ?? option.name}
       // @ts-expect-error TODO
       iconComponent={iconComponents[option.type]}
       {...props}

--- a/extension/src/prototypes/view/hooks/useSearchOptions.ts
+++ b/extension/src/prototypes/view/hooks/useSearchOptions.ts
@@ -89,35 +89,32 @@ function useDatasetSearchOptions({
           );
         })
         .map(dataset => {
-          const labelParts = [];
-          if (inEditor() && dataset.year) {
-            labelParts.push(`[${dataset.year}]`);
-          }
-          labelParts.push(dataset.name);
+          const name = `[${inEditor() && dataset.year ? dataset.year : ""}] ${dataset.name}`;
+          const locations = [];
 
-          const locationParts = [];
           if (dataset.prefecture?.name) {
-            locationParts.push(dataset.prefecture.name);
+            locations.push(dataset.prefecture.name);
           }
           if (dataset.city?.name) {
-            locationParts.push(dataset.city.name);
+            locations.push(dataset.city.name);
           }
           if (dataset.ward?.name) {
-            locationParts.push(dataset.ward.name);
+            locations.push(dataset.ward.name);
           }
 
-          if (locationParts.length > 0) {
-            labelParts.push(`[${locationParts.join(".")}]`);
-          }
-
-          const formattedLabel = labelParts.join(" ");
+          const nameWithLocation = `${name}${
+            locations.length > 0 ? ` [${locations.join(".")}]` : ""
+          }`;
 
           return {
             type: "dataset" as const,
-            name: formattedLabel,
-            index: formattedLabel,
+            name: nameWithLocation,
+            displayName: {
+              primary: name,
+              secondary: locations.length > 0 ? `${locations.join(" ")}` : "",
+            },
+            index: nameWithLocation,
             dataset,
-            title: formattedLabel,
           };
         }) ?? []
     );

--- a/extension/src/prototypes/view/ui-containers/SearchList.tsx
+++ b/extension/src/prototypes/view/ui-containers/SearchList.tsx
@@ -27,7 +27,11 @@ const OptionItem: FC<{
     [option, onClick],
   );
   return (
-    <EntityTitleButton iconComponent={iconComponent} title={option.name} onClick={handleClick} />
+    <EntityTitleButton
+      iconComponent={iconComponent}
+      title={option.displayName ?? option.name}
+      onClick={handleClick}
+    />
   );
 };
 


### PR DESCRIPTION
## Overview

This PR refactors the UI style for search result item. Set the location as secondary title to follow the original design language.

## Screenshot
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/7588d578-79b6-4f78-b90d-b1dd2a6e22f0)
