### PR TITLE
fix: handle Tokyo sample data as Tokyo prefecture data

### DIFF
--- a/extension/src/shared/constants/dataset.ts
+++ b/extension/src/shared/constants/dataset.ts
@@ -1,0 +1,1 @@
+export const TOKYO_SAMPLE_DATA_CITY_CODE = "13999";

--- a/extension/src/shared/constants/index.ts
+++ b/extension/src/shared/constants/index.ts
@@ -1,2 +1,3 @@
 export * from "./localStorage";
 export * from "./colorMaps";
+export * from "./dataset";

--- a/extension/src/shared/graphql/hooks/catalog/area.ts
+++ b/extension/src/shared/graphql/hooks/catalog/area.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { TOKYO_SAMPLE_DATA_CITY_CODE } from "../../../constants";
 import { AREAS, AREA_DATASETS } from "../../base/catalog/queries/area";
 import { AreasInput, DatasetsInput } from "../../types/catalog";
 
@@ -10,12 +11,26 @@ type Options = {
 };
 
 export const useAreas = (input?: AreasInput, options?: Options) => {
-  return useQuery(AREAS, {
+  const data = useQuery(AREAS, {
     variables: {
       input: input ?? {},
     },
     skip: options?.skip,
   });
+  const next = useMemo(
+    () => ({
+      ...data,
+      data: data.data
+        ? {
+            ...data.data,
+            areas: data.data.areas.filter(a => a.code !== TOKYO_SAMPLE_DATA_CITY_CODE),
+          }
+        : undefined,
+    }),
+    [data],
+  );
+
+  return next;
 };
 
 export const useAreaDatasets = (code: string, input?: DatasetsInput, options?: Options) => {
@@ -28,7 +43,12 @@ export const useAreaDatasets = (code: string, input?: DatasetsInput, options?: O
   });
 
   const nextDatasets = useMemo(
-    () => data?.area?.datasets.slice().sort((a, b) => a.type.order - b.type.order),
+    () =>
+      data?.area?.datasets
+        .map(d =>
+          d.cityCode === TOKYO_SAMPLE_DATA_CITY_CODE ? { ...d, cityCode: null, city: null } : d,
+        )
+        .sort((a, b) => a.type.order - b.type.order),
     [data],
   );
 


### PR DESCRIPTION
I fixed to handle 13999 city(*東京都サンプルデータ*) which is exception city as 13(Tokyo prefecture). 13999 is used to show special data for Tokyo, so this case should be Tokyo specific.

- Search panel should show 13999 data(city data) as 13 data(prefecture data).
- Location breadcrumb bar should show 13999 data(city data) as 13 data(prefecture data).

|Before|After|
|:--:|:--:|
|![Screenshot 2024-11-19 at 11 56 31](https://github.com/user-attachments/assets/d337cd11-bf75-4551-9e93-c7dfcb985272)|![Screenshot 2024-11-19 at 11 54 32](https://github.com/user-attachments/assets/ac04885f-06e8-456e-b52e-8f50c6caca97)|
|![Screenshot 2024-11-19 at 11 56 54](https://github.com/user-attachments/assets/eea7b036-09cb-4693-b7c4-90882f8e5dfc)|![Screenshot 2024-11-19 at 11 55 30](https://github.com/user-attachments/assets/c75e2e4f-2169-4204-bb08-bb6ac1c2bcca)|
|![Screenshot 2024-11-19 at 11 57 11](https://github.com/user-attachments/assets/67a8acb2-8aaf-40a6-8373-373c742378f9)|![Screenshot 2024-11-19 at 11 55 47](https://github.com/user-attachments/assets/58863f3a-d3ec-4b8b-a37a-5ba1f7bad7df)|




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for Tokyo city code to enhance data handling.
	- Updated hooks to filter and map datasets based on the new Tokyo city code.

- **Enhancements**
	- Improved data processing logic in the `useAreas` and `useAreaDatasets` hooks for better performance and accuracy. 

- **Documentation**
	- Enhanced module export capabilities by including new constants in the index file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->