### PR TITLE
fix(extension): shared project's initial camera doesn't work

### DIFF
--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -3,7 +3,6 @@
 import { FC, useEffect } from "react";
 
 import { AmbientOcclusion, Antialias, CameraPosition, Tile, TileLabels } from "../types";
-import { Camera } from "../types/viewer";
 import { isReEarthAPIv2 } from "../utils/reearth";
 
 // nx = red
@@ -110,7 +109,6 @@ export const Scene: FC<SceneProps> = ({
     if (isReEarthAPIv2(window?.reearth)) {
       window.reearth?.viewer?.overrideProperty?.({
         camera: {
-          camera: initialCamera as Camera,
           allowEnterGround: enterUnderground,
         },
         scene: {
@@ -208,6 +206,9 @@ export const Scene: FC<SceneProps> = ({
           },
         },
       });
+      if (initialCamera) {
+        window.reearth?.camera?.flyTo(initialCamera, { duration: 0 });
+      }
     } else {
       window.reearth?.scene?.overrideProperty({
         default: {

--- a/extension/src/shared/reearth/types/viewer.ts
+++ b/extension/src/shared/reearth/types/viewer.ts
@@ -149,7 +149,6 @@ export type SkyAtmosphereProperty = {
 };
 
 export type CameraProperty = {
-  camera?: Camera;
   allowEnterGround?: boolean;
   limiter?: CameraLimiterProperty;
 };


### PR DESCRIPTION
## Overview

We should use camera API to set the camera in plugin API v2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced camera handling with a fly-to animation for the `initialCamera` property in the Scene component.
  
- **Bug Fixes**
	- Updated camera settings application for both v2 and non-v2 API versions.

- **Refactor**
	- Removed the `camera` property from the `CameraProperty` type to streamline camera-related configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->