### PR TITLE
fix(extension): use show property to toggle Japan polygon

### DIFF
--- a/extension/src/shared/view/containers/JapanPlateauPolygon.tsx
+++ b/extension/src/shared/view/containers/JapanPlateauPolygon.tsx
@@ -50,7 +50,7 @@ const JapanPlateauPolygon: FC = () => {
     [visible],
   );
 
-  if (!initializedRef.current) return;
+  if (!initializedRef.current) return null;
 
   return <PolygonLayer appearances={appearances} />;
 };

--- a/extension/src/shared/view/containers/JapanPlateauPolygon.tsx
+++ b/extension/src/shared/view/containers/JapanPlateauPolygon.tsx
@@ -1,44 +1,58 @@
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback, useMemo, useRef, useState } from "react";
 
 import { useCamera, useReEarthEvent } from "../../reearth/hooks";
 import { PolygonAppearances, PolygonLayer } from "../../reearth/layers";
 
 const CAMERA_ZOOM_LEVEL_HEIGHT = 300000;
-const appererances: PolygonAppearances = {
-  resource: {
-    fill: "rgba(0,190,190, 0.2)",
-    stroke: "rgba(0, 190, 190, 1)",
-    strokeWidth: 1,
-    hideIndicator: true,
-    clampToGround: true,
-  },
-  polygon: {
-    classificationType: "terrain",
-    fill: true,
-    fillColor: "rgba(0, 190, 190, 0.2)",
-    heightReference: "clamp",
-    hideIndicator: true,
-    selectedFeatureColor: "rgba(0, 190, 190, 0.4)",
-  },
-};
 const JapanPlateauPolygon: FC = () => {
   const { getCameraPosition } = useCamera();
   const [visible, setVisible] = useState(false);
+  const initializedRef = useRef(false);
 
+  const timer = useRef<number>();
   const updateVisibility = useCallback(() => {
-    const camera = getCameraPosition();
-    if (camera?.height && camera.height >= CAMERA_ZOOM_LEVEL_HEIGHT) {
-      setVisible(true);
-    } else {
-      setVisible(false);
-    }
+    if (timer.current) return;
+
+    timer.current = window.setTimeout(() => {
+      const camera = getCameraPosition();
+      if (camera?.height && camera.height >= CAMERA_ZOOM_LEVEL_HEIGHT) {
+        initializedRef.current = true;
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+      timer.current = undefined;
+    }, 300);
   }, [getCameraPosition]);
 
   useReEarthEvent("cameramove", updateVisibility);
 
-  if (!visible) return null;
+  const appearances: PolygonAppearances = useMemo(
+    () => ({
+      resource: {
+        fill: "rgba(0,190,190, 0.2)",
+        stroke: "rgba(0, 190, 190, 0.2)",
+        strokeWidth: 1,
+        hideIndicator: true,
+        clampToGround: true,
+        show: visible,
+      },
+      polygon: {
+        classificationType: "terrain",
+        fill: true,
+        fillColor: "rgba(0, 190, 190, 0.2)",
+        heightReference: "clamp",
+        hideIndicator: true,
+        selectedFeatureColor: "rgba(0, 190, 190, 0.4)",
+        show: visible,
+      },
+    }),
+    [visible],
+  );
 
-  return <PolygonLayer appearances={appererances} />;
+  if (!initializedRef.current) return;
+
+  return <PolygonLayer appearances={appearances} />;
 };
 
 export default JapanPlateauPolygon;


### PR DESCRIPTION
Japan polygon is yellow sometimes when I continue to zoom-in and out to show the polygon. The cause seems that the the style of polygon isn't applied by Cesium when the big polygon is re-loaded(removed and created) frequently(I don't known why...). So I fixed to update `show` property which is defined in some appearance to show the polygon without re-loading. The polygon is too big, so I did to use `show` property only if the polygon is loaded at least once.