### PR TITLE
fix(extension): use component from PLATEAU in city project

### DIFF
--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -104,6 +104,17 @@ const yml = {
             title: "任意設定",
             fields: [
               {
+                id: "projectNameForCity",
+                type: "string",
+                title: "自治体用プロジェクト名",
+              },
+              {
+                id: "plateauAccessTokenForCity",
+                type: "string",
+                title: "自治体用バックエンドアクセストークン",
+                private: true,
+              },
+              {
                 id: "cityName",
                 type: "string",
                 title: "都市名",

--- a/extension/src/editor/containers/component-template/index.tsx
+++ b/extension/src/editor/containers/component-template/index.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "jotai";
 import { useMemo, useState, useCallback, useEffect, RefObject } from "react";
 
 import { useTemplateAPI } from "../../../shared/api";
@@ -30,8 +29,7 @@ export const EditorFieldComponentsTemplateSection: React.FC<
   const [templateId, setTemplateId] = useState<string>();
   const [isSaving, setIsSaving] = useState(false);
 
-  const { templatesAtom, saveTemplate, removeTemplate } = useTemplateAPI();
-  const templates = useAtomValue(templatesAtom);
+  const { templates, saveTemplate, removeTemplate } = useTemplateAPI();
 
   const componentTemplates = useMemo(
     () =>

--- a/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/FeatureInspectorEmphasisPropertyBlock.tsx
@@ -1,5 +1,4 @@
 import { Divider } from "@mui/material";
-import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DraftSetting, EditorDataset, UpdateSetting } from "..";
@@ -39,8 +38,7 @@ export const FeatureInspectorEmphasisPropertyBlock: React.FC<
     setTemplateId(e.target.value);
   }, []);
 
-  const { templatesAtom } = useTemplateAPI();
-  const templates = useAtomValue(templatesAtom);
+  const { templates } = useTemplateAPI();
 
   const emphasisPropertyTemplates = useMemo(
     () =>

--- a/extension/src/editor/containers/dataset/blocks/FieldComponentTemplateBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/FieldComponentTemplateBlock.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DraftSetting, EditorDataset, UpdateSetting } from "..";
@@ -38,8 +37,7 @@ export const FieldComponentTemplateBlock: React.FC<FieldComponentTemplateBlockPr
     setTemplateId(e.target.value);
   }, []);
 
-  const { templatesAtom } = useTemplateAPI();
-  const templates = useAtomValue(templatesAtom);
+  const { templates } = useTemplateAPI();
 
   const componentTemplates = useMemo(
     () =>

--- a/extension/src/editor/containers/dataset/index.tsx
+++ b/extension/src/editor/containers/dataset/index.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_SETTING_DATA_ID } from "../../../shared/api/constants";
 import { Setting } from "../../../shared/api/types";
 import { useDatasetById } from "../../../shared/graphql";
 import { DatasetFragmentFragment } from "../../../shared/graphql/types/catalog";
+import { useIsCityProject } from "../../../shared/states/environmentVariables";
 import { updateSettingAtom } from "../../../shared/states/setting";
 import { generateID } from "../../../shared/utils/id";
 import {
@@ -66,6 +67,7 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
 
   const { settingsAtom, saveSetting } = useSettingsAPI();
   const settings = useAtomValue(settingsAtom);
+  const [isCityProject] = useIsCityProject();
 
   const highlightedLayer = useAtomValue(highlightedLayersAtom)?.[0];
   const selectedLayer = useAtomValue(layerSelectionAtom)?.[0];
@@ -73,8 +75,8 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
   const query = useDatasetById(layer?.id ?? "");
 
   const dataset = useMemo(() => {
-    return query.data?.node;
-  }, [query]);
+    return !isCityProject || query.data?.node?.type?.code === "city" ? query.data?.node : undefined;
+  }, [query, isCityProject]);
 
   const tree = useMemo(() => {
     if (!dataset) return [];
@@ -254,6 +256,8 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
 
   const updateSetting = useSetAtom(updateSettingAtom);
   const handleApply = useCallback(() => {
+    if (!dataset) return;
+
     if (draftSetting) {
       cache?.set(`dataset-${dataset.id}-${dataId}`, cloneDeep(draftSetting));
     }
@@ -264,9 +268,11 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
         updateSetting(cachedSetting as Setting);
       }
     });
-  }, [cache, dataId, dataset?.id, dataset?.items, draftSetting, updateSetting]);
+  }, [cache, dataId, dataset, draftSetting, updateSetting]);
 
   const handleSave = useCallback(() => {
+    if (!dataset) return;
+
     // Save all settings belongs to current dataset
     setIsSaving(true);
     const savingTasks: Promise<void>[] = [];
@@ -296,7 +302,7 @@ export const EditorDatasetSection: FC<EditorDatasetSectionProps> = ({ cache, edi
       .finally(() => {
         setIsSaving(false);
       });
-  }, [dataId, dataset?.id, dataset?.items, cache, draftSetting, editorNoticeRef, saveSetting]);
+  }, [dataId, dataset, cache, draftSetting, editorNoticeRef, saveSetting]);
 
   return layer && dataset ? (
     <EditorSection

--- a/extension/src/editor/containers/emphasis-property-template/index.tsx
+++ b/extension/src/editor/containers/emphasis-property-template/index.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "jotai";
 import { useMemo, useState, useCallback, useEffect } from "react";
 
 import { useTemplateAPI } from "../../../shared/api";
@@ -32,8 +31,7 @@ export const EditorInspectorEmphasisPropertyTemplateSection: React.FC<
   const [templateId, setTemplateId] = useState<string>();
   const [isSaving, setIsSaving] = useState(false);
 
-  const { templatesAtom, saveTemplate, removeTemplate } = useTemplateAPI();
-  const templates = useAtomValue(templatesAtom);
+  const { templates, saveTemplate, removeTemplate } = useTemplateAPI();
 
   const emphasisPropertyTemplates = useMemo(
     () =>

--- a/extension/src/shared/api/clients/base.ts
+++ b/extension/src/shared/api/clients/base.ts
@@ -1,26 +1,47 @@
+import invariant from "tiny-invariant";
+
 import { fetchWithDelete, fetchWithGet, fetchWithPatch, fetchWithPost } from "../fetch";
 
 export type PlateauAPIType = "data" | "templates";
+
+export type CityOptions = { projectId: string; token: string };
 
 export class PlateauAPIClient<V> {
   projectId: string;
   url: string;
   token: string;
   type: PlateauAPIType;
+  cityOptions?: CityOptions;
 
-  constructor(projectId: string, url: string, token: string, type: PlateauAPIType) {
+  constructor(
+    projectId: string,
+    url: string,
+    token: string,
+    type: PlateauAPIType,
+    cityOptions?: CityOptions,
+  ) {
     this.projectId = projectId;
     this.url = url;
     this.token = token;
     this.type = type;
+    this.cityOptions = cityOptions;
   }
 
   baseUrl() {
     return `${this.url}/${this.projectId}/${this.type}`;
   }
 
+  baseUrlForCity() {
+    invariant(this.cityOptions);
+    return `${this.url}/${this.cityOptions.projectId}/${this.type}`;
+  }
+
   urlWithId(id: string) {
-    return `${this.baseUrl()}/${id}`;
+    return this.cityOptions ? `${this.baseUrlForCity()}/${id}` : `${this.baseUrl()}/${id}`;
+  }
+
+  _token() {
+    return this.cityOptions ? this.cityOptions.token : this.token;
   }
 
   handleError(obj: any) {
@@ -29,8 +50,18 @@ export class PlateauAPIClient<V> {
     return obj;
   }
 
+  // Combine the data only in findAll.
   async findAll(): Promise<V[]> {
-    return this.handleError(await fetchWithGet(this.baseUrl()));
+    return this.handleError(
+      await Promise.all<(Promise<V[]> | undefined)[]>([
+        fetchWithGet(this.baseUrl()),
+        this.cityOptions ? fetchWithGet(this.baseUrlForCity()) : undefined,
+      ]).then(r => r.filter((v): v is V[] => !!v).flat()),
+    );
+  }
+
+  async findAllForCity(): Promise<V[]> {
+    return this.handleError(await fetchWithGet(this.baseUrlForCity()));
   }
 
   async findById(id: string): Promise<V> {
@@ -38,14 +69,18 @@ export class PlateauAPIClient<V> {
   }
 
   async save(data: V) {
-    return await fetchWithPost(this.baseUrl(), data, this.token);
+    return await fetchWithPost(
+      this.cityOptions ? this.baseUrlForCity() : this.baseUrl(),
+      data,
+      this._token(),
+    );
   }
 
   async update(id: string, data: V) {
-    return await fetchWithPatch(this.urlWithId(id), data, this.token);
+    return await fetchWithPatch(this.urlWithId(id), data, this._token());
   }
 
   async delete(id: string) {
-    return await fetchWithDelete(this.urlWithId(id), this.token);
+    return await fetchWithDelete(this.urlWithId(id), this._token());
   }
 }

--- a/extension/src/shared/api/clients/setting.ts
+++ b/extension/src/shared/api/clients/setting.ts
@@ -1,8 +1,13 @@
 import { Setting } from "../types";
 
-import { PlateauAPIClient } from "./base";
+import { CityOptions, PlateauAPIClient } from "./base";
 
 export let settingClient: PlateauAPIClient<Setting> | undefined;
-export const createSettingClient = (projectId: string, url: string, token: string) => {
-  settingClient = new PlateauAPIClient(projectId, url, token, "data");
+export const createSettingClient = (
+  projectId: string,
+  url: string,
+  token: string,
+  cityOptions?: CityOptions,
+) => {
+  settingClient = new PlateauAPIClient(projectId, url, token, "data", cityOptions);
 };

--- a/extension/src/shared/api/clients/template.ts
+++ b/extension/src/shared/api/clients/template.ts
@@ -1,8 +1,13 @@
 import { Template } from "../types/template";
 
-import { PlateauAPIClient } from "./base";
+import { CityOptions, PlateauAPIClient } from "./base";
 
 export let templateClient: PlateauAPIClient<Template> | undefined;
-export const createTemplateClient = (projectId: string, url: string, token: string) => {
-  templateClient = new PlateauAPIClient(projectId, url, token, "templates");
+export const createTemplateClient = (
+  projectId: string,
+  url: string,
+  token: string,
+  cityOptions?: CityOptions,
+) => {
+  templateClient = new PlateauAPIClient(projectId, url, token, "templates", cityOptions);
 };

--- a/extension/src/shared/api/hooks/settings.ts
+++ b/extension/src/shared/api/hooks/settings.ts
@@ -6,7 +6,6 @@ import { Setting } from "../types";
 
 import { useSettingClient } from "./useSettingClient";
 
-// TODO: Imple saving setting state to API
 export default () => {
   const client = useSettingClient();
   const [isSaving, setIsSaving] = useState(false);

--- a/extension/src/shared/api/hooks/template.ts
+++ b/extension/src/shared/api/hooks/template.ts
@@ -1,6 +1,7 @@
-import { useSetAtom } from "jotai";
-import { useCallback, useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useEffect, useState } from "react";
 
+import { useIsCityProject } from "../../states/environmentVariables";
 import {
   templatesAtom,
   updateTemplateAtom,
@@ -14,6 +15,19 @@ import { useTemplateClient } from "./useTemplateClient";
 export default () => {
   const client = useTemplateClient();
   const [isSaving, setIsSaving] = useState(false);
+
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const templatesFromAtom = useAtomValue(templatesAtom);
+  const [isCityProject] = useIsCityProject();
+  useEffect(() => {
+    if (isCityProject) {
+      client.findAllForCity().then(data => {
+        setTemplates(data);
+      });
+    } else {
+      setTemplates(templatesFromAtom);
+    }
+  }, [templatesFromAtom, isCityProject, client]);
 
   const updateTemplate = useSetAtom(updateTemplateAtom);
   const addTemplate = useSetAtom(addTemplateAtom);
@@ -30,8 +44,10 @@ export default () => {
       })();
 
       if (isUpdate) {
+        setTemplates(p => p.map(v => (v.id === nextTemplate.id ? nextTemplate : v)));
         updateTemplate(nextTemplate);
       } else {
+        setTemplates(p => [...p, nextTemplate]);
         addTemplate(nextTemplate);
       }
 
@@ -46,6 +62,7 @@ export default () => {
       if (!templateId) return;
       await client.delete(templateId);
 
+      setTemplates(p => p.filter(v => v.id !== templateId));
       removeTemplateById(templateId);
     },
     [client, removeTemplateById],
@@ -53,7 +70,7 @@ export default () => {
 
   return {
     isSaving,
-    templatesAtom,
+    templates,
     saveTemplate,
     removeTemplate,
   };

--- a/extension/src/shared/context/WidgetContext.tsx
+++ b/extension/src/shared/context/WidgetContext.tsx
@@ -21,6 +21,7 @@ import {
   useGsiTileUrl,
   useHideFeedback,
   useInitialPedestrianCoordinates,
+  useIsCityProject,
   useLogo,
   usePlateauApiUrl,
   usePlateauGeojsonUrl,
@@ -43,6 +44,8 @@ type Props = {
   geojsonURL?: string;
   hideFeedback?: boolean;
   // Custom settings
+  projectIdForCity?: string;
+  plateauTokenForCity?: string;
   cityName?: string;
   cityCode?: string;
   customPrimaryColor?: string;
@@ -63,6 +66,8 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   hideFeedback,
   children,
   inEditor,
+  projectIdForCity,
+  plateauTokenForCity,
   cityName,
   cityCode,
   customPrimaryColor,
@@ -180,17 +185,31 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   useEffect(() => {
     const url = inEditor ? catalogURLForAdmin || catalogUrl : catalogUrl;
     if (url) {
-      createCatalogClient(url, inEditor ? plateauToken : undefined);
+      createCatalogClient(url, inEditor ? plateauTokenForCity || plateauToken : undefined);
     }
-  }, [catalogUrl, catalogURLForAdmin, plateauToken, inEditor]);
+  }, [catalogUrl, catalogURLForAdmin, plateauToken, inEditor, plateauTokenForCity]);
+
+  const [_, setIsCityProject] = useIsCityProject();
 
   useEffect(() => {
     if (!settingClient && !templateClient && plateauUrl && projectId && plateauToken) {
       const sidebar = `${plateauUrl}/sidebar`;
-      createSettingClient(projectId, sidebar, plateauToken);
-      createTemplateClient(projectId, sidebar, plateauToken);
+      const cityOptions =
+        projectIdForCity && plateauTokenForCity
+          ? { projectId: projectIdForCity, token: plateauTokenForCity }
+          : undefined;
+      createSettingClient(projectId, sidebar, plateauToken, cityOptions);
+      createTemplateClient(projectId, sidebar, plateauToken, cityOptions);
+      setIsCityProject(!!cityOptions);
     }
-  }, [projectId, plateauUrl, plateauToken]);
+  }, [
+    projectId,
+    plateauUrl,
+    plateauToken,
+    projectIdForCity,
+    plateauTokenForCity,
+    setIsCityProject,
+  ]);
 
   const [customTheme, setCustomTheme] = useState<Theme | undefined>(undefined);
 

--- a/extension/src/shared/states/environmentVariables.ts
+++ b/extension/src/shared/states/environmentVariables.ts
@@ -21,6 +21,9 @@ export const useGoogleStreetViewApiKey = () => useAtom(googleStreetViewApiKey);
 const hideFeedback = atom(false);
 export const useHideFeedback = () => useAtom(hideFeedback);
 
+const isCityProject = atom(false);
+export const useIsCityProject = () => useAtom(isCityProject);
+
 // custom settings
 
 const cityName = atom<string | undefined>(undefined);

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -49,6 +49,8 @@ type DefaultProps = {
 };
 
 type OptionalProps = {
+  projectNameForCity?: string;
+  plateauAccessTokenForCity?: string;
   cityName?: string;
   cityCode?: string;
   primaryColor?: string;
@@ -82,6 +84,8 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
         googleStreetViewAPIKey={widget.property.default.googleStreetViewAPIKey}
         geojsonURL={widget.property.default.geojsonURL}
         hideFeedback={widget.property.default.hideFeedback}
+        projectIdForCity={widget.property.optional?.projectNameForCity}
+        plateauTokenForCity={widget.property.optional?.plateauAccessTokenForCity}
         cityName={widget.property.optional?.cityName}
         cityCode={widget.property.optional?.cityCode}
         customPrimaryColor={widget.property.optional?.primaryColor}


### PR DESCRIPTION
In city project, we need to use the component which is set up in VIEW3.0 project, but city project's component API return just the component for city project. So we need to fetch the component for VIEW3.0 and city project.
The specification of city project is below.
1. Use VIEW3.0's component and template for VIEW3.0's dataset.
2. Edit the component and template only for city project's dataset.
3. We don't allow to show and edit the component and template for VIEW3.0 in city project.