### PR TITLE
feat(extension): support continuous adding dataset for usecase and sample data on shortcut menu

### DIFF
--- a/extension/src/prototypes/ui-components/ContextSelect.tsx
+++ b/extension/src/prototypes/ui-components/ContextSelect.tsx
@@ -10,7 +10,15 @@ import {
   type SelectChangeEvent,
   type SelectProps,
 } from "@mui/material";
-import { forwardRef, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { mergeRefs } from "react-merge-refs";
 import invariant from "tiny-invariant";
 
@@ -52,37 +60,45 @@ const StyledAddIcon = styled(AddIcon)({
   fontSize: 16,
 });
 
+const StyledStack = styled(Stack)({
+  minHeight: 18,
+  minWidth: 98,
+});
+
 export interface ContextSelectProps extends SelectProps<string[]> {
   label: ReactNode;
+  autoClose?: boolean;
 }
 
 export const ContextSelect = forwardRef<HTMLButtonElement, ContextSelectProps>(
-  ({ label, children, onChange, ...props }, forwardedRef) => {
+  ({ label, autoClose = true, children, onChange, ...props }, forwardedRef) => {
     const [open, setOpen] = useState(false);
 
     const handleChange = useCallback(
       (event: SelectChangeEvent<string[]>, value: ReactNode) => {
         invariant(Array.isArray(event.target.value));
         onChange?.(event, value);
-        setOpen(false);
+        if (autoClose) {
+          setOpen(false);
+        }
       },
-      [onChange],
+      [autoClose, onChange],
     );
 
     const renderValue = useCallback(
       (value: string[]) =>
         value.length === 0 ? (
-          <Stack direction="row" spacing={0.75} alignItems="center">
+          <StyledStack direction="row" spacing={0.75} alignItems="center">
             <StyledAddIcon color="action" />
             <Typography variant="body2">{label}</Typography>
-          </Stack>
+          </StyledStack>
         ) : (
-          <Stack direction="row" spacing={0.75}>
+          <StyledStack direction="row" spacing={0.75} alignItems="center">
             <Badge>{value.length}</Badge>
             <Typography variant="body2" color="primary">
               {label}
             </Typography>
-          </Stack>
+          </StyledStack>
         ),
       [label],
     );
@@ -110,6 +126,23 @@ export const ContextSelect = forwardRef<HTMLButtonElement, ContextSelectProps>(
       };
     }, []);
 
+    const menuProps = useMemo(
+      () => ({
+        ...props.MenuProps,
+        sx: {
+          ...props.MenuProps?.sx,
+          [`& .${menuClasses.paper}`]: {
+            maxWidth: 700,
+          },
+        },
+        MenuListProps: {
+          ...props.MenuProps?.MenuListProps,
+          ref: menuRef,
+        },
+      }),
+      [props.MenuProps],
+    );
+
     return (
       <StyledSelect
         ref={mergeRefs([ref, forwardedRef])}
@@ -121,19 +154,7 @@ export const ContextSelect = forwardRef<HTMLButtonElement, ContextSelectProps>(
         renderValue={renderValue}
         {...props}
         onChange={handleChange}
-        MenuProps={{
-          ...props.MenuProps,
-          sx: {
-            ...props.MenuProps?.sx,
-            [`& .${menuClasses.paper}`]: {
-              maxWidth: 700,
-            },
-          },
-          MenuListProps: {
-            ...props.MenuProps?.MenuListProps,
-            ref: menuRef,
-          },
-        }}>
+        MenuProps={menuProps}>
         {children}
       </StyledSelect>
     );

--- a/extension/src/prototypes/ui-components/ContextSelect.tsx
+++ b/extension/src/prototypes/ui-components/ContextSelect.tsx
@@ -60,11 +60,6 @@ const StyledAddIcon = styled(AddIcon)({
   fontSize: 16,
 });
 
-const StyledStack = styled(Stack)({
-  minHeight: 18,
-  minWidth: 98,
-});
-
 export interface ContextSelectProps extends SelectProps<string[]> {
   label: ReactNode;
   autoClose?: boolean;
@@ -88,17 +83,17 @@ export const ContextSelect = forwardRef<HTMLButtonElement, ContextSelectProps>(
     const renderValue = useCallback(
       (value: string[]) =>
         value.length === 0 ? (
-          <StyledStack direction="row" spacing={0.75} alignItems="center">
+          <Stack direction="row" spacing={0.75} alignItems="center">
             <StyledAddIcon color="action" />
             <Typography variant="body2">{label}</Typography>
-          </StyledStack>
+          </Stack>
         ) : (
-          <StyledStack direction="row" spacing={0.75} alignItems="center">
+          <Stack direction="row" spacing={0.75} alignItems="center">
             <Badge>{value.length}</Badge>
             <Typography variant="body2" color="primary">
               {label}
             </Typography>
-          </StyledStack>
+          </Stack>
         ),
       [label],
     );

--- a/extension/src/prototypes/view/ui-containers/DatasetTreeSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DatasetTreeSelect.tsx
@@ -45,10 +45,11 @@ export interface DatasetTreeSelectProps {
   datasets: DatasetItem[];
   municipalityCode: string;
   disabled?: boolean;
+  allowContinuousAdd?: boolean;
 }
 
 export const DatasetTreeSelect: FC<DatasetTreeSelectProps> = memo(
-  ({ datasets, municipalityCode, disabled, label }) => {
+  ({ datasets, municipalityCode, disabled, label, allowContinuousAdd }) => {
     invariant(datasets.length > 0);
     const rootLayers = useAtomValue(rootLayersAtom);
     const settings = useAtomValue(settingsAtom);
@@ -142,7 +143,12 @@ export const DatasetTreeSelect: FC<DatasetTreeSelectProps> = memo(
     }, [datasets]);
 
     return (
-      <ContextSelect label={label} value={value} onChange={handleChange} disabled={disabled}>
+      <ContextSelect
+        label={label}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        autoClose={!allowContinuousAdd}>
         {selectTreeItems.map((item, index) => {
           if (item.isFolder) {
             return (

--- a/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
+++ b/extension/src/prototypes/view/ui-containers/DefaultDatasetSelect.tsx
@@ -48,10 +48,11 @@ export interface DefaultDatasetSelectProps {
   datasets: DatasetFragmentFragment[];
   municipalityCode: string;
   disabled?: boolean;
+  allowContinuousAdd?: boolean;
 }
 
 export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
-  ({ datasets, municipalityCode, disabled }) => {
+  ({ datasets, municipalityCode, disabled, allowContinuousAdd }) => {
     invariant(datasets.length > 0);
     const rootLayers = useAtomValue(rootLayersAtom);
     const settings = useAtomValue(settingsAtom);
@@ -151,7 +152,8 @@ export const DefaultDatasetSelect: FC<DefaultDatasetSelectProps> = memo(
         label={datasets[0].type.name ?? datasetTypeNames.usecase}
         value={value}
         onChange={handleChange}
-        disabled={disabled}>
+        disabled={disabled}
+        autoClose={!allowContinuousAdd}>
         {datasets.flatMap((dataset, index) => {
           if (
             dataset.items.length > 1 ||

--- a/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
+++ b/extension/src/prototypes/view/ui-containers/LocationBreadcrumbItem.tsx
@@ -10,7 +10,7 @@ import { isNotNullish } from "../../type-helpers";
 import { AppBreadcrumbsItem, ContextBar, OverlayPopper } from "../../ui-components";
 import { isGenericDatasetType } from "../constants/generic";
 import { PlateauDatasetType } from "../constants/plateau";
-import { getDatasetGroups } from "../utils/datasetGroups";
+import { DatasetGroupItem, getDatasetGroups } from "../utils/datasetGroups";
 
 import { BuildingDatasetButtonSelect } from "./BuildingDatasetButtonSelect";
 import { DatasetTreeSelect } from "./DatasetTreeSelect";
@@ -29,7 +29,7 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
   );
   const query = useAreaDatasets(area.code);
 
-  const datasetGroups = useMemo(() => {
+  const datasetGroups: DatasetGroupItem[] | undefined = useMemo(() => {
     const datasets = query.data?.area?.datasets;
     if (!datasets) {
       return;
@@ -112,7 +112,7 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
       {hasDatasets && (
         <OverlayPopper {...popoverProps} inset={1.5} onClose={handleClose}>
           <ContextBar expanded={expanded} onCollapse={handleCollapse} onExpand={handleExpand}>
-            {datasetGroups.map(({ useTree, label, datasets }) => {
+            {datasetGroups.map(({ useTree, label, datasets, allowContinuousAdd }) => {
               if (useTree) {
                 return (
                   <DatasetTreeSelect
@@ -120,6 +120,7 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
                     label={label}
                     datasets={datasets}
                     municipalityCode={area.code}
+                    allowContinuousAdd={allowContinuousAdd}
                   />
                 );
               }
@@ -129,6 +130,7 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
                     key={datasets[0].id}
                     datasets={datasets}
                     municipalityCode={area.code}
+                    allowContinuousAdd={allowContinuousAdd}
                   />
                 );
               }
@@ -151,6 +153,7 @@ export const LocationBreadcrumbItem: FC<LocationBreadcrumbItemProps> = ({ area }
                   key={dataset.id}
                   datasets={[dataset]}
                   municipalityCode={area.code}
+                  allowContinuousAdd={allowContinuousAdd}
                 />
               );
             })}

--- a/extension/src/prototypes/view/utils/datasetGroups.test.ts
+++ b/extension/src/prototypes/view/utils/datasetGroups.test.ts
@@ -194,12 +194,14 @@ test("Dataset group with sample data", () => {
         groupId: "generic:ユースケース",
         label: "ユースケース",
         useTree: true,
+        allowContinuousAdd: true,
       },
       {
         datasets: [{ folderPath: "Mock Sample Dataset", ...d5 }],
         groupId: "generic:サンプルデータ",
         label: "サンプルデータ",
         useTree: true,
+        allowContinuousAdd: true,
       },
     ],
     cityDatasetGroups: [],
@@ -326,6 +328,7 @@ test("Dataset group with city dataset", () => {
         groupId: "generic:ユースケース",
         label: "ユースケース",
         useTree: true,
+        allowContinuousAdd: true,
       },
     ],
     cityDatasetGroups: [

--- a/extension/src/prototypes/view/utils/datasetGroups.ts
+++ b/extension/src/prototypes/view/utils/datasetGroups.ts
@@ -10,6 +10,7 @@ export type DatasetGroupItem = {
   groupId: string;
   datasets: DatasetItem[];
   useTree?: boolean;
+  allowContinuousAdd?: boolean;
 };
 
 export function getDatasetGroups({
@@ -73,8 +74,8 @@ export function getDatasetGroups({
   const genericDatasets = datasets?.filter(
     d =>
       !(d.groups && d.groups.length > 0) &&
-      isGenericDatasetType(d.type.code) &&
-      d.type.code !== "city",
+      d.type.code !== "city" &&
+      isGenericDatasetType(d.type.code),
   );
   const genericGroups = genericDatasets
     ? Object.entries(groupBy(genericDatasets, d => d.type.name)).map(([key, value]) => ({
@@ -82,6 +83,7 @@ export function getDatasetGroups({
         groupId: generateGroupId("generic", key, prefCode, cityCode, areaCode),
         datasets: value.map(v => ({ ...v, folderPath: v.name })),
         useTree: true,
+        allowContinuousAdd: true,
       }))
     : undefined;
 


### PR DESCRIPTION
## Overview

This PR supports continuous add dataset for usecase and sample data on shortcut menu.

NOTE: the popup menu UI will change position after add one dataset, i think it's from the UI component library. 

## Screenshot

![image](https://github.com/user-attachments/assets/49f02057-a503-4efe-a245-ac06b60f66be)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `autoClose` property in `ContextSelect` for controlling dropdown behavior.
	- Added `allowContinuousAdd` property in `DatasetTreeSelect` and `DefaultDatasetSelect`, enhancing continuous addition functionality.
  
- **Improvements**
	- Enhanced type safety and structure in `LocationBreadcrumbItem` with `allowContinuousAdd`.
	- Updated test cases to reflect the new `allowContinuousAdd` property in dataset groups.

These changes improve user interaction with dropdowns and dataset selections, providing more flexible options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->