### PR TITLE
refactor(extension): update frustum color

### DIFF
--- a/extension/src/prototypes/pedestrian/StreetViewFrustum.tsx
+++ b/extension/src/prototypes/pedestrian/StreetViewFrustum.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from "@mui/material";
 import { animate, useMotionValue, usePresence } from "framer-motion";
 import { useEffect, type FC, useMemo, useCallback, useState, useRef } from "react";
 
@@ -23,8 +22,6 @@ export const StreetViewFrustum: FC<StreetViewFrustumProps> = ({
   aspectRatio = 3 / 2,
   length = 200,
 }) => {
-  const theme = useTheme();
-
   const [ready, setReady] = useState(false);
   const handleLoad = useCallback(() => {
     setReady(true);
@@ -89,7 +86,7 @@ export const StreetViewFrustum: FC<StreetViewFrustumProps> = ({
   const frustumAppearance: PedestrianFrustumAppearances = useMemo(
     () => ({
       frustum: {
-        color: theme.palette.primary.main,
+        color: "#00E0E0",
         opacity,
         zoom,
         length,
@@ -99,7 +96,7 @@ export const StreetViewFrustum: FC<StreetViewFrustumProps> = ({
         rotate: [headingPitch.heading, headingPitch.pitch, 0],
       },
     }),
-    [theme, zoom, length, aspectRatio, headingPitch, opacity],
+    [zoom, length, aspectRatio, headingPitch, opacity],
   );
 
   return (


### PR DESCRIPTION
## Overview

The frustum color looks a little bit darker than prototype since View 3.0 project doesn't hide underground by default. We need to change the color manually to make it looks more close to prototype's appearance.

| Before | After |
| -- | -- |
|![WX20240402-173711](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/b0bae017-0ed3-4f82-8601-4247d47a9b00) |![WX20240402-173635](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/57b71e89-1577-40f3-bab8-367c13deb913) |