### PR TITLE
fix(extension): correct property name of admin publish status

### DIFF
--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -20,12 +20,12 @@ export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) =
     label: string;
   } = useMemo(
     () =>
-      dataset?.admin?.status === "alpha"
+      dataset?.admin?.stage === "alpha"
         ? { value: "alpha", label: "登録中" }
-        : dataset?.admin?.status === "beta"
+        : dataset?.admin?.stage === "beta"
         ? { value: "beta", label: "レビュー待ち" }
         : { value: "published", label: "公開済" },
-    [dataset?.admin?.status],
+    [dataset?.admin?.stage],
   );
 
   const localCreatedAt = useMemo(


### PR DESCRIPTION
## Overview

The property name should be `stage` not `status`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the dataset status display to reflect the current stage (alpha/beta) instead of status.
  
- **Bug Fixes**
	- Corrected logic for determining dataset stage, ensuring accurate representation in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->