### PR TITLE
refactor(extension): update time format to YYYY-MM-DD HH:mm

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -40,6 +40,7 @@
     "chroma-js": "2.4.2",
     "class-validator": "0.14.0",
     "d3": "7.8.5",
+    "dayjs": "1.11.13",
     "easymde": "2.18.0",
     "file-saver": "2.0.5",
     "framer-motion": "10.16.1",

--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -1,4 +1,6 @@
 import { styled } from "@mui/material";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { useMemo } from "react";
 
 import { EditorDataset } from "..";
@@ -9,6 +11,8 @@ import {
   EditorCommonField,
   EditorTextField,
 } from "../../ui-components";
+
+dayjs.extend(utc);
 
 type StatusBlockProps = EditorBlockProps & {
   dataset?: EditorDataset;
@@ -29,11 +33,11 @@ export const StatusBlock: React.FC<StatusBlockProps> = ({ dataset, ...props }) =
   );
 
   const localCreatedAt = useMemo(
-    () => UTCTimeToLocalTime(dataset?.admin?.createdAt),
+    () => toLocalTime(dataset?.admin?.createdAt),
     [dataset?.admin?.createdAt],
   );
   const localUpdatedAt = useMemo(
-    () => UTCTimeToLocalTime(dataset?.admin?.updatedAt),
+    () => toLocalTime(dataset?.admin?.updatedAt),
     [dataset?.admin?.updatedAt],
   );
 
@@ -71,15 +75,7 @@ const PublishStatus = styled("div")<{ status: "alpha" | "beta" | "published" }>(
   }),
 );
 
-function UTCTimeToLocalTime(utcTime: string): string {
-  if (!utcTime) return "";
-  return new Date(utcTime).toLocaleString("en-US", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
+function toLocalTime(time: string): string {
+  if (!time) return "";
+  return dayjs(time).local().format("YYYY-MM-DD HH:mm");
 }

--- a/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
+++ b/extension/src/editor/containers/dataset/blocks/StatusBlock.tsx
@@ -1,6 +1,4 @@
 import { styled } from "@mui/material";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import { useMemo } from "react";
 
 import { EditorDataset } from "..";
@@ -11,8 +9,7 @@ import {
   EditorCommonField,
   EditorTextField,
 } from "../../ui-components";
-
-dayjs.extend(utc);
+import dayjs from "../../utils-dayjs";
 
 type StatusBlockProps = EditorBlockProps & {
   dataset?: EditorDataset;

--- a/extension/src/editor/containers/utils-dayjs.ts
+++ b/extension/src/editor/containers/utils-dayjs.ts
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+export default dayjs;

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -7944,6 +7944,11 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+dayjs@1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION
## Overview

This PR updates the time format used in editor status panel. It should be `YYYY-MM-DD HH:mm` in local time.

## Screenshot

![image](https://github.com/user-attachments/assets/3ea32182-96e0-449d-875a-190361adeab7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced date handling capabilities with the addition of the `dayjs` library for improved local time conversion.
  
- **Bug Fixes**
	- Updated time conversion logic to ensure accurate formatting of `createdAt` and `updatedAt` fields.
  
- **Chores**
	- Added a new dependency for date manipulation: `dayjs`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->