### PR TITLE
fix: prevent updating initial camera every time

### DIFF
--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -206,9 +206,6 @@ export const Scene: FC<SceneProps> = ({
           },
         },
       });
-      if (initialCamera) {
-        window.reearth?.camera?.flyTo(initialCamera, { duration: 0 });
-      }
     } else {
       window.reearth?.scene?.overrideProperty({
         default: {
@@ -323,6 +320,12 @@ export const Scene: FC<SceneProps> = ({
     enterUnderground,
     hideUnderground,
   ]);
+
+  useEffect(() => {
+    if (initialCamera) {
+      window.reearth?.camera?.flyTo(initialCamera, { duration: 0 });
+    }
+  }, [initialCamera]);
 
   return null;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced camera functionality: The camera now flies to the specified position immediately upon component mount if `initialCamera` is provided.
  
- **Bug Fixes**
	- Improved clarity and control flow by separating camera movement logic from property overriding in the ReEarth API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->