### PR TITLE
fix(extension): add a distance condition for tile label

### DIFF
--- a/extension/src/shared/reearth/types/scene.ts
+++ b/extension/src/shared/reearth/types/scene.ts
@@ -35,6 +35,8 @@ export type TileLabels = {
   id: string;
   labelType: "japan_gsi_optimal_bvmap"; // | "other_map"
   style: Record<string, any>; // Function isn't allowed
+  near?: number;
+  far?: number;
 };
 
 export type AmbientOcclusion = {


### PR DESCRIPTION
Hide a tile label if camera pitch is under the specific degree.
ReEarth Core: https://github.com/reearth/core/pull/48

https://github.com/user-attachments/assets/07223cde-3b81-40a4-809e-78154fc4712c

