### PR TITLE
feat(extension): add component to apply empty sphericalHarmonicCoefficients

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetApplyEmptySHCField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetApplyEmptySHCField.tsx
@@ -1,0 +1,8 @@
+import { BasicFieldProps } from "..";
+import { PropertyInfo } from "../../../../ui-components";
+
+export const EditorTilesetApplyEmptySHCField: React.FC<
+  BasicFieldProps<"TILESET_APPLY_EMPTY_SHC">
+> = () => {
+  return <PropertyInfo>Apply Empty Spherical Harmonic Coefficients</PropertyInfo>;
+};

--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/index.ts
@@ -1,6 +1,7 @@
 import { SettingComponent } from "../../../../../shared/api/types";
 import { ComponentBase } from "../../../../../shared/types/fieldComponents";
 
+import { EditorTilesetApplyEmptySHCField } from "./3dtiles/EditorTilesetApplyEmptySHCField";
 import { EditorTilesetBuildingModelColorField } from "./3dtiles/EditorTilesetBuildingModelColorField";
 import { EditorTilesetBuildingModelFilterField } from "./3dtiles/EditorTilesetBuildingModelFilterField";
 import { EditorTilesetClippingField } from "./3dtiles/EditorTilesetClippingField";
@@ -402,6 +403,11 @@ export const fields: {
     category: FIELD_CATEGORY_THREE_D_TILES,
     name: "Disable Default Material",
     Component: EditorDisableDefaultMaterialField,
+  },
+  TILESET_APPLY_EMPTY_SHC: {
+    category: FIELD_CATEGORY_THREE_D_TILES,
+    name: "Apply Empty SHC",
+    Component: EditorTilesetApplyEmptySHCField,
   },
 };
 

--- a/extension/src/shared/layerContainers/buildingModel.tsx
+++ b/extension/src/shared/layerContainers/buildingModel.tsx
@@ -21,6 +21,7 @@ import {
   TILESET_WIREFRAME,
   TILESET_DISABLE_DEFAULT_MATERIAL,
   TILESET_DRAW_CLIPPING,
+  TILESET_APPLY_EMPTY_SHC,
 } from "../types/fieldComponents/3dtiles";
 import { OPACITY_FIELD } from "../types/fieldComponents/general";
 import { SearchedFeatures } from "../view-layers";
@@ -146,6 +147,8 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
     TILESET_DISABLE_DEFAULT_MATERIAL,
   );
 
+  const applyEmptySHCAtom = useFindComponent(componentAtoms, TILESET_APPLY_EMPTY_SHC);
+
   const hiddenFeatures = useAtomValue(hiddenFeaturesAtom);
   const hiddenFeaturesConditions: ConditionsExpression = useMemo(
     () => ({
@@ -184,6 +187,7 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
   const opacity = useOptionalAtomValue(opacityAtom);
   const wireframeView = useOptionalAtomValue(wireframeAtom);
   const disableDefaultMaterial = useOptionalAtomValue(disableDefaultMaterialAtom);
+  const applyEmptySHC = useOptionalAtomValue(applyEmptySHCAtom);
 
   const color = useEvaluateFeatureColor({
     colorProperty: buildingModelColorAtom ? colorProperty ?? undefined : undefined,
@@ -224,6 +228,7 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
       experimental_clipping: { ...clippingBox, ...drawClipping },
       showWireframe: wireframeView?.value?.wireframe,
       disableIndexingFeature: isMobile,
+      ...(applyEmptySHC ? { sphericalHarmonicCoefficients: [] } : {}),
     }),
     [
       textured,
@@ -238,6 +243,7 @@ export const BuildingModelLayerContainer: FC<TilesetContainerProps> = ({
       wireframeView,
       disableDefaultMaterial,
       isMobile,
+      applyEmptySHC,
     ],
   );
 

--- a/extension/src/shared/layerContainers/floodModel.tsx
+++ b/extension/src/shared/layerContainers/floodModel.tsx
@@ -19,6 +19,7 @@ import {
   TILESET_FLOOD_MODEL_COLOR,
   TILESET_FLOOD_MODEL_FILTER,
   TILESET_DISABLE_DEFAULT_MATERIAL,
+  TILESET_APPLY_EMPTY_SHC,
 } from "../types/fieldComponents/3dtiles";
 import { OPACITY_FIELD } from "../types/fieldComponents/general";
 import { hexToRGBArray } from "../utils";
@@ -130,6 +131,8 @@ export const FloodModelLayerContainer: FC<TilesetContainerProps> = ({
     TILESET_DISABLE_DEFAULT_MATERIAL,
   );
 
+  const applyEmptySHCAtom = useFindComponent(componentAtoms, TILESET_APPLY_EMPTY_SHC);
+
   // Field components
   const opacityAtom = useFindComponent(componentAtoms, OPACITY_FIELD);
   const floodModelColorAtom = useFindComponent(componentAtoms, TILESET_FLOOD_MODEL_COLOR);
@@ -139,6 +142,7 @@ export const FloodModelLayerContainer: FC<TilesetContainerProps> = ({
   );
 
   const disableDefaultMaterial = useOptionalAtomValue(disableDefaultMaterialAtom);
+  const applyEmptySHC = useOptionalAtomValue(applyEmptySHCAtom);
   const theme = useTheme();
 
   const primaryRGB = useMemo(() => hexToRGBArray(theme.palette.primary.main), [theme]);
@@ -172,8 +176,16 @@ export const FloodModelLayerContainer: FC<TilesetContainerProps> = ({
       },
       shadows: "disabled",
       selectedFeatureColor: theme.palette.primary.main,
+      ...(applyEmptySHC ? { sphericalHarmonicCoefficients: [] } : {}),
     }),
-    [color, colorProperty, theme.palette.primary.main, filter, disableDefaultMaterial],
+    [
+      color,
+      colorProperty,
+      theme.palette.primary.main,
+      filter,
+      disableDefaultMaterial,
+      applyEmptySHC,
+    ],
   );
 
   return (

--- a/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
+++ b/extension/src/shared/layerContainers/hooks/useEvaluateGeneralAppearance.ts
@@ -10,6 +10,7 @@ import {
   TILESET_WIREFRAME,
   TILESET_DISABLE_DEFAULT_MATERIAL,
   TILESET_DRAW_CLIPPING,
+  TILESET_APPLY_EMPTY_SHC,
 } from "../../types/fieldComponents/3dtiles";
 import { OPACITY_FIELD, STYLE_CODE_FIELD } from "../../types/fieldComponents/general";
 import {
@@ -180,6 +181,9 @@ export const useEvaluateGeneralAppearance = ({
   const tilesetDisableDefaultMaterial = useOptionalAtomValue(
     useFindComponent(componentAtoms ?? [], TILESET_DISABLE_DEFAULT_MATERIAL),
   );
+  const tilesetApplyEmptySHC = useOptionalAtomValue(
+    useFindComponent(componentAtoms ?? [], TILESET_APPLY_EMPTY_SHC),
+  );
 
   // General
   const opacity = useOptionalAtomValue(useFindComponent(componentAtoms ?? [], OPACITY_FIELD));
@@ -316,6 +320,7 @@ export const useEvaluateGeneralAppearance = ({
           experimental_clipping: { ...clippingBox, ...drawClipping },
           disableSelection: clippingBox?.disabledSelection,
           showWireframe: tilesetWireframe?.value?.wireframe,
+          ...(tilesetApplyEmptySHC ? { sphericalHarmonicCoefficients: [] } : {}),
         },
         box: boxAppearance,
       }),
@@ -358,6 +363,7 @@ export const useEvaluateGeneralAppearance = ({
       drawClipping,
       tilesetWireframe?.value?.wireframe,
       tilesetDisableDefaultMaterial,
+      tilesetApplyEmptySHC,
       boxAppearance,
       opacity,
     ],

--- a/extension/src/shared/types/fieldComponents/3dtiles.ts
+++ b/extension/src/shared/types/fieldComponents/3dtiles.ts
@@ -104,6 +104,11 @@ export type TileSetDefaultMaterialField = FieldBase<{
   type: typeof TILESET_DISABLE_DEFAULT_MATERIAL;
 }>;
 
+export const TILESET_APPLY_EMPTY_SHC = "TILESET_APPLY_EMPTY_SHC";
+export type TilesetApplyEmptySHCField = FieldBase<{
+  type: typeof TILESET_APPLY_EMPTY_SHC;
+}>;
+
 export type TilesetFields =
   | TilesetBuildingModelColorField
   | TilesetFloodModelColorField
@@ -115,4 +120,5 @@ export type TilesetFields =
   | TilesetBuildingModelFilterField
   | TilesetFloodModelFilterField
   | TilesetWireframeField
-  | TileSetDefaultMaterialField;
+  | TileSetDefaultMaterialField
+  | TilesetApplyEmptySHCField;

--- a/extension/src/shared/view/fields/fieldSettings.ts
+++ b/extension/src/shared/view/fields/fieldSettings.ts
@@ -253,4 +253,5 @@ export const fieldSettings: {
     hasLayerUI: true,
   },
   TILESET_DISABLE_DEFAULT_MATERIAL: {},
+  TILESET_APPLY_EMPTY_SHC: {},
 };


### PR DESCRIPTION
## Overview

This PR adds a new field component to set sphericalHarmonicCoefficients to `[]` on 3dtiles.

## Screenshot

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/7aaf1e7e-cf2d-4916-b7c9-674d7b5375c5)

## Test

Test with dataset `ストーリーテリング型GISを用いたエリアマネジメントの高度化/作成した3D都市モデル/高輪ゲートウェイシティ 1街区（港区）`