### PR TITLE
refactor(extension): display dataset admin time in local time

### DIFF
--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -27,14 +27,24 @@ export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) =
         : { value: "published", label: "公開済" },
     [dataset?.admin?.status],
   );
+
+  const localCreatedAt = useMemo(
+    () => UTCTimeToLocalTime(dataset?.admin?.createdAt),
+    [dataset?.admin?.createdAt],
+  );
+  const localUpdatedAt = useMemo(
+    () => UTCTimeToLocalTime(dataset?.admin?.updatedAt),
+    [dataset?.admin?.updatedAt],
+  );
+
   return (
     <EditorBlock title="Status" expandable {...props}>
       <BlockContentWrapper>
         <EditorCommonField label="Status" inline>
           <PublishStatus status={status.value}>{status.label}</PublishStatus>
         </EditorCommonField>
-        <EditorTextField label="Created At" value={dataset?.admin?.createdAt ?? ""} disabled />
-        <EditorTextField label="Updated At" value={dataset?.admin?.updatedAt ?? ""} disabled />
+        <EditorTextField label="Created At" value={localCreatedAt} disabled />
+        <EditorTextField label="Updated At" value={localUpdatedAt} disabled />
         <EditorTextField
           label="CMS URL"
           value={dataset?.admin?.cmsUrl ?? ""}
@@ -60,3 +70,16 @@ const PublishStatus = styled("div")<{ status: "alpha" | "beta" | "published" }>(
     borderRadius: theme.shape.borderRadius,
   }),
 );
+
+function UTCTimeToLocalTime(utcTime: string): string {
+  if (!utcTime) return "";
+  return new Date(utcTime).toLocaleString("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}


### PR DESCRIPTION
## Overview

This PR formatted the `CreatedAt` and `UpdatedAt` to local time.

## Screenshot

![image](https://github.com/user-attachments/assets/54be0779-9e1c-4f41-8617-c3246e8740a6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date handling in the Status Block to display creation and update times in local time instead of UTC.

- **Bug Fixes**
	- Improved user experience by ensuring timestamps are more user-friendly and accurately reflect local time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->