### PR TITLE
fix(extension): override building model color

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelColorField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelColorField.tsx
@@ -1,8 +1,232 @@
+import MonacoEditor from "@monaco-editor/react";
+import CheckOutlinedIcon from "@mui/icons-material/CheckOutlined";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import { styled, svgIconClasses } from "@mui/material";
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import { BasicFieldProps } from "..";
-import { PropertyInfo } from "../../../../ui-components";
+import {
+  EditorDialog,
+  PropertyBox,
+  PropertyButton,
+  PropertyInfo,
+  PropertyInlineWrapper,
+  PropertyWrapper,
+} from "../../../../ui-components";
+
+const options = {
+  bracketPairColorization: {
+    enabled: true,
+  },
+  automaticLayout: true,
+  minimap: {
+    enabled: false,
+  },
+  selectOnLineNumbers: true,
+  fontSize: 12,
+};
+
+export type TilesetBuildingModelColorFieldPreset = {
+  code: string;
+  overrides:
+    | {
+        propertyName?: string;
+        title?: string;
+        matcher?: "equal" | "startsWith" | "endsWith";
+        colorSet?: { value?: string | number; color?: string; name?: string }[];
+      }[]
+    | undefined;
+};
 
 export const EditorTilesetBuildingModelColorField: React.FC<
   BasicFieldProps<"TILESET_BUILDING_MODEL_COLOR">
-> = () => {
-  return <PropertyInfo preset="no-settings" />;
+> = props => {
+  return <JSONField {...props} />;
 };
+
+const JSONField: React.FC<BasicFieldProps<"TILESET_BUILDING_MODEL_COLOR">> = ({
+  component,
+  onUpdate,
+}) => {
+  const [editorCode, setEditorCode] = useState<string | undefined>(component.preset?.code);
+  const [codeValid, setCodeValid] = useState<boolean | undefined>();
+
+  const handleCodeChange = useCallback(
+    (code: string | undefined) => {
+      if (!code) return;
+      try {
+        const json = JSON.parse(code) as TilesetBuildingModelColorFieldPreset | undefined;
+        console.log("EDITOR", json);
+        onUpdate({
+          ...component,
+          preset: {
+            ...component.preset,
+            code,
+            overrides: json?.overrides,
+          },
+        });
+        setCodeValid(true);
+      } catch (error) {
+        setCodeValid(false);
+      }
+    },
+    [component, onUpdate],
+  );
+
+  const handleCodeChangeRef = useRef(handleCodeChange);
+  handleCodeChangeRef.current = handleCodeChange;
+  useEffect(() => {
+    handleCodeChangeRef.current(editorCode);
+  }, [editorCode]);
+
+  const [fullsizeEditorOpen, setFullsizeEditorOpen] = useState(false);
+  const openFullsizeEditor = useCallback(() => {
+    setEditorCode(editorCode);
+    setFullsizeEditorOpen(true);
+  }, [editorCode]);
+  const closeFullsizeEditor = useCallback(() => {
+    setFullsizeEditorOpen(false);
+  }, []);
+
+  const handleEditorCodeChange = useCallback(
+    (code: string | undefined) => {
+      setEditorCode(code);
+    },
+    [setEditorCode],
+  );
+  const submitEditorCode = useCallback(() => {
+    closeFullsizeEditor();
+  }, [closeFullsizeEditor]);
+
+  const handleApplyTemplate = useCallback(() => {
+    handleEditorCodeChange(TEMPLATE_CODE);
+  }, [handleEditorCodeChange]);
+
+  return (
+    <PropertyWrapper>
+      <PropertyBox>
+        <PropertyButton onClick={handleApplyTemplate}>Fill with Template</PropertyButton>
+        <CodeEditorWrapper>
+          <StyledMonacoEditor
+            language="json"
+            value={editorCode}
+            options={options}
+            onChange={handleEditorCodeChange}
+          />
+        </CodeEditorWrapper>
+        <PropertyInlineWrapper label="">
+          <Tools>
+            <Tool valid={codeValid ? 1 : 0}>
+              {codeValid ? <CheckOutlinedIcon /> : <ErrorOutlineOutlinedIcon />}JSON
+            </Tool>
+            <Tool valid={1} clickable={1} onClick={openFullsizeEditor}>
+              <OpenInFullIcon />
+            </Tool>
+          </Tools>
+        </PropertyInlineWrapper>
+        <PropertyInfo>
+          Plasese Don&apos;t use this together with other color components.
+        </PropertyInfo>
+      </PropertyBox>
+      <EditorDialog
+        title="Custom Legend Editor"
+        open={fullsizeEditorOpen}
+        fullWidth
+        onClose={closeFullsizeEditor}
+        onSubmit={submitEditorCode}>
+        <MonacoEditor
+          language="json"
+          height={"80vh"}
+          value={editorCode}
+          options={options}
+          onChange={handleEditorCodeChange}
+        />
+      </EditorDialog>
+    </PropertyWrapper>
+  );
+};
+
+const CodeEditorWrapper = styled("div")({
+  position: "relative",
+  height: 200,
+  width: "100%",
+});
+
+const Tools = styled("div")(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(0.5),
+  alignItems: "center",
+  justifyContent: "flex-end",
+}));
+
+const Tool = styled("div")<{ valid: number; clickable?: number }>(
+  ({ valid, clickable, theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing(0.5),
+    color: "#fff",
+    fontSize: "11px",
+    padding: theme.spacing(0.2, 0.5),
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: valid ? theme.palette.success.light : theme.palette.error.light,
+    opacity: 0.5,
+    cursor: clickable ? "pointer" : "default",
+
+    [`& .${svgIconClasses.root}`]: {
+      fontSize: 16,
+    },
+  }),
+);
+
+const StyledMonacoEditor = styled(MonacoEditor)(({ theme }) => ({
+  fontSize: theme.typography.body2.fontSize,
+}));
+
+type CustomLegendType = "square" | "circle" | "line" | "icon";
+
+type CustomLegendItem = {
+  type?: CustomLegendType;
+  title?: string;
+  color?: string;
+  strokeColor?: string;
+  url?: string;
+};
+
+export type CustomLegends = {
+  type?: CustomLegendType;
+  name?: string;
+  legends?: CustomLegendItem[];
+};
+
+const TEMPLATE_CODE = `{
+  "overrides": [
+    {
+      "propertyName": "津波浸水想定",
+      "matcher": "startsWith",
+      "colorSet": [
+        {
+          "value": 6,
+          "color": "#F9FD4C",
+          "name": "0.3m未満"
+        },
+        {
+          "value": 5,
+          "color": "#F9FD4C",
+          "name": "0.3m未満"
+        },
+        {
+          "value": 4,
+          "color": "#F9FD4C",
+          "name": "0.3m未満"
+        },
+        {
+          "value": 3,
+          "color": "#F9FD4C",
+          "name": "0.3m未満"
+        }
+      ]
+    }
+  ]
+}`;

--- a/extension/src/prototypes/view/selection/BuildingLayerColorSection.tsx
+++ b/extension/src/prototypes/view/selection/BuildingLayerColorSection.tsx
@@ -32,6 +32,10 @@ const StyledButton = styled(Button)(({ theme }) => ({
   textAlign: "left",
 }));
 
+const StyledTypography = styled(Typography)(() => ({
+  whiteSpace: "normal",
+}));
+
 const Legend: FC<{
   layers: readonly (BuildingLayerModel | FloodLayerModel)[];
 }> = ({ layers }) => {
@@ -97,7 +101,7 @@ const Legend: FC<{
   return (
     <StyledButton variant="text" onClick={handleClick}>
       <Stack spacing={1} width="100%" marginY={1}>
-        <Typography variant="body2">{colorScheme.name}</Typography>
+        <StyledTypography variant="body2">{colorScheme.name}</StyledTypography>
         {colorScheme.type === "quantitative" && (
           <QuantitativeColorLegend
             colorMap={colorScheme.colorMap}

--- a/extension/src/shared/types/fieldComponents/3dtiles.ts
+++ b/extension/src/shared/types/fieldComponents/3dtiles.ts
@@ -1,3 +1,4 @@
+import { TilesetBuildingModelColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetBuildingModelColorField";
 import { TilesetFloodColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/3dtiles/EditorTilesetFloodColorField";
 import { FillColorConditionFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorConditionField";
 import { FillGradientColorFieldPreset } from "../../../editor/containers/common/fieldComponentEditor/fields/common/EditorFillColorGradientField";
@@ -8,6 +9,7 @@ import { ConditionalColorSchemeValue, GradientColorSchemeValue } from "./colorSc
 export const TILESET_BUILDING_MODEL_COLOR = "TILESET_BUILDING_MODEL_COLOR";
 export type TilesetBuildingModelColorField = FieldBase<{
   type: typeof TILESET_BUILDING_MODEL_COLOR;
+  preset?: TilesetBuildingModelColorFieldPreset;
 }>;
 
 export const TILESET_FLOOD_MODEL_COLOR = "TILESET_FLOOD_MODEL_COLOR";

--- a/extension/src/shared/view-layers/component.ts
+++ b/extension/src/shared/view-layers/component.ts
@@ -55,6 +55,7 @@ export const makeComponentAtoms = (
   components: SettingComponent[],
   shareId: string | undefined,
   shouldInitialize: boolean,
+  hasShareIdInParams?: boolean,
 ): ComponentAtom[] => {
   invariant(datasetId);
   return components.map(component => {
@@ -75,14 +76,14 @@ export const makeComponentAtoms = (
               componentForAtom.value?.storeable.omitPropertyNames,
               shouldInitialize,
             ),
-            shouldInitialize,
+            shouldInitialize && hasShareIdInParams,
           ),
         ),
       };
     }
     return {
       type: component.type,
-      atom: sharedAtomValue(sharedStoreAtom(a, shouldInitialize)),
+      atom: sharedAtomValue(sharedStoreAtom(a, shouldInitialize && hasShareIdInParams)),
     };
   });
 };

--- a/extension/src/shared/view-layers/rootLayer.ts
+++ b/extension/src/shared/view-layers/rootLayer.ts
@@ -52,6 +52,7 @@ export type RootLayerForDatasetParams = {
   shareId: string | undefined;
   shouldInitialize: boolean;
   hidden?: boolean;
+  hasShareIdInParams?: boolean;
 };
 
 export type RootLayerForLayerAtomParams<T extends LayerType> = {
@@ -209,6 +210,7 @@ const createViewLayerWithComponentGroup = (
   shareId: string | undefined,
   shouldInitialize: boolean,
   hidden?: boolean,
+  hasShareIdInParams?: boolean,
 ): LayerModel => {
   invariant(type);
   return {
@@ -227,6 +229,7 @@ const createViewLayerWithComponentGroup = (
       componentGroup?.components ?? [],
       shareId,
       shouldInitialize,
+      hasShareIdInParams,
     ),
     id: datasetId,
     format: data?.format ? REEARTH_DATA_FORMATS[data.format] : undefined,
@@ -253,6 +256,7 @@ const createRootLayerForDataset = ({
   shareId,
   shouldInitialize,
   hidden,
+  hasShareIdInParams,
 }: RootLayerForDatasetParams): RootLayerForDataset => {
   const setting = findSetting(settings, currentDataId);
   const data = findData(dataList, currentDataId);
@@ -291,6 +295,7 @@ const createRootLayerForDataset = ({
         shareId,
         shouldInitialize,
         hidden,
+        hasShareIdInParams,
       ),
     ),
   };
@@ -326,6 +331,7 @@ export const createRootLayerForDatasetAtom = (
       currentGroupId: initialCurrentGroupId,
       shareId,
       shouldInitialize: true,
+      hasShareIdInParams: !!params.shareId,
       hidden: initialHidden,
     }),
   );

--- a/extension/src/shared/view/selection/ColorSchemeSectionForComponentField.tsx
+++ b/extension/src/shared/view/selection/ColorSchemeSectionForComponentField.tsx
@@ -39,6 +39,10 @@ const StyledButton = styled(Button)(({ theme }) => ({
   textAlign: "left",
 }));
 
+const StyledTypography = styled(Typography)(() => ({
+  whiteSpace: "normal",
+}));
+
 const Legend: FC<{
   layers: readonly LayerModel[];
   colorSchemeAtom: ReturnType<typeof makeColorSchemeForComponent>;
@@ -56,7 +60,7 @@ const Legend: FC<{
   return (
     <StyledButton variant="text" onClick={handleClick}>
       <Stack spacing={1} width="100%" marginY={1}>
-        <Typography variant="body2">{colorScheme.name}</Typography>
+        <StyledTypography variant="body2">{colorScheme.name}</StyledTypography>
         {colorScheme.type === "quantitative" && (
           <QuantitativeColorLegend
             colorMap={colorScheme.colorMap}

--- a/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
+++ b/extension/src/shared/view/selection/ImageSchemaSectionForComponentField.tsx
@@ -34,6 +34,10 @@ const StyledButton = styled(Button)(({ theme }) => ({
   textAlign: "left",
 }));
 
+const StyledTypography = styled(Typography)(() => ({
+  whiteSpace: "normal",
+}));
+
 const Legend: FC<{
   layers: readonly LayerModel[];
   imageSchemeAtom: ReturnType<typeof makeImageSchemeForComponent>;
@@ -51,7 +55,7 @@ const Legend: FC<{
   return (
     <StyledButton variant="text" onClick={handleClick}>
       <Stack spacing={1} width="100%" marginY={1}>
-        <Typography variant="body2">{imageScheme.name}</Typography>
+        <StyledTypography variant="body2">{imageScheme.name}</StyledTypography>
         <ImageIconLegend imageIcons={imageScheme.imageIcons} />
       </Stack>
     </StyledButton>


### PR DESCRIPTION
![Screenshot 2024-04-11 at 18 00 18](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/34934510/7f87a450-a86a-49ce-bacd-ebdbf792e8b8)

I updated the TilesetBuildingModelColorField to be able to override the hard-coded property's color by JSON. For this requirement, we might get additional requirement, and it's impossible to support all of requirement as UI, so we decided to use JSON.

You can test it by using `TEST-kya/OVERRIDE_COLOR_SET` template and using `建築物モデル（沼津市）`. And you need to re-add the dataset after you applied the component.

The format is like below.
```
{
  // First matched value is used to override the colorSet.
  "overrides": [
    {
      "propertyName": "津波浸水想定区域モデル 静岡県第４次地震被害想定（元禄型関東地震）", // REQUIRED
      "matcher": "startsWith", // OPTIONAL: `startsWith` or `endsWith` (default is `equal`)
      "colorSet": [ // REQUIRED
        {
          "value": 6,
          "color": "#FF0000",
          "name": "6"
        },
        {
          "value": 5,
          "color": "#00FF00",
          "name": "5"
        },
        {
          "value": 4,
          "color": "#0000FF",
          "name": "4"
        },
        {
          "value": 3,
          "color": "#FFFF00",
          "name": "3"
        },
        {
          "value": 2,
          "color": "#FF00FF",
          "name": "2"
        },
        {
          "value": 1,
          "color": "#FF55AA",
          "name": "1"
        }
      ]
    },
  ]
}
```