### PR TITLE
fix(server): Add validation for empty URL list in citygml packer

### DIFF
--- a/server/citygml/packer.go
+++ b/server/citygml/packer.go
@@ -85,6 +85,11 @@ func (p *packer) handlePackRequest(c echo.Context) error {
 			"error":  err.Error(),
 		})
 	}
+	if len(req.URLs) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"reason": "no urls provided",
+		})
+	}
 	for _, citygmlURL := range req.URLs {
 		u, err := url.Parse(citygmlURL)
 		if err != nil {
@@ -144,7 +149,7 @@ func (p *packer) packAsync(ctx context.Context, req PackAsyncRequest) error {
 			p.conf.CityGMLPackerImage,
 		},
 		Steps: []*cloudbuild.BuildStep{
-			{Args: append([]string{"citygml-packer", "-dest", req.Dest, "-domain", req.Domain}, req.URLs...)},
+			{Name: "citygml-pack", Args: append([]string{"citygml-packer", "-dest", req.Dest, "-domain", req.Domain}, req.URLs...)},
 		},
 	}
 	var err error


### PR DESCRIPTION
This update introduces a check to ensure the URL list is not empty, returning a BadRequest error if no URLs are provided. Additionally, a missing step name "citygml-pack" is added for clarity in build steps. These modifications enhance the robustness and readability of the citygml packer process.