### PR TITLE
feat(extension): support loop and display past time in timeline component

### DIFF
--- a/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineCustomizedField.tsx
+++ b/extension/src/editor/containers/common/fieldComponentEditor/fields/general/EditorTimelineCustomizedField.tsx
@@ -23,6 +23,8 @@ export type EditorTimelineCustomizedFieldPreset = {
   timezone?: string;
   defaultUnit?: number;
   defaultAmount?: number;
+  timeDisplayType?: "current" | "past";
+  timeDisplayFormat?: string;
 };
 
 const speedUnitOptions = [
@@ -56,6 +58,17 @@ const speedAmountOptions = [
   {
     value: 30,
     label: "30",
+  },
+];
+
+const timeDisplayTypeOptions = [
+  {
+    value: "current",
+    label: "Current Time",
+  },
+  {
+    value: "past",
+    label: "Past Time",
   },
 ];
 
@@ -140,6 +153,33 @@ export const EditorTimelineCustomizedField: React.FC<
     [component, onUpdate],
   );
 
+  const handleTimeDisplayTypeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.value !== "current" && e.target.value !== "past") return;
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          timeDisplayType: e.target.value,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
+  const handleTimeDisplayFormatChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onUpdate({
+        ...component,
+        preset: {
+          ...component.preset,
+          timeDisplayFormat: e.target.value,
+        },
+      });
+    },
+    [component, onUpdate],
+  );
+
   return (
     <PropertyWrapper>
       <PropertyBox>
@@ -185,6 +225,22 @@ export const EditorTimelineCustomizedField: React.FC<
             onChange={handleDefaultUnitChange}
           />
         </PropertyInlineWrapper>
+        <PropertyInlineWrapper label="Time Display Type">
+          <PropertySelectField
+            options={timeDisplayTypeOptions}
+            value={component.preset?.timeDisplayType ?? "current"}
+            onChange={handleTimeDisplayTypeChange}
+          />
+        </PropertyInlineWrapper>
+        {component.preset?.timeDisplayType === "past" && (
+          <PropertyInlineWrapper label="Past Time Format">
+            <PropertyInputField
+              placeholder="Text HH:mm:ss"
+              value={component.preset?.timeDisplayFormat ?? ""}
+              onChange={handleTimeDisplayFormatChange}
+            />
+          </PropertyInlineWrapper>
+        )}
       </PropertyBox>
     </PropertyWrapper>
   );

--- a/extension/src/shared/reearth/hooks/useTimeline.ts
+++ b/extension/src/shared/reearth/hooks/useTimeline.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 
 export const useTimeline = () => {
   const getTimeline = useCallback(() => {
@@ -71,17 +71,19 @@ export const useTimeline = () => {
     window.reearth?.clock?.setSpeed?.(speed);
   }, []);
 
+  const handleTimelineSetRangeType = useCallback(
+    (rangeType: "unbounded" | "clamped" | "bounced") => {
+      window.reearth?.clock?.setRangeType?.(rangeType);
+    },
+    [],
+  );
+
   const handleTimelineOnTickEventAdd = useCallback((callback: (date: Date) => void) => {
     window.reearth?.on?.("tick", callback);
   }, []);
 
   const handleTimelineOnTickEventRemove = useCallback((callback: (date: Date) => void) => {
     window.reearth?.off?.("tick", callback);
-  }, []);
-
-  useEffect(() => {
-    // set default range type to clamped
-    window.reearth?.clock?.setRangeType?.("clamped");
   }, []);
 
   return {
@@ -91,6 +93,7 @@ export const useTimeline = () => {
     handleTimelinePause,
     handleTimelineJump,
     handleTimelineSetSpeed,
+    handleTimelineSetRangeType,
     handleTimelineOnTickEventAdd,
     handleTimelineOnTickEventRemove,
   };

--- a/extension/src/shared/ui-components/TimelineParameterItem.tsx
+++ b/extension/src/shared/ui-components/TimelineParameterItem.tsx
@@ -1,6 +1,8 @@
 // Note: this component does not follow the pattern of the other parameterItem components.
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import RepeatIcon from "@mui/icons-material/Repeat";
+import RepeatOneIcon from "@mui/icons-material/RepeatOne";
 import { styled, IconButton, Select, Typography, SelectChangeEvent } from "@mui/material";
 import { PrimitiveAtom, useAtom } from "jotai";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -23,6 +25,7 @@ type TimelineParameterItemProps = {
   onPause?: () => void;
   onJump?: (props: { start: Date; stop: Date; current: Date }) => void;
   onSetSpeed?: (speed: number) => void;
+  onSetRangeType?: (rangeType: "unbounded" | "clamped" | "bounced") => void;
   onTickEventAdd?: (callback: (date: Date) => void) => void;
   onTickEventRemove?: (callback: (date: Date) => void) => void;
 };
@@ -50,8 +53,8 @@ const ButtonsWrapper = styled("div")(() => ({
 }));
 
 const ButtonWrapper = styled("div")(() => ({
-  width: 48,
-  height: 48,
+  width: 36,
+  height: 36,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -126,16 +129,22 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
   onPause,
   onJump,
   onSetSpeed,
+  onSetRangeType,
   onTickEventAdd,
   onTickEventRemove,
 }) => {
   const startDate = useMemo(() => new Date(start ?? ""), [start]);
   const endDate = useMemo(() => new Date(end ?? ""), [end]);
   const [currentDate, setCurrentDate] = useState(new Date(current ?? ""));
+  const [rangeType, setRangeType] = useState<"bounced" | "clamped">("bounced");
 
   useEffect(() => {
     setCurrentDate(new Date(current ?? ""));
   }, [current]);
+
+  useEffect(() => {
+    onSetRangeType?.(rangeType);
+  }, [rangeType, onSetRangeType]);
 
   const [activeTimelineComponentId, setActiveTimelineComponentId] = useAtom(activeIdAtom);
 
@@ -162,6 +171,10 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
     },
     [playState, speedAmount, onSetSpeed],
   );
+
+  const handleSwitchRangeType = useCallback(() => {
+    setRangeType(rangeType === "clamped" ? "bounced" : "clamped");
+  }, [rangeType]);
 
   const handlePlay = useCallback(() => {
     setActiveTimelineComponentId(id);
@@ -283,6 +296,15 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
           <ButtonWrapper>
             <StyledButton size="small" onClick={handlePlay} active={playState === "play" ? 1 : 0}>
               <PlayArrowIcon fontSize="medium" />
+            </StyledButton>
+          </ButtonWrapper>
+          <ButtonWrapper>
+            <StyledButton size="small" onClick={handleSwitchRangeType}>
+              {rangeType === "clamped" ? (
+                <RepeatOneIcon fontSize="medium" />
+              ) : (
+                <RepeatIcon fontSize="medium" />
+              )}
             </StyledButton>
           </ButtonWrapper>
         </ButtonsWrapper>

--- a/extension/src/shared/ui-components/TimelineParameterItem.tsx
+++ b/extension/src/shared/ui-components/TimelineParameterItem.tsx
@@ -19,6 +19,8 @@ type TimelineParameterItemProps = {
   timezone?: string;
   defaultUnit?: number;
   defaultAmount?: number;
+  timeDisplayType?: "current" | "past";
+  timeDisplayFormat?: string;
   activeIdAtom: PrimitiveAtom<string>;
   onPlay?: (props: { start: Date; stop: Date; current: Date; speed: number }) => void;
   onPlayReverse?: (props: { start: Date; stop: Date; current: Date; speed: number }) => void;
@@ -123,6 +125,8 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
   timezone = "+9",
   defaultUnit = 60,
   defaultAmount = 1,
+  timeDisplayType = "current",
+  timeDisplayFormat,
   activeIdAtom,
   onPlay,
   onPlayReverse,
@@ -337,7 +341,11 @@ export const TimelineParameterItem: FC<TimelineParameterItemProps> = ({
         timezone={timezone}
         onChange={handleJumpTime}
       />
-      <CurrentTime>{formatDateWithTimezone(currentDate, timezone)}</CurrentTime>
+      <CurrentTime>
+        {timeDisplayType === "current"
+          ? formatDateWithTimezone(currentDate, timezone)
+          : formatPastTime(currentDate, startDate, timeDisplayFormat)}
+      </CurrentTime>
     </Timeline>
   );
 };
@@ -363,3 +371,17 @@ const formatDateWithTimezone = (date: Date, timezone: string) => {
 const SpeedTick = styled("span")(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
 }));
+
+const formatPastTime = (current: Date, start: Date, format?: string) => {
+  const diff = current.getTime() - start.getTime();
+  const diffSec = Math.floor(diff / 1000);
+  const sec = diffSec % 60;
+  const min = Math.floor(diffSec / 60) % 60;
+  const hour = Math.floor(diffSec / 3600);
+  const HH = hour < 10 ? "0" + hour : `${hour}`;
+  const mm = min < 10 ? "0" + min : `${min}`;
+  const ss = sec < 10 ? "0" + sec : `${sec}`;
+  return format
+    ? format.replace("HH", HH).replace("mm", mm).replace("ss", ss)
+    : `${HH}:${mm}:${ss}`;
+};

--- a/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
+++ b/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
@@ -37,6 +37,8 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
   const timezone = useMemo(() => component.preset?.timezone ?? "+9", [component.preset]);
   const defaultUnit = useMemo(() => component.preset?.defaultUnit, [component.preset]);
   const defaultAmount = useMemo(() => component.preset?.defaultAmount, [component.preset]);
+  const timeDisplayType = useMemo(() => component.preset?.timeDisplayType, [component.preset]);
+  const timeDisplayFormat = useMemo(() => component.preset?.timeDisplayFormat, [component.preset]);
 
   return start && current && end && timezone !== undefined ? (
     <ParameterList>
@@ -49,6 +51,8 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
           timezone={timezone}
           defaultUnit={defaultUnit}
           defaultAmount={defaultAmount}
+          timeDisplayType={timeDisplayType}
+          timeDisplayFormat={timeDisplayFormat}
           activeIdAtom={activeTimelineComponentIdAtom}
           onPlay={handleTimelinePlay}
           onPlayReverse={handleTimelinePlayReverse}

--- a/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
+++ b/extension/src/shared/view/fields/general/LayerTimelineCustomizedField.tsx
@@ -23,6 +23,7 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
     handleTimelinePause,
     handleTimelineJump,
     handleTimelineSetSpeed,
+    handleTimelineSetRangeType,
     handleTimelineOnTickEventAdd,
     handleTimelineOnTickEventRemove,
   } = useTimeline();
@@ -54,6 +55,7 @@ export const LayerTimelineCustomizedField: FC<LayerTimelineCustomizedFieldProps>
           onPause={handleTimelinePause}
           onJump={handleTimelineJump}
           onSetSpeed={handleTimelineSetSpeed}
+          onSetRangeType={handleTimelineSetRangeType}
           onTickEventAdd={handleTimelineOnTickEventAdd}
           onTickEventRemove={handleTimelineOnTickEventRemove}
         />

--- a/extension/src/shared/view/fields/general/LayerTimelineMonthField.tsx
+++ b/extension/src/shared/view/fields/general/LayerTimelineMonthField.tsx
@@ -36,6 +36,7 @@ export const LayerTimelineMonthField: FC<LayerTimelineMonthFieldProps> = ({ atom
     handleTimelinePause,
     handleTimelineJump,
     handleTimelineSetSpeed,
+    handleTimelineSetRangeType,
     handleTimelineOnTickEventAdd,
     handleTimelineOnTickEventRemove,
   } = useTimeline();
@@ -56,6 +57,7 @@ export const LayerTimelineMonthField: FC<LayerTimelineMonthFieldProps> = ({ atom
             onPause={handleTimelinePause}
             onJump={handleTimelineJump}
             onSetSpeed={handleTimelineSetSpeed}
+            onSetRangeType={handleTimelineSetRangeType}
             onTickEventAdd={handleTimelineOnTickEventAdd}
             onTickEventRemove={handleTimelineOnTickEventRemove}
           />


### PR DESCRIPTION
## Overview

This PR adds these support on timeline component:

- Switch play mode between play once and loop (default).

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/1b4c69b6-e899-4540-893d-f8ca676b0f18)
 
- Set time display type as current or past for customized timeline component. When it's past editor can setup a format for the text. Support `HH` `mm` `ss` only.

![image](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/assets/21994748/02a42737-8495-49b2-adf2-449f47f58b9e)

## Test

You can test by searching datasets with `時系列` in name. (prod API)