### PR TITLE
refactor(extension): hide elevation legend button on mobile

### DIFF
--- a/extension/src/prototypes/ui-components/Inspector.tsx
+++ b/extension/src/prototypes/ui-components/Inspector.tsx
@@ -10,7 +10,9 @@ import { forwardRef } from "react";
 import { AutoHeight } from "./AutoHeight";
 import { Scrollable } from "./Scrollable";
 
-const StyledPaper = styled(Paper)(({ theme, elevation = 4 }) => ({
+const StyledPaper = styled(Paper, {
+  shouldForwardProp: props => props !== "maxWidth",
+})(({ theme, elevation = 4 }) => ({
   position: "relative",
   maxHeight: "100%",
   boxShadow: theme.shadows[elevation],

--- a/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/EnvironmentSelect.tsx
@@ -1,4 +1,14 @@
-import { alpha, Button, Popover, styled, Divider, FormControlLabel, Switch } from "@mui/material";
+import {
+  alpha,
+  Button,
+  Popover,
+  styled,
+  Divider,
+  FormControlLabel,
+  Switch,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import { useAtom, useAtomValue } from "jotai";
 import { bindPopover, bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { useCallback, useId, type FC, type ChangeEvent } from "react";
@@ -241,6 +251,9 @@ export const EnvironmentSelect: FC = () => {
     [setShowMapLabel],
   );
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
+
   return (
     <>
       <AppIconButton
@@ -250,7 +263,7 @@ export const EnvironmentSelect: FC = () => {
         {...bindTrigger(popupState)}>
         <MapIcon />
       </AppIconButton>
-      {selectedItem === "elevation" && <ElevationLegendButton />}
+      {selectedItem === "elevation" && !isMobile && <ElevationLegendButton />}
       <OverlayPopper {...popoverProps} inset={1.5}>
         <FloatingPanel>
           <Item item="light-map" selectedItem={selectedItem} onClick={handleLightMap} />


### PR DESCRIPTION
## Overview

Hide this button on mobile:
![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/485776f9-6516-4669-b199-78f87d69bc20)

Also fix a small issue that forwarded `maxWidth` prop on a DOM element which leading to error msg throw out.
