### PR TITLE
fix(extension): DRAFT clear store and global vars when scene id changed

### DIFF
--- a/extension/src/editor/Widget.tsx
+++ b/extension/src/editor/Widget.tsx
@@ -1,15 +1,24 @@
-import { useAtomValue } from "jotai";
+import { Provider, useAtomValue } from "jotai";
 import { memo } from "react";
 
 import { readyAtom } from "../prototypes/view/states/app";
 import { WidgetContext } from "../shared/context/WidgetContext";
 import { inEditor } from "../shared/reearth/utils";
+import { store } from "../shared/states/store";
 
 import { Editor } from "./containers";
 
-export const Widget = memo(function WidgetPresenter() {
+const WidgetContent = memo(function WidgetPresenter() {
   const enabled = inEditor();
   const ready = useAtomValue(readyAtom);
 
   return enabled ? <WidgetContext>{ready && <Editor />}</WidgetContext> : null;
+});
+
+export const Widget = memo(() => {
+  return (
+    <Provider store={store}>
+      <WidgetContent />
+    </Provider>
+  );
 });

--- a/extension/src/inspector/Widget.tsx
+++ b/extension/src/inspector/Widget.tsx
@@ -1,15 +1,25 @@
+import { Provider } from "jotai";
 import { memo } from "react";
 
 import { AppOverlay } from "../prototypes/view/ui-containers/AppOverlay";
 import { WidgetContext } from "../shared/context/WidgetContext";
+import { store } from "../shared/states/store";
 import { PLATEAUVIEW_INSPECTOR_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 
-export const Widget = memo(function WidgetPresenter() {
+const WidgetContent = memo(function WidgetPresenter() {
   return (
     <div id={PLATEAUVIEW_INSPECTOR_DOM_ID}>
       <WidgetContext>
         <AppOverlay type="aside" width={320} height={0} />
       </WidgetContext>
     </div>
+  );
+});
+
+export const Widget = memo(() => {
+  return (
+    <Provider store={store}>
+      <WidgetContent />
+    </Provider>
   );
 });

--- a/extension/src/search/Widget.tsx
+++ b/extension/src/search/Widget.tsx
@@ -1,17 +1,26 @@
-import { useAtomValue } from "jotai";
+import { Provider, useAtomValue } from "jotai";
 import { memo } from "react";
 
 import { readyAtom } from "../prototypes/view/states/app";
 import { AppOverlay } from "../prototypes/view/ui-containers/AppOverlay";
 import { WidgetContext } from "../shared/context/WidgetContext";
+import { store } from "../shared/states/store";
 import { PLATEAUVIEW_SEARCH_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 
-export const Widget = memo(function WidgetPresenter() {
+const WidgetContent = memo(function WidgetPresenter() {
   const ready = useAtomValue(readyAtom);
 
   return (
     <div id={PLATEAUVIEW_SEARCH_DOM_ID}>
       <WidgetContext>{ready && <AppOverlay type="main" width={360} height={81} />}</WidgetContext>
     </div>
+  );
+});
+
+export const Widget = memo(() => {
+  return (
+    <Provider store={store}>
+      <WidgetContent />
+    </Provider>
   );
 });

--- a/extension/src/shared/constants/api.ts
+++ b/extension/src/shared/constants/api.ts
@@ -56,3 +56,17 @@ export let PLATEAU_GEOJSON_URL: string | undefined;
 export const setPlateauGeojsonUrl = (url: string) => {
   PLATEAU_GEOJSON_URL = url;
 };
+
+export const resetAPIValues = () => {
+  setPlateauApiUrl("");
+  setProjectId("");
+  setGeoApiUrl("");
+  setGISTileURL("");
+  setGoogleStreetViewAPIKey("");
+  setCityName("");
+  setPrimaryColor("");
+  setLogo("");
+  setSiteURL("");
+  setInitialPededstrianCoordinates(undefined);
+  setPlateauGeojsonUrl("");
+};

--- a/extension/src/shared/constants/instance.ts
+++ b/extension/src/shared/constants/instance.ts
@@ -1,0 +1,4 @@
+export let PLATEAU_INSTANCE_ID: string | undefined;
+export const setPlateauInstanceId = (id: string) => {
+  PLATEAU_INSTANCE_ID = id;
+};

--- a/extension/src/shared/states/store.ts
+++ b/extension/src/shared/states/store.ts
@@ -1,0 +1,5 @@
+import { createStore } from "jotai";
+
+export let store = createStore();
+
+export const resetStore = () => (store = createStore());

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -72,56 +72,54 @@ const WidgetContent: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
 
   return (
     <div id={PLATEAUVIEW_TOOLBAR_DOM_ID}>
-      <Provider store={store}>
-        <WidgetContext
-          inEditor={inEditor}
-          plateauUrl={widget.property.default.plateauURL}
-          projectId={widget.property.default.projectName}
-          plateauToken={widget.property.default.plateauAccessToken}
-          catalogUrl={widget.property.default.catalogURL}
-          catalogURLForAdmin={widget.property.default.catalogURLForAdmin}
-          geoUrl={widget.property.default.geoURL}
-          gsiTileURL={widget.property.default.gsiTileURL}
-          googleStreetViewAPIKey={widget.property.default.googleStreetViewAPIKey}
-          geojsonURL={widget.property.default.geojsonURL}
-          cityName={widget.property.optional?.cityName}
-          customPrimaryColor={widget.property.optional?.primaryColor}
-          customLogo={widget.property.optional?.logo}
-          customPedestrian={widget.property.optional?.pedestrian}
-          customSiteUrl={widget.property.optional?.siteUrl}>
-          <InitializeApp />
-          <AppFrame header={<AppHeader arURL={widget.property.default.arURL} />} />
-          {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}
-          <Loading />
-          {/* <Suspense>
+      <WidgetContext
+        inEditor={inEditor}
+        plateauUrl={widget.property.default.plateauURL}
+        projectId={widget.property.default.projectName}
+        plateauToken={widget.property.default.plateauAccessToken}
+        catalogUrl={widget.property.default.catalogURL}
+        catalogURLForAdmin={widget.property.default.catalogURLForAdmin}
+        geoUrl={widget.property.default.geoURL}
+        gsiTileURL={widget.property.default.gsiTileURL}
+        googleStreetViewAPIKey={widget.property.default.googleStreetViewAPIKey}
+        geojsonURL={widget.property.default.geojsonURL}
+        cityName={widget.property.optional?.cityName}
+        customPrimaryColor={widget.property.optional?.primaryColor}
+        customLogo={widget.property.optional?.logo}
+        customPedestrian={widget.property.optional?.pedestrian}
+        customSiteUrl={widget.property.optional?.siteUrl}>
+        <InitializeApp />
+        <AppFrame header={<AppHeader arURL={widget.property.default.arURL} />} />
+        {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}
+        <Loading />
+        {/* <Suspense>
         <SuspendUntilTilesLoaded
           initialTileCount={35}
           remainingTileCount={30}
           onComplete={handleTilesLoadComplete}> */}
-          <LayersRenderer components={layerComponents} />
-          {/* </SuspendUntilTilesLoaded>
+        <LayersRenderer components={layerComponents} />
+        {/* </SuspendUntilTilesLoaded>
       </Suspense> */}
-          <Environments />
-          <ToolMachineEvents />
-          <Notifications />
-          <InitialLayers />
-          <JapanPlateauPolygon />
-          <SelectionCoordinator />
-          <KeyBindings />
-          <ScreenSpaceSelection />
-          <FileDrop />
-          <ScreenSpaceCamera tiltByRightButton />
-          <HighlightedAreas />
-          <ReverseGeocoding />
-          <PedestrianTool />
-          <SketchTool />
-          <MyData />
-          <Help />
-          <AutoRotateCamera />
-          <FeedBack />
-          <StoryCreator />
-        </WidgetContext>
-      </Provider>
+        <Environments />
+        <ToolMachineEvents />
+        <Notifications />
+        <InitialLayers />
+        <JapanPlateauPolygon />
+        <SelectionCoordinator />
+        <KeyBindings />
+        <ScreenSpaceSelection />
+        <FileDrop />
+        <ScreenSpaceCamera tiltByRightButton />
+        <HighlightedAreas />
+        <ReverseGeocoding />
+        <PedestrianTool />
+        <SketchTool />
+        <MyData />
+        <Help />
+        <AutoRotateCamera />
+        <FeedBack />
+        <StoryCreator />
+      </WidgetContext>
     </div>
   );
 });


### PR DESCRIPTION
## Overview

This PR trys to clear store and global vars when user navigate between different view 3.0 projects in reearth editor.
I'm not confident on this implement so titled as `DRAFT`. For me it looks a little bit risky.

In detail:
- Wrap all widgets with jotai Provider.
- In Toolbar check the scene id from url and reset store and global vars if it changes.