### PR TITLE
feat(extension): select feature with shift

### DIFF
--- a/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionEvent.ts
+++ b/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionEvent.ts
@@ -1,3 +1,5 @@
+import { PickedFeature } from "../../shared/reearth/types";
+
 export type ScreenSpaceSelectionEventType = "point" | "rectangle" | "imagery";
 export type ScreenSpaceSelectionEventAction = "replace" | "add" | "remove";
 
@@ -10,6 +12,7 @@ export interface PointScreenSpaceSelectionEvent extends ScreenSpaceSelectionEven
   type: "point";
   x: number;
   y: number;
+  feature: PickedFeature | undefined;
 }
 
 export type Rectangle = {
@@ -24,6 +27,7 @@ export interface RectangleScreenSpaceSelectionEvent extends ScreenSpaceSelection
   startPosition: [x: number, y: number];
   endPosition: [x: number, y: number];
   rectangle: Rectangle;
+  features: PickedFeature[] | undefined;
 }
 
 export interface ImageryScreenSpaceSelectionEvent extends ScreenSpaceSelectionEventBase {

--- a/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionHandler.ts
+++ b/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionHandler.ts
@@ -2,8 +2,8 @@
 
 import { Event } from "../../shared/helpers";
 import {
-  LayerSelectWithDragEnd,
-  LayerSelectWithDragMove,
+  LayerSelectWithRectEnd,
+  LayerSelectWithRectMove,
   MouseEvent,
   PickedFeature,
 } from "../../shared/reearth/types";
@@ -73,15 +73,15 @@ export class ScreenSpaceSelectionHandler {
     // it will conflict with pinch motion.
     window.reearth?.on?.("click", this.handleClickOnMobile);
 
-    window.reearth?.on?.("layerSelectWithDragMove", this.handleMouseMove);
-    window.reearth?.on?.("layerSelectWithDragEnd", this.handleMouseUp);
+    window.reearth?.on?.("layerSelectWithRectMove", this.handleMouseMove);
+    window.reearth?.on?.("layerSelectWithRectEnd", this.handleMouseUp);
   }
 
   destroy(): void {
     window.reearth?.off?.("select", this.handleSelect);
     window.reearth?.off?.("click", this.handleClickOnMobile);
-    window.reearth?.off?.("layerSelectWithDragMove", this.handleMouseMove);
-    window.reearth?.off?.("layerSelectWithDragEnd", this.handleMouseUp);
+    window.reearth?.off?.("layerSelectWithRectMove", this.handleMouseMove);
+    window.reearth?.off?.("layerSelectWithRectEnd", this.handleMouseUp);
   }
 
   get disabled(): boolean {
@@ -146,7 +146,7 @@ export class ScreenSpaceSelectionHandler {
     this.change.dispatch(imageryEvent);
   };
 
-  private readonly handleMouseUp = (event: LayerSelectWithDragEnd): void => {
+  private readonly handleMouseUp = (event: LayerSelectWithRectEnd): void => {
     if (this.disabled) {
       return;
     }
@@ -166,7 +166,7 @@ export class ScreenSpaceSelectionHandler {
   };
 
   private readonly handleMouseMove = (
-    event: LayerSelectWithDragMove,
+    event: LayerSelectWithRectMove,
     indeterminate = true,
   ): void => {
     this.moving = true;

--- a/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionHandler.ts
+++ b/extension/src/prototypes/screen-space-selection/ScreenSpaceSelectionHandler.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Event } from "../../shared/helpers";
-import { MouseEvent } from "../../shared/reearth/types";
+import {
+  LayerSelectWithDragEnd,
+  LayerSelectWithDragMove,
+  MouseEvent,
+  PickedFeature,
+} from "../../shared/reearth/types";
 import { DataType } from "../../shared/reearth/types/layer";
 
 import {
@@ -16,6 +21,7 @@ const pointEvent = {
   action: "replace" as ScreenSpaceSelectionEventAction,
   x: 0,
   y: 0,
+  feature: undefined as PickedFeature | undefined,
 } satisfies ScreenSpaceSelectionEvent;
 
 const rectangleEvent = {
@@ -29,6 +35,7 @@ const rectangleEvent = {
     width: 0,
     height: 0,
   },
+  features: undefined as PickedFeature[] | undefined,
 } satisfies ScreenSpaceSelectionEvent;
 
 const IMAGERY_LAYER_TYPE: DataType[] = ["mvt", "wms"];
@@ -41,20 +48,14 @@ const imageryEvent = {
 function actionForModifier(keyName?: string): ScreenSpaceSelectionEventAction {
   // TODO: How we can determine meta key is pressed?
 
-  return keyName === "Shift" ? "add" : "replace";
+  return keyName === "shift" ? "add" : "replace";
 }
 
 export class ScreenSpaceSelectionHandler {
   readonly indeterminate = new Event<ScreenSpaceSelectionEvent>();
   readonly change = new Event<ScreenSpaceSelectionEvent>();
 
-  // private readonly handler: ScreenSpaceEventHandler;
-  private startPosition?: [x: number, y: number];
-
-  private currentKeyName?: string;
-
   private moving?: boolean = false;
-  private downing?: boolean = false;
 
   #disabled = false;
   #allowClickWhenDisabled = false;
@@ -65,11 +66,6 @@ export class ScreenSpaceSelectionHandler {
   };
 
   constructor() {
-    // const handler = new ScreenSpaceEventHandler(scene.canvas);
-
-    window.addEventListener("keydown", this.handleKeyDown);
-
-    // TODO(reearth): Support event with `shift` key
     window.reearth?.on?.("select", this.handleSelect);
 
     // This is for mobile.
@@ -77,19 +73,15 @@ export class ScreenSpaceSelectionHandler {
     // it will conflict with pinch motion.
     window.reearth?.on?.("click", this.handleClickOnMobile);
 
-    window.reearth?.on?.("mousedown", this.handleMouseDown);
-    window.reearth?.on?.("mouseup", this.handleMouseUp);
-    window.reearth?.on?.("mousemove", this.handleMouseMove);
+    window.reearth?.on?.("layerSelectWithDragMove", this.handleMouseMove);
+    window.reearth?.on?.("layerSelectWithDragEnd", this.handleMouseUp);
   }
 
   destroy(): void {
-    window.removeEventListener("keydown", this.handleKeyDown);
-
     window.reearth?.off?.("select", this.handleSelect);
     window.reearth?.off?.("click", this.handleClickOnMobile);
-    window.reearth?.off?.("mousedown", this.handleMouseDown);
-    window.reearth?.off?.("mouseup", this.handleMouseUp);
-    window.reearth?.off?.("mousemove", this.handleMouseMove);
+    window.reearth?.off?.("layerSelectWithDragMove", this.handleMouseMove);
+    window.reearth?.off?.("layerSelectWithDragEnd", this.handleMouseUp);
   }
 
   get disabled(): boolean {
@@ -116,13 +108,9 @@ export class ScreenSpaceSelectionHandler {
     this.#allowedEvents = value;
   }
 
-  private handleKeyDown(e: KeyboardEvent) {
-    this.currentKeyName = e.key;
-  }
-
   private readonly handleClickOnMobile = (event: MouseEvent): void => {
     if (this.disabled && !this.allowClickWhenDisabled) return;
-    this.handleClick([event.x ?? 0, event.y ?? 0], this.currentKeyName);
+    this.handleClick([event.x ?? 0, event.y ?? 0]);
   };
 
   private readonly handleClick = (position: [x: number, y: number], keyName?: string): void => {
@@ -136,6 +124,7 @@ export class ScreenSpaceSelectionHandler {
     pointEvent.action = actionForModifier(keyName);
     pointEvent.x = position[0];
     pointEvent.y = position[1];
+    pointEvent.feature = window.reearth?.scene?.pickManyFromViewport(position, 1, 1)?.[0];
     this.change.dispatch(pointEvent);
   };
 
@@ -157,71 +146,38 @@ export class ScreenSpaceSelectionHandler {
     this.change.dispatch(imageryEvent);
   };
 
-  private readonly handleMouseDown = (event: MouseEvent): void => {
+  private readonly handleMouseUp = (event: LayerSelectWithDragEnd): void => {
     if (this.disabled) {
       return;
     }
-    // TODO(ReEarth): Support selecting multiple feature
-    this.startPosition = [event.x ?? 0, event.y ?? 0];
-    this.downing = true;
+    if (!event.isClick && !this.#allowedEvents.rectangle) return;
+
+    if (event.isClick) {
+      this.handleClick([event.x ?? 0, event.y ?? 0], event.pressedKey);
+      pointEvent.feature = event.features?.[0];
+      this.change.dispatch(pointEvent);
+    } else {
+      this.handleMouseMove(event);
+      rectangleEvent.features = event.features;
+      this.change.dispatch(rectangleEvent);
+    }
+
     this.moving = false;
   };
 
-  private readonly handleMouseUp = (event: MouseEvent): void => {
-    if (this.disabled) {
-      return;
-    }
-
-    if (this.moving) {
-      this.handleMouseMove(event, false);
-      this.moving = false;
-      this.startPosition = undefined;
-      this.downing = false;
-    } else {
-      this.startPosition = undefined;
-      this.downing = false;
-      this.handleClick([event.x ?? 0, event.y ?? 0], this.currentKeyName);
-    }
-  };
-
-  private readonly handleMouseMove = (event: MouseEvent, indeterminate = true): void => {
-    if (this.disabled) {
-      return;
-    }
-    if (!this.allowedEvents.rectangle) {
-      this.moving = true;
-      return;
-    }
-    if (!this.startPosition) {
-      return;
-    }
-    if (!this.downing) {
-      return;
-    }
-
-    let x1 = this.startPosition[0];
-    let y1 = this.startPosition[1];
-    let x2 = event.x ?? 0;
-    let y2 = event.y ?? 0;
-
-    if (x2 - x1 === 0 && y2 - y1 === 0) return;
-
+  private readonly handleMouseMove = (
+    event: LayerSelectWithDragMove,
+    indeterminate = true,
+  ): void => {
     this.moving = true;
-
-    if (x1 > x2) {
-      [x2, x1] = [x1, x2];
-    }
-    if (y1 > y2) {
-      [y2, y1] = [y1, y2];
-    }
     // TODO(ReEarth): Support selecting multiple feature
-    rectangleEvent.action = actionForModifier(this.currentKeyName);
-    rectangleEvent.startPosition = [...this.startPosition];
+    rectangleEvent.action = actionForModifier(event.pressedKey);
+    rectangleEvent.startPosition = [event.startX ?? 0, event.startY ?? 0];
     rectangleEvent.endPosition = [event.x ?? 0, event.y ?? 0];
-    rectangleEvent.rectangle.x = x1;
-    rectangleEvent.rectangle.y = y1;
-    rectangleEvent.rectangle.width = x2 - x1;
-    rectangleEvent.rectangle.height = y2 - y1;
+    rectangleEvent.rectangle.x = event.startX ?? 0;
+    rectangleEvent.rectangle.y = event.startY ?? 0;
+    rectangleEvent.rectangle.width = event.width ?? 0;
+    rectangleEvent.rectangle.height = event.height ?? 0;
     if (indeterminate) {
       this.indeterminate.dispatch(rectangleEvent);
     } else {

--- a/extension/src/prototypes/view/containers/ScreenSpaceSelection.tsx
+++ b/extension/src/prototypes/view/containers/ScreenSpaceSelection.tsx
@@ -2,6 +2,8 @@ import { useMediaQuery, useTheme } from "@mui/material";
 import { useAtomValue } from "jotai";
 import { type FC } from "react";
 
+import { STORY_MARKER_ID_PROPERTY } from "../../../shared/reearth/layers";
+import { PickedFeature } from "../../../shared/reearth/types";
 import {
   ScreenSpaceSelection as PlateauScreenSpaceSelection,
   type ScreenSpaceSelectionProps as PlateauScreenSpaceSelectionProps,
@@ -22,6 +24,9 @@ const EVENTS_ON_STORY_TOOL = {
 
 export type ScreenSpaceSelectionProps = Omit<PlateauScreenSpaceSelectionProps, "disabled">;
 
+const isFeatureStoryCapture = (f: PickedFeature | undefined) =>
+  f?.properties && !!f.properties[STORY_MARKER_ID_PROPERTY];
+
 export const ScreenSpaceSelection: FC<ScreenSpaceSelectionProps> = props => {
   const tool = useAtomValue(toolAtom);
   const theme = useTheme();
@@ -31,6 +36,7 @@ export const ScreenSpaceSelection: FC<ScreenSpaceSelectionProps> = props => {
       {...props}
       disabled={tool?.type !== "select" && tool?.type !== "story"}
       allowClickWhenDisabled={isMobile}
+      filterSelectedFeature={tool?.type === "story" ? isFeatureStoryCapture : undefined}
       allowedEvents={
         isMobile || tool?.type === "select" ? EVENTS_ON_SELECT_TOOL : EVENTS_ON_STORY_TOOL
       }

--- a/extension/src/shared/reearth/layers/index.ts
+++ b/extension/src/shared/reearth/layers/index.ts
@@ -5,3 +5,4 @@ export * from "./pedestrian";
 export * from "./heatmap";
 export * from "./highlightPolygon";
 export * from "./polygon";
+export * from "./story";

--- a/extension/src/shared/reearth/types/event.ts
+++ b/extension/src/shared/reearth/types/event.ts
@@ -20,15 +20,15 @@ export type LayerLoadEvent = {
   layerId: string | undefined;
 };
 
-export type LayerSelectWithDrag = MouseEvent & { pressedKey?: "shift" };
-export type LayerSelectWithDragStart = LayerSelectWithDrag;
-export type LayerSelectWithDragMove = LayerSelectWithDrag & {
+export type LayerSelectWithRect = MouseEvent & { pressedKey?: "shift" };
+export type LayerSelectWithRectStart = LayerSelectWithRect;
+export type LayerSelectWithRectMove = LayerSelectWithRect & {
   startX?: number;
   startY?: number;
   width?: number;
   height?: number;
 };
-export type LayerSelectWithDragEnd = LayerSelectWithDrag & {
+export type LayerSelectWithRectEnd = LayerSelectWithRect & {
   features: PickedFeature[] | undefined;
   isClick?: boolean;
 };
@@ -68,7 +68,7 @@ export type ReearthEventType = {
   ];
   layerVisibility: [e: LayerVisibilityEvent];
   layerload: [e: LayerLoadEvent];
-  layerSelectWithDragStart: [e: LayerSelectWithDragStart];
-  layerSelectWithDragMove: [e: LayerSelectWithDragMove];
-  layerSelectWithDragEnd: [e: LayerSelectWithDragEnd];
+  layerSelectWithRectStart: [e: LayerSelectWithRectStart];
+  layerSelectWithRectMove: [e: LayerSelectWithRectMove];
+  layerSelectWithRectEnd: [e: LayerSelectWithRectEnd];
 };

--- a/extension/src/shared/reearth/types/event.ts
+++ b/extension/src/shared/reearth/types/event.ts
@@ -1,4 +1,5 @@
 import { CameraPosition } from "./camera";
+import { PickedFeature } from "./scene";
 import { SketchFeature } from "./sketch";
 
 export type MouseEvent = {
@@ -17,6 +18,19 @@ export type LayerVisibilityEvent = {
 
 export type LayerLoadEvent = {
   layerId: string | undefined;
+};
+
+export type LayerSelectWithDrag = MouseEvent & { pressedKey?: "shift" };
+export type LayerSelectWithDragStart = LayerSelectWithDrag;
+export type LayerSelectWithDragMove = LayerSelectWithDrag & {
+  startX?: number;
+  startY?: number;
+  width?: number;
+  height?: number;
+};
+export type LayerSelectWithDragEnd = LayerSelectWithDrag & {
+  features: PickedFeature[] | undefined;
+  isClick?: boolean;
 };
 
 export type ReearthEventType = {
@@ -54,4 +68,7 @@ export type ReearthEventType = {
   ];
   layerVisibility: [e: LayerVisibilityEvent];
   layerload: [e: LayerLoadEvent];
+  layerSelectWithDragStart: [e: LayerSelectWithDragStart];
+  layerSelectWithDragMove: [e: LayerSelectWithDragMove];
+  layerSelectWithDragEnd: [e: LayerSelectWithDragEnd];
 };


### PR DESCRIPTION
Need: https://github.com/reearth/reearth/pull/932

I added support a feature to keep selecting the layer's feature with shift key. 

## Test
- In select mode, you can keep selecting the layer's feature with shift key.