### PR TITLE
refactor(extension): display cms admin data on editor

### DIFF
--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -1,5 +1,5 @@
 import { styled } from "@mui/material";
-import { green, red } from "@mui/material/colors";
+import { useMemo } from "react";
 
 import { EditorDataset } from "..";
 import {
@@ -15,28 +15,48 @@ type StatusBlockProps = EditorBlockProps & {
 };
 
 export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) => {
+  const status: {
+    value: "alpha" | "beta" | "published";
+    label: string;
+  } = useMemo(
+    () =>
+      dataset?.admin?.status === "alpha"
+        ? { value: "alpha", label: "登録中" }
+        : dataset?.admin?.status === "beta"
+        ? { value: "beta", label: "レビュー待ち" }
+        : { value: "published", label: "公開済" },
+    [dataset?.admin?.status],
+  );
   return (
     <EditorBlock title="Status" expandable {...props}>
       <BlockContentWrapper>
         <EditorCommonField label="Status" inline>
-          <PublishStatus published={dataset?.published}>
-            {dataset?.published ? "CMS公開済" : "CMS未公開"}
-          </PublishStatus>
+          <PublishStatus status={status.value}>{status.label}</PublishStatus>
         </EditorCommonField>
-        <EditorTextField label="Created At" value={""} disabled />
-        <EditorTextField label="Updated At" value={""} disabled />
-        <EditorTextField label="CMS URL" value={""} multiline disabled rows={4} />
+        <EditorTextField label="Created At" value={dataset?.admin?.createdAt ?? ""} disabled />
+        <EditorTextField label="Updated At" value={dataset?.admin?.updatedAt ?? ""} disabled />
+        <EditorTextField
+          label="CMS URL"
+          value={dataset?.admin?.cmsUrl ?? ""}
+          multiline
+          disabled
+          rows={8}
+        />
       </BlockContentWrapper>
     </EditorBlock>
   );
 };
 
-const PublishStatus = styled("div")<{ published?: boolean }>(({ theme, published }) => ({
-  display: "inline-block",
-  padding: theme.spacing(0.4, 1),
-  fontSize: theme.typography.body2.fontSize,
-  color: published ? theme.palette.success.main : theme.palette.error.main,
-  border: published ? `1px solid ${green[200]}` : `1px solid ${red[200]}`,
-  backgroundColor: published ? green[100] : red[100],
-  borderRadius: theme.shape.borderRadius,
-}));
+const PublishStatus = styled("div")<{ status: "alpha" | "beta" | "published" }>(
+  ({ theme, status }) => ({
+    display: "inline-block",
+    padding: theme.spacing(0.4, 1),
+    fontSize: theme.typography.body2.fontSize,
+    color: status === "alpha" ? "#595959" : status === "beta" ? "#FAAD14" : "#52C41A",
+    border: `1px solid ${
+      status === "alpha" ? "#D9D9D9" : status === "beta" ? "#FFE58F" : "#B7EB8F"
+    }`,
+    backgroundColor: status === "alpha" ? "#FAFAFA" : status === "beta" ? "#FFFBE6" : "#F6FFED",
+    borderRadius: theme.shape.borderRadius,
+  }),
+);

--- a/extension/src/editor/containers/dataset/index.tsx
+++ b/extension/src/editor/containers/dataset/index.tsx
@@ -31,10 +31,7 @@ import { FieldComponentsPage } from "./FieldComponentsPage";
 import { GeneralPage } from "./GeneralPage";
 import { StatusPage } from "./StatusPage";
 
-// TODO: use plateview dataset type
-export type EditorDataset = DatasetFragmentFragment & {
-  published?: boolean;
-};
+export type EditorDataset = DatasetFragmentFragment;
 
 export type EditorDatasetSectionProps = {
   cache?: EditorCache;

--- a/extension/src/editor/containers/ui-components/editor/EditorTextField.tsx
+++ b/extension/src/editor/containers/ui-components/editor/EditorTextField.tsx
@@ -19,6 +19,9 @@ export const EditorTextInput: React.FC<TextFieldProps> = ({ ...props }) => {
 };
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
+  [`.${inputBaseClasses.root}`]: {
+    padding: 0,
+  },
   [`.${inputBaseClasses.input}`]: {
     padding: theme.spacing(0.5, 1),
     borderRadius: theme.shape.borderRadius,


### PR DESCRIPTION
## Overview

This PR displays the admin data on Status page of Editor panel.

## Screenshot

![image](https://github.com/user-attachments/assets/933aae20-106b-47ba-a689-b1e4212b0822)
(url hidden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset status display with localized labels for "alpha," "beta," and "published."
	- Introduced a more detailed `PublishStatus` component for better status representation.

- **Bug Fixes**
	- Updated `EditorTextField` to correctly display values for "Created At," "Updated At," and "CMS URL."

- **Style**
	- Adjusted styling of `StyledTextField` to improve visual spacing.

- **Refactor**
	- Simplified the `EditorDataset` type by removing the optional `published` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->