### PR TITLE
feat(extension): support duplicate template

### DIFF
--- a/extension/src/editor/containers/common/commonTemplate/TemplateHeader.tsx
+++ b/extension/src/editor/containers/common/commonTemplate/TemplateHeader.tsx
@@ -9,6 +9,7 @@ import {
   EditorPopperListItemButton,
   EditorTextField,
 } from "../../ui-components";
+import dayjs from "../../utils-dayjs";
 import { EditorClickAwayListener } from "../EditorClickAwayListener";
 
 type TemplateHeaderProps = {
@@ -213,7 +214,7 @@ const StyledButton = styled(Button)(({ theme }) => ({
 }));
 
 function generateDuplicateTemplateName(ori: string) {
-  return `${ori} (copy-${new Date().getTime()})`;
+  return `${ori} (copy-${dayjs(new Date()).local().format("YYYY-MM-DD HH:mm:ss")})`;
 }
 
 function isTemplateNameInvalid(name: string, existNames: string[]) {

--- a/extension/src/editor/containers/common/commonTemplate/TemplateHeader.tsx
+++ b/extension/src/editor/containers/common/commonTemplate/TemplateHeader.tsx
@@ -65,12 +65,7 @@ export const TemplateHeader: React.FC<TemplateHeaderProps> = ({
   }, []);
 
   const newTemplateNameInvalid = useMemo(() => {
-    return (
-      templateNames.includes(newTemplateName) ||
-      newTemplateName === "" ||
-      newTemplateName.endsWith("/") ||
-      newTemplateName.split("/").some(p => p === "")
-    );
+    return isTemplateNameInvalid(newTemplateName, templateNames);
   }, [newTemplateName, templateNames]);
 
   const handleClickAway = useCallback(() => {
@@ -106,14 +101,10 @@ export const TemplateHeader: React.FC<TemplateHeaderProps> = ({
     },
     [],
   );
-  const duplicatedTemplateNameValid = useMemo(() => {
-    return (
-      templateNames.includes(duplicatedTemplateName) ||
-      duplicatedTemplateName === "" ||
-      duplicatedTemplateName.endsWith("/") ||
-      duplicatedTemplateName.split("/").some(p => p === "")
-    );
+  const duplicatedTemplateNameInvalid = useMemo(() => {
+    return isTemplateNameInvalid(duplicatedTemplateName, templateNames);
   }, [duplicatedTemplateName, templateNames]);
+
   const handleTemplateDuplicate = useCallback(() => {
     onTemplateDuplicate?.(duplicatedTemplateName);
     setDuplicateTemplateOpen(false);
@@ -182,7 +173,7 @@ export const TemplateHeader: React.FC<TemplateHeaderProps> = ({
           primaryButtonText="Duplicate"
           onClose={handleCloseDuplicateTemplate}
           onSubmit={handleTemplateDuplicate}
-          submitDisabled={duplicatedTemplateNameValid}>
+          submitDisabled={duplicatedTemplateNameInvalid}>
           <EditorTextField
             autoFocus
             label="Full path:"
@@ -223,4 +214,13 @@ const StyledButton = styled(Button)(({ theme }) => ({
 
 function generateDuplicateTemplateName(ori: string) {
   return `${ori} (copy-${new Date().getTime()})`;
+}
+
+function isTemplateNameInvalid(name: string, existNames: string[]) {
+  return (
+    existNames.includes(name) ||
+    name === "" ||
+    name.endsWith("/") ||
+    name.split("/").some(p => p === "")
+  );
 }

--- a/extension/src/editor/containers/component-template/index.tsx
+++ b/extension/src/editor/containers/component-template/index.tsx
@@ -197,6 +197,43 @@ export const EditorFieldComponentsTemplateSection: React.FC<
     [editorNoticeRef, removeTemplate],
   );
 
+  const handleTemplateDuplicate = useCallback(
+    async (newTemplateName: string) => {
+      if (!template) return;
+      const newTemplate = {
+        name: newTemplateName,
+        type: "component",
+        groups: template.groups.map(g => ({
+          ...g,
+          id: generateID(),
+          components: g.components.map(c => ({
+            ...c,
+            id: generateID(),
+          })),
+        })),
+      } as unknown as ComponentTemplate;
+
+      setIsSaving(true);
+      await saveTemplate(newTemplate)
+        .then(() => {
+          editorNoticeRef?.current?.show({
+            severity: "success",
+            message: "Template duplicated!",
+          });
+        })
+        .catch(() => {
+          editorNoticeRef?.current?.show({
+            severity: "error",
+            message: "Template duplicate failed!",
+          });
+        })
+        .finally(() => {
+          setIsSaving(false);
+        });
+    },
+    [editorNoticeRef, saveTemplate, template],
+  );
+
   return (
     <EditorSection
       sidebarMain={
@@ -230,6 +267,7 @@ export const EditorFieldComponentsTemplateSection: React.FC<
             templateNames={templateNames}
             onTemplateRename={handleTemplateRename}
             onTemplateRemove={handleTemplateRemove}
+            onTemplateDuplicate={handleTemplateDuplicate}
           />
         )
       }

--- a/extension/src/editor/containers/emphasis-property-template/index.tsx
+++ b/extension/src/editor/containers/emphasis-property-template/index.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback, useEffect } from "react";
 
 import { useTemplateAPI } from "../../../shared/api";
 import { EmphasisPropertyTemplate } from "../../../shared/api/types";
+import { generateID } from "../../../shared/utils";
 import { TemplateAddButton } from "../common/commonTemplate/TemplateAddButton";
 import { TemplateHeader } from "../common/commonTemplate/TemplateHeader";
 import { EditorSection, EditorTree, EditorTreeSelection } from "../ui-components";
@@ -188,6 +189,36 @@ export const EditorInspectorEmphasisPropertyTemplateSection: React.FC<
     [editorNoticeRef, removeTemplate],
   );
 
+  const handleTemplateDuplicate = useCallback(
+    async (newTemplateName: string) => {
+      if (!template) return;
+      const newTemplate = {
+        name: newTemplateName,
+        type: "emphasis",
+        properties: template.properties.map(p => ({ ...p, id: generateID() })),
+      } as unknown as EmphasisPropertyTemplate;
+
+      setIsSaving(true);
+      await saveTemplate(newTemplate)
+        .then(() => {
+          editorNoticeRef?.current?.show({
+            severity: "success",
+            message: "Template duplicated!",
+          });
+        })
+        .catch(() => {
+          editorNoticeRef?.current?.show({
+            severity: "error",
+            message: "Template duplicate failed!",
+          });
+        })
+        .finally(() => {
+          setIsSaving(false);
+        });
+    },
+    [editorNoticeRef, saveTemplate, template],
+  );
+
   return (
     <EditorSection
       sidebarMain={
@@ -223,6 +254,7 @@ export const EditorInspectorEmphasisPropertyTemplateSection: React.FC<
             templateNames={templateNames}
             onTemplateRename={handleTemplateRename}
             onTemplateRemove={handleTemplateRemove}
+            onTemplateDuplicate={handleTemplateDuplicate}
           />
         )
       }


### PR DESCRIPTION
## Overview

This PR adds the support for duplicate template
- Create a new template with the same settings
- Support component template and emphasis property template
- Automatically generate the name with timestamp, user can rename to what they want.

## Screenshot

![image](https://github.com/user-attachments/assets/3825c3f4-ecfd-40f7-9237-397a09689476)
![image](https://github.com/user-attachments/assets/7d3dbed1-eca5-4dc0-b38f-2d0f312fc130)
![image](https://github.com/user-attachments/assets/695b03ef-7569-4c54-bea4-3d11056250f5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a template duplication feature across multiple components, allowing users to easily create copies of existing templates.
	- Added a dialog for users to enter the name of the duplicated template, enhancing the template management experience.

- **Bug Fixes**
	- Improved error handling and user notifications during the template duplication process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->