### PR TITLE
refactor: max height of search panel on mobile

### DIFF
--- a/extension/src/prototypes/ui-components/AppOverlayLayout.tsx
+++ b/extension/src/prototypes/ui-components/AppOverlayLayout.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@mui/material";
+import { styled, useMediaQuery, useTheme } from "@mui/material";
 import { atom, type Atom, useSetAtom } from "jotai";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
 import { createContext, memo, useEffect, useMemo, useRef, type FC, type ReactNode } from "react";
@@ -204,26 +204,29 @@ export const AppOverlayLayout: FC<AppOverlayLayoutProps> = memo(
     const setMaxMainHeight = useSetAtom(maxMainHeightAtom);
     const setGridHeight = useSetAtom(gridHeightAtom);
 
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
+
     const rootRef = useRef<HTMLDivElement>(null);
     const mainRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
       invariant(rootRef.current != null);
       invariant(mainRef.current != null);
       setGridHeight(rootRef.current.getBoundingClientRect().height);
-      setMaxMainHeight(mainRef.current.getBoundingClientRect().height);
+      setMaxMainHeight(mainRef.current.getBoundingClientRect().height * (isMobile ? 0.75 : 1));
       const observerForRoot = new ResizeObserver(([entry]) => {
         setGridHeight(entry.contentRect.height);
       });
       observerForRoot.observe(rootRef.current);
       const observerForMain = new ResizeObserver(([entry]) => {
-        setMaxMainHeight(entry.contentRect.height);
+        setMaxMainHeight(entry.contentRect.height * (isMobile ? 0.75 : 1));
       });
       observerForMain.observe(mainRef.current);
       return () => {
         observerForRoot.disconnect();
         observerForMain.disconnect();
       };
-    }, [setMaxMainHeight, setGridHeight]);
+    }, [isMobile, setMaxMainHeight, setGridHeight]);
 
     const contextValue = useMemo(
       () => ({ maxMainHeightAtom, gridHeightAtom, searchHeaderHeight: HEADER_HEIGHT + 8 }),

--- a/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetAreaList.tsx
@@ -195,14 +195,14 @@ export const DatasetAreaList: FC = () => {
     },
     [setExpanded],
   );
-  const { gridHeightAtom, searchHeaderHeight } = useContext(AppOverlayLayoutContext);
-  const gridHeight = useAtomValue(gridHeightAtom);
+  const { maxMainHeightAtom, searchHeaderHeight } = useContext(AppOverlayLayoutContext);
+  const maxMainHeight = useAtomValue(maxMainHeightAtom);
 
   return (
     <DatasetTreeView
       expanded={expanded}
       onNodeToggle={handleNodeToggle}
-      maxheight={gridHeight - searchHeaderHeight}>
+      maxheight={maxMainHeight - searchHeaderHeight}>
       <RegionalMeshItem />
       <GlobalItem />
       {query.data?.areas.map(

--- a/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetTypeList.tsx
@@ -172,14 +172,14 @@ export const DatasetTypeList: FC = () => {
     [setExpanded],
   );
 
-  const { gridHeightAtom, searchHeaderHeight } = useContext(AppOverlayLayoutContext);
-  const gridHeight = useAtomValue(gridHeightAtom);
+  const { maxMainHeightAtom, searchHeaderHeight } = useContext(AppOverlayLayoutContext);
+  const maxMainHeight = useAtomValue(maxMainHeightAtom);
 
   return (
     <DatasetTreeView
       expanded={expanded}
       onNodeToggle={handleNodeToggle}
-      maxheight={gridHeight - searchHeaderHeight}>
+      maxheight={maxMainHeight - searchHeaderHeight}>
       {filteredDatasetTypeOrder?.map(datasetType => (
         <DatasetTypeItem
           key={datasetType.id}

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -154,7 +154,10 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
         onChange={handleChange}
         disabled={disabled}>
         {datasets.flatMap((dataset, index) => {
-          if (dataset.items.length) {
+          if (
+            dataset.items.length > 1 ||
+            dataset.type.code === PlateauDatasetType.RiverFloodingRisk
+          ) {
             if (dataset.name === "") {
               return dataset.items.map(datum => (
                 <SelectItem

--- a/extension/src/prototypes/view/ui-containers/SearchList.tsx
+++ b/extension/src/prototypes/view/ui-containers/SearchList.tsx
@@ -1,8 +1,10 @@
 import { Button, ListItemSecondaryAction, ListSubheader, MenuList } from "@mui/material";
-import { useCallback, type FC, type MouseEvent } from "react";
+import { useAtomValue } from "jotai";
+import { useCallback, type FC, type MouseEvent, useContext } from "react";
 
 import {
   AddressIcon,
+  AppOverlayLayoutContext,
   BuildingIcon,
   DatasetIcon,
   EntityTitleButton,
@@ -74,8 +76,11 @@ export const SearchList: FC<SearchListProps> = ({
     [onFiltersChange],
   );
 
+  const { maxMainHeightAtom, searchHeaderHeight } = useContext(AppOverlayLayoutContext);
+  const maxMainHeight = useAtomValue(maxMainHeightAtom);
+
   return (
-    <MenuList component="div" dense>
+    <MenuList component="div" dense sx={{ maxHeight: `${maxMainHeight - searchHeaderHeight}px` }}>
       {datasets.length > 0 && [
         <ListSubheader component="div" key="datasets">
           周辺のデータセット


### PR DESCRIPTION
## Overview

This PR:
- sets the max height to 75% of the main height for search panel.
- always show select items for `fld` in location bread crumb popup.