### PR TITLE
fix(extension): order shifting on type list

### DIFF
--- a/extension/src/shared/graphql/hooks/catalog/datasetType.ts
+++ b/extension/src/shared/graphql/hooks/catalog/datasetType.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 
 import { DatasetTypesInput } from "../../base/catalog/__gen__/graphql";
 import { DATASET_TYPES } from "../../base/catalog/queries/datasetType";
@@ -17,10 +17,15 @@ export const useDatasetTypes = (input?: DatasetTypesInput, options?: Options) =>
     skip: options?.skip,
   });
 
-  const nextData = useMemo(
-    () => data?.datasetTypes.slice().sort((a, b) => a.order - b.order),
-    [data],
+  const [datasetTypes, setDatasetTypes] = useState(
+    data?.datasetTypes.slice().sort((a, b) => a.order - b.order),
   );
 
-  return { data: nextData, ...rest };
+  useEffect(() => {
+    if (data?.datasetTypes && !datasetTypes) {
+      setDatasetTypes(data.datasetTypes.slice().sort((a, b) => a.order - b.order));
+    }
+  }, [data?.datasetTypes, datasetTypes]);
+
+  return { data: datasetTypes, ...rest };
 };


### PR DESCRIPTION
## Overveiw

This PR fixes the order shifting with using the initial type data and ignore the later data.