### PR TITLE
ci: migrate to GAR from GCR

### DIFF
--- a/.github/workflows/deploy-cms-dev.yml
+++ b/.github/workflows/deploy-cms-dev.yml
@@ -5,10 +5,10 @@ env:
   GCS_DEST: gs://cms-plateau-dev
   CMS_IMAGE_NAME: reearth/reearth-cms:rc
   CMS_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms:latest
-  CMS_IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau-dev/reearth-cms:latest
+  CMS_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/reearth-cms:latest
   WORKER_IMAGE_NAME: reearth/reearth-cms-worker:rc
   WORKER_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms-worker:latest
-  WORKER_IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau-dev/reearth-cms-worker:latest
+  WORKER_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/reearth-cms-worker:latest
 concurrency:
   group: ${{ github.workflow }}
 jobs:
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-cms-prod.yml
+++ b/.github/workflows/deploy-cms-prod.yml
@@ -9,10 +9,10 @@ on:
 env:
   GCS_DEST: gs://cms-plateau-prod
   CMS_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms:latest
-  CMS_IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau/reearth-cms:latest
+  CMS_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-cms:latest
   CMS_IMAGE_NAME_HUB: eukarya/plateauview2-reearth-cms:latest
   WORKER_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms-worker:latest
-  WORKER_IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau/reearth-cms-worker:latest
+  WORKER_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-cms-worker:latest
   WORKER_IMAGE_NAME_HUB: eukarya/plateauview2-reearth-cms-worker:latest
 concurrency:
   group: ${{ github.workflow }}
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-geo-dev.yml
+++ b/.github/workflows/deploy-geo-dev.yml
@@ -5,7 +5,7 @@ on:
     types: [deploy-geo-dev]
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-geo:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau-dev/plateauview-geo:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/plateauview-geo:latest
 jobs:
   deploy_geo:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-geo-prod.yml
+++ b/.github/workflows/deploy-geo-prod.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-geo:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau/plateauview-geo:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/plateauview-geo:latest
   IMAGE_HUB: eukarya/plateauview-geo:latest
 jobs:
   deploy_geo:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-reearth-dev.yml
+++ b/.github/workflows/deploy-reearth-dev.yml
@@ -8,7 +8,7 @@ env:
   # TODO: allow to specify version of reearth
   IMAGE_NAME: reearth/reearth:rc
   IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth:latest
-  IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau-dev/reearth:latest
+  IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/reearth:latest
 concurrency:
   group: ${{ github.workflow }}
 jobs:
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-reearth-prod.yml
+++ b/.github/workflows/deploy-reearth-prod.yml
@@ -9,7 +9,7 @@ on:
 env:
   GCS_DEST: gs://plateau-prod-reearth-app-bucket
   IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth:latest
-  IMAGE_NAME_GCP: asia.gcr.io/reearth-plateau/reearth:latest
+  IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth:latest
   IMAGE_NAME_HUB: eukarya/plateauview2-reearth:latest
 concurrency:
   group: ${{ github.workflow }}
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-server-dev.yml
+++ b/.github/workflows/deploy-server-dev.yml
@@ -5,7 +5,7 @@ on:
     types: [deploy-server-dev]
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-api:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau-dev/plateauview-api:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/plateauview-api:latest
 jobs:
   deploy_server:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-server-prod.yml
+++ b/.github/workflows/deploy-server-prod.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-api:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau/plateauview-api:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/plateauview-api:latest
   IMAGE_HUB: eukarya/plateauview2-sidecar:latest
 jobs:
   deploy_server:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-tiles-dev.yml
+++ b/.github/workflows/deploy-tiles-dev.yml
@@ -5,7 +5,7 @@ on:
     types: [deploy-tiles-dev]
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-tiles:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau-dev/plateauview-tiles:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/plateauview-tiles:latest
 jobs:
   deploy_tiles:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-tiles-prod.yml
+++ b/.github/workflows/deploy-tiles-prod.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-tiles:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau/plateauview-tiles:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/plateauview-tiles:latest
   IMAGE_HUB: eukarya/plateauview-tiles:latest
 jobs:
   deploy_tiles:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-worker-dev.yml
+++ b/.github/workflows/deploy-worker-dev.yml
@@ -5,7 +5,7 @@ on:
     types: [deploy-worker-dev]
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-api-worker:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau-dev/plateauview-api-worker:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/plateauview-api-worker:latest
 concurrency:
   group: ${{ github.workflow }}
 jobs:
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-worker-prod.yml
+++ b/.github/workflows/deploy-worker-prod.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 env:
   IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-api-worker:latest
-  IMAGE_GCP: asia.gcr.io/reearth-plateau/plateauview-api-worker:latest
+  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/plateauview-api-worker:latest
   IMAGE_HUB: eukarya/plateauview2-sidecar-worker:latest
 concurrency:
   group: ${{ github.workflow }}
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
## Why

Because the GCR (Google Container Registry) will be decommissioned.
Note that production and development environment refers to the images on GitHub registry so they can be migrated step by step. 

## Ref

* [Transition from Container Registry, Google Cloud](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr) 

> Container Registry is deprecated and scheduled for shutdown. After May 15, 2024, Artifact Registry will host images for the gcr.io domain in Google Cloud projects without previous Container Registry usage