### PR TITLE
ci: remove Re:Earth CMS web GCS deploy workflow

### DIFF
--- a/.github/workflows/deploy-cms-dev.yml
+++ b/.github/workflows/deploy-cms-dev.yml
@@ -2,7 +2,6 @@ name: ⭐️ Deploy CMS dev
 on:
   workflow_dispatch:
 env:
-  GCS_DEST: gs://cms-plateau-dev
   CMS_IMAGE_NAME: reearth/reearth-cms:rc
   CMS_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms:latest
   CMS_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/reearth-cms:latest
@@ -60,60 +59,6 @@ jobs:
         env:
           GCP_REGION: ${{ vars.GCP_REGION }}
 
-  # TODO: Remove after migrating to Cloud Run.
-  deploy_web_gcs:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Download CMS web
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          repo: reearth/reearth-cms
-          workflow: ci_web.yml
-          branch: release
-          name: reearth-cms-web
-          check_artifacts: true
-          search_artifacts: true
-      - name: Extract
-        run: tar -xvf reearth-cms-web.tar.gz
-      - name: Replace favicon / App name
-        env:
-          PLATEAU_FAVICON:  https://cms.plateau.reearth.io/img/favicon.ico
-          APP_PATH: reearth-cms-web/index.html
-          APP_NAME: PLATEAU CMS
-        run: |
-          SOURCE=$(cat $APP_PATH)
-          SOURCE=${SOURCE/\/assets\/favicon*.ico/$PLATEAU_FAVICON}
-          SOURCE=${SOURCE/\<title\>*\<\/title\>/<title>$APP_NAME</title>}
-          echo $SOURCE > $APP_PATH
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^reearth_config\\.json$" -dr reearth-cms-web/ ${{ env.GCS_DEST }}
-      - name: Pack web
-        run: |
-          rm reearth-cms-web.tar.gz
-          tar -zcvf reearth-cms-web.tar.gz reearth-cms-web
-      - name: Save as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: reearth-cms-web
-          path: reearth-cms-web.tar.gz
   deploy_server_worker:
     runs-on: ubuntu-latest
     environment: dev

--- a/.github/workflows/deploy-cms-prod.yml
+++ b/.github/workflows/deploy-cms-prod.yml
@@ -7,8 +7,6 @@ on:
         description: Deploy the specific version of web to specify the run ID. If specified, deployment of the server will be skipped. (Optional)
         required: false
 env:
-  GCS_DEST: gs://cms-plateau-prod
-  
   CMS_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-cms:latest
   CMS_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-cms:latest
   CMS_IMAGE_NAME_HUB: eukarya/plateauview2-reearth-cms:latest
@@ -62,44 +60,6 @@ jobs:
         env:
           GCP_REGION: ${{ vars.GCP_REGION }}
 
-  # TODO: Remove after migrating to Cloud Run.
-  deploy_web_gcs:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
-    environment: prod
-    permissions:
-      contents: read
-      id-token: write
-      packages: read
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow: deploy-cms-dev.yml
-          branch: ${{ !github.event.inputs.web_run_id && 'main' || '' }}
-          name: reearth-cms-web
-          check_artifacts: true
-          search_artifacts: true
-          run_id: ${{ github.event.inputs.web_run_id }}
-      - name: Extract
-        run: tar -xvf reearth-cms-web.tar.gz
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^reearth_config\\.json|img.*$" -dr reearth-cms-web/ ${{ env.GCS_DEST }}
-      # - name: Disable cache
-      #   run: gsutil setmeta -h "Cache-Control:no-store" ${{ env.GCS_DEST }}/index.html
-      # TODO: purge CDN cache
   deploy_server:
     runs-on: ubuntu-latest
     environment: prod


### PR DESCRIPTION
# Why

We have already migrated to Cloud Run already so it's not used anymore.

For example:

https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/blob/a9cfc2ae85017677f4b15cff80ac4a7ba0e18713/.github/workflows/deploy-cms-dev.yml#L19-L60