### PR TITLE
fix: propagate GCP region to Re:Earth and CMS Terraform modules

### DIFF
--- a/terraform/gcp/reearth.tf
+++ b/terraform/gcp/reearth.tf
@@ -6,6 +6,7 @@ module "reearth" {
   dns_managed_zone_name      = google_dns_managed_zone.zone.name
   domain                     = var.domain
   gcp_project_id             = var.gcp_project_id
+  gcp_region                 = var.gcp_region
   mongodb_connection_string  = var.mongodb_connection_string
   reearth_marketplace_secret = var.reearth_marketplace_secret
   reearth_web_config         = var.reearth_web_config

--- a/terraform/gcp/reearth_cms.tf
+++ b/terraform/gcp/reearth_cms.tf
@@ -8,6 +8,7 @@ module "reearth_cms" {
   dns_managed_zone_name     = google_dns_managed_zone.zone.name
   fme_token                 = var.fme_token
   gcp_project_id            = data.google_project.project.project_id
+  gcp_region                = var.gcp_region
   mongodb_connection_string = var.mongodb_connection_string
   plateauview               = var.plateauview
   prefix                    = var.prefix


### PR DESCRIPTION
## Why

Because the values were not passed even though the CMS module has a API:

https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/blob/4cfeac732fbee33edff0c4a53306dcd0a13be0e8/terraform/gcp/modules/reearth_cms/variables.tf#L46-L50

https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/blob/ead5e6727e4721485bd1dc89bf49285fde641c07/terraform/gcp/modules/reearth/variables.tf#L35-L39