### PR TITLE
refactor(extension): open markdown link in new tab

### DIFF
--- a/extension/src/shared/ui-components/common/ViewMarkdownViewer.tsx
+++ b/extension/src/shared/ui-components/common/ViewMarkdownViewer.tsx
@@ -7,7 +7,11 @@ type ViewMarkdownViewerProps = {
 };
 
 export const ViewMarkdownViewer: FC<ViewMarkdownViewerProps> = ({ content }) => {
-  return <StyledMarkdown skipHtml>{content}</StyledMarkdown>;
+  return (
+    <StyledMarkdown skipHtml components={{ a: LinkRenderer }}>
+      {content}
+    </StyledMarkdown>
+  );
 };
 
 const StyledMarkdown = styled(Markdown)(({ theme }) => ({
@@ -46,3 +50,11 @@ const StyledMarkdown = styled(Markdown)(({ theme }) => ({
     margin: 0,
   },
 }));
+
+function LinkRenderer(props: any) {
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
+}

--- a/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
+++ b/extension/src/shared/view/fields/general/LayerDatasetStoryField.tsx
@@ -44,7 +44,9 @@ export const LayerDatasetStoryField: FC<LayerDatasetStoryFieldProps> = ({ atoms 
   return component?.preset?.pages?.length > 0 ? (
     <ParameterList>
       <CommonContentWrapper>
-        <Markdown skipHtml>{component.preset.pages[currentPage].content}</Markdown>
+        <Markdown skipHtml components={{ a: LinkRenderer }}>
+          {component.preset.pages[currentPage].content}
+        </Markdown>
         <PaginationWrapper>
           <StyledPagination
             count={component.preset.pages.length}
@@ -60,3 +62,11 @@ export const LayerDatasetStoryField: FC<LayerDatasetStoryFieldProps> = ({ atoms 
     </ParameterList>
   ) : null;
 };
+
+function LinkRenderer(props: any) {
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
+}

--- a/extension/src/shared/view/fields/general/LayerLayerDescriptionField.tsx
+++ b/extension/src/shared/view/fields/general/LayerLayerDescriptionField.tsx
@@ -16,8 +16,16 @@ export const LayerLayerDescriptionField: FC<LayerLayerDescriptionFieldProps> = (
   return component.preset?.description ? (
     <ParameterList>
       <CommonContentWrapper>
-        <Markdown skipHtml>{component.preset?.description}</Markdown>
+        <Markdown skipHtml components={{ a: LinkRenderer }}>{component.preset?.description}</Markdown>
       </CommonContentWrapper>
     </ParameterList>
   ) : null;
 };
+
+function LinkRenderer(props: any) {
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
+}

--- a/extension/src/shared/view/selection/LegendDescriptionSection.tsx
+++ b/extension/src/shared/view/selection/LegendDescriptionSection.tsx
@@ -32,7 +32,17 @@ export const LegendDescriptionSection: FC<LegendDescriptionSectionProps> = ({ va
 
   return legendDescription?.preset?.description ? (
     <CommonContentWrapper>
-      <Markdown skipHtml>{legendDescription?.preset?.description}</Markdown>
+      <Markdown skipHtml components={{ a: LinkRenderer }}>
+        {legendDescription?.preset?.description}
+      </Markdown>
     </CommonContentWrapper>
   ) : null;
 };
+
+function LinkRenderer(props: any) {
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Overview

This PR refactors the link component for markdown to open links in new tab.