### PR TITLE
fix(extension): allow editing an initial layer field for PLATEAU dataset in a city project

### DIFF
--- a/extension/src/editor/containers/dataset/GeneralPage.tsx
+++ b/extension/src/editor/containers/dataset/GeneralPage.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTING_DATA_ID } from "../../../shared/api/constants";
+import { useCityOrPlateauDataset } from "../../hooks/useIsCityOrPlateauDataset";
 
 import { CameraBlock } from "./blocks/CameraBlock";
 import { DataBlock } from "./blocks/DataBlock";
@@ -21,28 +22,33 @@ export const GeneralPage: React.FC<GeneralPageProps> = ({
   dataId,
   updateSetting,
 }) => {
+  const isCityOrPlateauDataset = useCityOrPlateauDataset(dataset);
   return (
     <>
-      <DataBlock
-        key={`${setting.datasetId}-${setting.dataId}-data`}
-        dataset={dataset}
-        dataId={dataId}
-      />
-      <CameraBlock
-        key={`${setting.datasetId}-${setting.dataId}-camera`}
-        setting={setting}
-        updateSetting={updateSetting}
-      />
-      <DataFetchingBlock
-        key={`${setting.datasetId}-${setting.dataId}-data-fetching`}
-        setting={setting}
-        updateSetting={updateSetting}
-      />
-      <EventBlock
-        key={`${setting.datasetId}-${setting.dataId}-event`}
-        setting={setting}
-        updateSetting={updateSetting}
-      />
+      {isCityOrPlateauDataset && (
+        <>
+          <DataBlock
+            key={`${setting.datasetId}-${setting.dataId}-data`}
+            dataset={dataset}
+            dataId={dataId}
+          />
+          <CameraBlock
+            key={`${setting.datasetId}-${setting.dataId}-camera`}
+            setting={setting}
+            updateSetting={updateSetting}
+          />
+          <DataFetchingBlock
+            key={`${setting.datasetId}-${setting.dataId}-data-fetching`}
+            setting={setting}
+            updateSetting={updateSetting}
+          />
+          <EventBlock
+            key={`${setting.datasetId}-${setting.dataId}-event`}
+            setting={setting}
+            updateSetting={updateSetting}
+          />
+        </>
+      )}
       {setting.dataId !== DEFAULT_SETTING_DATA_ID && (
         <InitialLayerBlock
           key={`${setting.datasetId}-${setting.dataId}-initial-layer`}

--- a/extension/src/editor/containers/ui-components/editor/EditorTreeItem.tsx
+++ b/extension/src/editor/containers/ui-components/editor/EditorTreeItem.tsx
@@ -19,6 +19,7 @@ export type EditorTreeItemType = {
   name: string;
   property?: any;
   edited?: boolean;
+  show?: boolean;
   children?: EditorTreeItemType[];
 };
 
@@ -58,6 +59,10 @@ export const EditorTreeItem: React.FC<EditorTreeItemProps> = ({
   const handleOpen = useCallback(() => {
     onExpandClick?.(item.id);
   }, [item, onExpandClick]);
+
+  if (item.show === false) {
+    return null;
+  }
 
   return (
     <>

--- a/extension/src/editor/hooks/useIsCityOrPlateauDataset.ts
+++ b/extension/src/editor/hooks/useIsCityOrPlateauDataset.ts
@@ -1,0 +1,9 @@
+import { useMemo } from "react";
+
+import { DatasetFragmentFragment } from "../../shared/graphql/types/catalog";
+import { useIsCityProject } from "../../shared/states/environmentVariables";
+
+export const useCityOrPlateauDataset = (dataset: DatasetFragmentFragment | undefined) => {
+  const [isCityProject] = useIsCityProject();
+  return useMemo(() => !isCityProject || dataset?.type?.code === "city", [dataset, isCityProject]);
+};

--- a/extension/src/shared/api/hooks/settings.ts
+++ b/extension/src/shared/api/hooks/settings.ts
@@ -1,7 +1,8 @@
-import { useSetAtom } from "jotai";
-import { useCallback, useState } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useMemo, useState } from "react";
 
-import { settingsAtom, updateSettingAtom } from "../../states/setting";
+import { useIsCityProject } from "../../states/environmentVariables";
+import { settingForCityIdsAtom, settingsAtom, updateSettingAtom } from "../../states/setting";
 import { Setting } from "../types";
 
 import { useSettingClient } from "./useSettingClient";
@@ -9,13 +10,15 @@ import { useSettingClient } from "./useSettingClient";
 export default () => {
   const client = useSettingClient();
   const [isSaving, setIsSaving] = useState(false);
+  const [isCityProject] = useIsCityProject();
+  const [settingForCityIds, setSettingForCityIds] = useAtom(settingForCityIdsAtom);
 
   const updateSetting = useSetAtom(updateSettingAtom);
   const saveSetting = useCallback(
     async (setting: Setting) => {
       setIsSaving(true);
 
-      const settings = await client.findAll();
+      const settings = isCityProject ? await client.findAllForCity() : await client.findAll();
       const existSetting = settings?.find(
         s => s.datasetId === setting.datasetId && s.dataId === setting.dataId,
       );
@@ -30,16 +33,25 @@ export default () => {
         return await client.save(setting);
       })();
 
+      if (isCityProject) {
+        setSettingForCityIds(((await client.findAllForCity()) ?? []).map(s => s.id));
+      }
       updateSetting(nextSetting);
 
       setIsSaving(false);
     },
-    [client, updateSetting],
+    [client, updateSetting, isCityProject, setSettingForCityIds],
+  );
+
+  const settingsAll = useAtomValue(settingsAtom);
+  const settings = useMemo(
+    () => (isCityProject ? settingsAll.filter(s => settingForCityIds.includes(s.id)) : settingsAll),
+    [isCityProject, settingForCityIds, settingsAll],
   );
 
   return {
     isSaving,
     saveSetting,
-    settingsAtom,
+    settings,
   };
 };

--- a/extension/src/shared/states/setting.ts
+++ b/extension/src/shared/states/setting.ts
@@ -12,6 +12,8 @@ import {
 export const settingsAtom = atom<Setting[]>([]);
 export const settingsAtomsAtom = splitAtom(settingsAtom);
 
+export const settingForCityIdsAtom = atom<Setting["id"][]>([]);
+
 export const addSettingAtom = atom(undefined, (_get, set, setting: Setting) => {
   set(updateRootLayerBySetting, setting);
   set(settingsAtomsAtom, {


### PR DESCRIPTION
I fixed the editor to allow overridding an `Initial layer` field for PLATEAU dataset in a city project.
This only allows `Initial layer` field, but other fields aren't allowed.
![Screenshot 2024-08-05 at 13 13 32](https://github.com/user-attachments/assets/313995ea-88be-44fa-9574-49b25f6f3f76)
