### PR TITLE
fix(extension): show building model for Hamamatsu city

### DIFF
--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useMemo, type FC } from "react";
 import invariant from "tiny-invariant";
 
 import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
+import { CITY_CODES_FOR_BUILDING_MODEL } from "../../../shared/plateau";
 import { rootLayersAtom } from "../../../shared/states/rootLayer";
 import { settingsAtom } from "../../../shared/states/setting";
 import { templatesAtom } from "../../../shared/states/template";
@@ -58,8 +59,6 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
     // Assume that all the datasets share the same type.
     const layerType =
       datasetTypeLayers[datasets[0].type.code as PlateauDatasetType] ?? datasetTypeLayers.usecase;
-
-    invariant(layerType !== "BUILDING_LAYER", "Building layer is not supported.");
 
     const datasetIds = useMemo(() => datasets.map(d => d.id), [datasets]);
 
@@ -173,6 +172,30 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
                 </SelectItem>
               ));
             }
+            return [
+              <SelectGroupItem key={index} size="small">
+                {dataset.name}
+              </SelectGroupItem>,
+              ...dataset.items.map(datum => (
+                <SelectItem
+                  key={datum.id}
+                  indent={1}
+                  value={serializeParams({
+                    datasetId: dataset.id,
+                    datumId: datum.id,
+                  })}>
+                  <Typography variant="body2">
+                    {datum.name}
+                    {showDataFormats ? ` (${datum.format})` : null}
+                  </Typography>
+                </SelectItem>
+              )),
+            ];
+          }
+          if (
+            dataset.type.code === PlateauDatasetType.Building &&
+            CITY_CODES_FOR_BUILDING_MODEL.includes(dataset.cityCode)
+          ) {
             return [
               <SelectGroupItem key={index} size="small">
                 {dataset.name}

--- a/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
@@ -4,6 +4,7 @@ import { useCallback, useId, useMemo, useState, type FC, type MouseEvent } from 
 import invariant from "tiny-invariant";
 
 import { useAreaDatasets, useDatasetTypes } from "../../../shared/graphql";
+import { CITY_CODES_FOR_BUILDING_MODEL } from "../../../shared/plateau";
 import { Area } from "../../../shared/states/address";
 import { isNotNullish } from "../../type-helpers";
 import { AppBreadcrumbsItem, ContextBar, OverlayPopper } from "../../ui-components";
@@ -36,7 +37,9 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
         datasets.filter(d =>
           !d.cityCode
             ? d.prefectureCode === area.code
-            : !d.wardCode
+            : !d.wardCode ||
+              (d.type.code === PlateauDatasetType.Building &&
+                CITY_CODES_FOR_BUILDING_MODEL.includes(d.cityCode))
             ? d.cityCode === area.code
             : d.wardCode === area.code,
         ),

--- a/extension/src/shared/plateau/constants.ts
+++ b/extension/src/shared/plateau/constants.ts
@@ -22,3 +22,8 @@ export const FEATURE_PROPERTIES_CONFIG = [
 ];
 
 export const BUILDING_FEATURE_TYPE = "bldg:Building";
+
+// Some area codes are changed due to some goverment reason, but digital data isn't updated yet.
+// Then we can't get the actual area code for each ward from API.
+// But we can get city's code, so we need to show the data for ward as city.
+export const CITY_CODES_FOR_BUILDING_MODEL = ["22130"];

--- a/extension/src/shared/plateau/index.ts
+++ b/extension/src/shared/plateau/index.ts
@@ -1,2 +1,3 @@
 export * from "./layers";
 export * from "./featureInspector";
+export * from "./constants";


### PR DESCRIPTION
Hammatsu city has some ward, but these are merged into one ward in this year. However the digital government data which is used to find the city from ward in geo API is still not updated. So we need to use workaround for this part to show the several building model's data for wards only in Hamamatsu city.

## Test
- Search `浜松市`, and select something data, and move the camera for the data.
- Then layer shortcut should show some dataset for building model as list like flood model.
![Screenshot 2024-03-25 at 16 03 40](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/d69d02f6-9c58-4408-a505-d38190fccd5b)
