### PR TITLE
feat(server): support sub name in asset name except fld in datacatalogv3

### DIFF
--- a/server/datacatalog/datacatalogv3/cms_model.go
+++ b/server/datacatalog/datacatalogv3/cms_model.go
@@ -44,6 +44,7 @@ type FeatureType struct {
 	MVTLayerNamesForLOD map[int][]string `json:"layer_names_for_lod,omitempty" cms:"-"`
 	MVTLayerNamePrefix  string           `json:"layer_name_prefix,omitempty" cms:"layer_name_prefix,text"`
 	HideTexture         bool             `json:"hide_texture,omitempty" cms:"hide_texture,bool"`
+	HideLOD             bool             `json:"hide_lod,omitempty" cms:"hide_lod,bool"`
 }
 
 type CityItem struct {

--- a/server/datacatalog/datacatalogv3/consts.go
+++ b/server/datacatalog/datacatalogv3/consts.go
@@ -56,6 +56,7 @@ var plateauFeatureTypes = []FeatureType{
 		Code:         "luse",
 		Name:         "土地利用モデル",
 		MVTLayerName: []string{"luse"},
+		HideLOD:      true,
 	},
 	{
 		Code:        "fld",
@@ -99,10 +100,12 @@ var plateauFeatureTypes = []FeatureType{
 		Name:         "土砂災害警戒区域モデル",
 		GroupName:    "災害リスク（土砂災害）モデル",
 		MVTLayerName: []string{"lsld"},
+		HideLOD:      true,
 	},
 	{
-		Code: "urf",
-		Name: "都市計画決定情報モデル",
+		Code:    "urf",
+		Name:    "都市計画決定情報モデル",
+		HideLOD: true,
 	},
 	{
 		Code:         "brid",
@@ -149,11 +152,13 @@ var plateauFeatureTypes = []FeatureType{
 		Code:         "area",
 		Name:         "区域モデル",
 		MVTLayerName: []string{"Zone"},
+		HideLOD:      true,
 	},
 	{
 		Code:               "gen",
 		Name:               "汎用都市オブジェクトモデル",
 		MVTLayerNamePrefix: "gen",
+		HideLOD:            true,
 	},
 }
 

--- a/server/datacatalog/datacatalogv3/consts.go
+++ b/server/datacatalog/datacatalogv3/consts.go
@@ -56,7 +56,6 @@ var plateauFeatureTypes = []FeatureType{
 		Code:         "luse",
 		Name:         "土地利用モデル",
 		MVTLayerName: []string{"luse"},
-		HideLOD:      true,
 	},
 	{
 		Code:        "fld",
@@ -100,12 +99,10 @@ var plateauFeatureTypes = []FeatureType{
 		Name:         "土砂災害警戒区域モデル",
 		GroupName:    "災害リスク（土砂災害）モデル",
 		MVTLayerName: []string{"lsld"},
-		HideLOD:      true,
 	},
 	{
-		Code:    "urf",
-		Name:    "都市計画決定情報モデル",
-		HideLOD: true,
+		Code: "urf",
+		Name: "都市計画決定情報モデル",
 	},
 	{
 		Code:         "brid",
@@ -152,13 +149,12 @@ var plateauFeatureTypes = []FeatureType{
 		Code:         "area",
 		Name:         "区域モデル",
 		MVTLayerName: []string{"Zone"},
-		HideLOD:      true,
 	},
 	{
 		Code:               "gen",
 		Name:               "汎用都市オブジェクトモデル",
 		MVTLayerNamePrefix: "gen",
-		HideLOD:            true,
+		// HideLOD:            true,
 	},
 }
 

--- a/server/datacatalog/datacatalogv3/conv.go
+++ b/server/datacatalog/datacatalogv3/conv.go
@@ -289,7 +289,8 @@ func setGroupsToDatasets(datasets []*plateauapi.PlateauDataset, groups []string)
 			continue
 		}
 
-		ds.Groups = append(groups)
+		ds.Groups = make([]string, len(groups))
+		copy(ds.Groups, groups)
 	}
 }
 

--- a/server/datacatalog/datacatalogv3/conv_asset.go
+++ b/server/datacatalog/datacatalogv3/conv_asset.go
@@ -214,32 +214,6 @@ func ParseAssetNameExNormal(name string) *AssetNameExNormal {
 	}
 }
 
-// var reAssetNameExUrf = regexp.MustCompile(`^([a-z]+)_([A-Za-z0-9-_]+)_(mvt|3dtiles)(_lod\d+)?(_no_texture)?$`)
-
-// func ParseAssetNameExUrf(name string) *AssetNameExUrf {
-// 	if name == "" {
-// 		return nil
-// 	}
-
-// 	m := reAssetNameExUrf.FindStringSubmatch(name)
-// 	if len(m) == 0 {
-// 		return nil
-// 	}
-
-// 	lod := 0
-// 	if m[4] != "" {
-// 		lod, _ = strconv.Atoi(m[4][4:])
-// 	}
-
-// 	return &AssetNameExUrf{
-// 		Type:      m[1],
-// 		Name:      m[2],
-// 		Format:    m[3],
-// 		LOD:       lod,
-// 		NoTexture: m[5] != "",
-// 	}
-// }
-
 var reAssetNameExFld = regexp.MustCompile(`^fld_(natl|pref)_([A-Za-z0-9-_]+)_3dtiles_(l\d+)(?:-(.+?))?(_no_texture)?$`)
 
 func ParseAssetNameExFld(name string) *AssetNameExFld {

--- a/server/datacatalog/datacatalogv3/conv_asset.go
+++ b/server/datacatalog/datacatalogv3/conv_asset.go
@@ -168,14 +168,14 @@ func ParseAssetNameEx(name string) (ex AssetNameEx) {
 	return
 }
 
-var reAasetNameExNormal = regexp.MustCompile(`^([a-z]+)(?:_([A-Za-z0-9-_]+))?_(mvt|3dtiles|dm_geometric_attributes)(?:_(\d+)_([a-z0-9-]+))?(_lod\d\d?)?(_no_texture)?$`)
+var reAssetNameExNormal = regexp.MustCompile(`^([a-z]+)(?:_([A-Za-z0-9-_]+))?_(mvt|3dtiles|dm_geometric_attributes)(?:_(\d+)_([a-z0-9-]+))?(_lod\d\d?)?(_no_texture)?$`)
 
 func ParseAssetNameExNormal(name string) *AssetNameExNormal {
 	if name == "" {
 		return nil
 	}
 
-	m := reAasetNameExNormal.FindStringSubmatch(name)
+	m := reAssetNameExNormal.FindStringSubmatch(name)
 	if len(m) == 0 {
 		return nil
 	}

--- a/server/datacatalog/datacatalogv3/conv_asset.go
+++ b/server/datacatalog/datacatalogv3/conv_asset.go
@@ -29,7 +29,6 @@ func (n AssetName) String() string {
 
 type AssetNameEx struct {
 	Normal *AssetNameExNormal
-	Urf    *AssetNameExUrf
 	Fld    *AssetNameExFld
 	Ex     string
 }
@@ -39,15 +38,13 @@ func (ex AssetNameEx) String() string {
 }
 
 func (ex AssetNameEx) IsValid() bool {
-	return ex.Normal != nil || ex.Urf != nil || ex.Fld != nil
+	return ex.Normal != nil || ex.Fld != nil
 }
 
 func (ex AssetNameEx) DatasetItemKey() string {
 	switch {
 	case ex.Normal != nil:
 		return ex.Normal.DatasetItemKey()
-	case ex.Urf != nil:
-		return ex.Urf.DatasetItemKey()
 	case ex.Fld != nil:
 		return ex.Fld.DatasetItemKey()
 	}
@@ -58,8 +55,6 @@ func (ex AssetNameEx) DatasetKey() string {
 	switch {
 	case ex.Normal != nil:
 		return ex.Normal.DatasetKey()
-	case ex.Urf != nil:
-		return ex.Urf.DatasetKey()
 	case ex.Fld != nil:
 		return ex.Fld.DatasetKey()
 	}
@@ -70,8 +65,6 @@ func (ex AssetNameEx) DicKey() string {
 	switch {
 	case ex.Normal != nil:
 		return ex.Normal.DicKey()
-	case ex.Urf != nil:
-		return ex.Urf.DicKey()
 	case ex.Fld != nil:
 		return ex.Fld.DicKey()
 	}
@@ -80,43 +73,25 @@ func (ex AssetNameEx) DicKey() string {
 
 type AssetNameExNormal struct {
 	Type      string
+	Name      string
 	Format    string
 	WardCode  string
 	WardName  string
 	LOD       int
 	LODEx     int
 	NoTexture bool
+	NoLOD     bool
 }
 
 func (ex AssetNameExNormal) DatasetItemKey() string {
-	return ""
+	return ex.Name
 }
 
 func (ex AssetNameExNormal) DatasetKey() string {
-	return ""
+	return ex.Name
 }
 
 func (ex AssetNameExNormal) DicKey() string {
-	return ""
-}
-
-type AssetNameExUrf struct {
-	Type      string
-	Name      string
-	Format    string
-	LOD       int
-	NoTexture bool
-}
-
-func (ex AssetNameExUrf) DatasetItemKey() string {
-	return ex.Name
-}
-
-func (ex AssetNameExUrf) DatasetKey() string {
-	return ex.Name
-}
-
-func (ex AssetNameExUrf) DicKey() string {
 	return ex.Name
 }
 
@@ -184,17 +159,16 @@ func ParseAssetNameEx(name string) (ex AssetNameEx) {
 		return
 	}
 
-	ex.Urf = ParseAssetNameExUrf(name)
-	if ex.Urf != nil {
-		return
-	}
+	// ex.Urf = ParseAssetNameExUrf(name)
+	// if ex.Urf != nil {
+	// 	return
+	// }
 
 	ex.Normal = ParseAssetNameExNormal(name)
 	return
 }
 
-var reAasetNameExNormal = regexp.MustCompile(`^([a-z]+)_(mvt|3dtiles)(?:_(\d+)_([a-z0-9-]+))?(_lod\d\d?)?(_no_texture)?$`)
-var reAasetNameExNormalDM = regexp.MustCompile(`^([a-z]+)_dm_geometric_attributes$`)
+var reAasetNameExNormal = regexp.MustCompile(`^([a-z]+)(?:_([A-Za-z0-9-_]+))?_(mvt|3dtiles|dm_geometric_attributes)(?:_(\d+)_([a-z0-9-]+))?(_lod\d\d?)?(_no_texture)?$`)
 
 func ParseAssetNameExNormal(name string) *AssetNameExNormal {
 	if name == "" {
@@ -203,61 +177,68 @@ func ParseAssetNameExNormal(name string) *AssetNameExNormal {
 
 	m := reAasetNameExNormal.FindStringSubmatch(name)
 	if len(m) == 0 {
-		m = reAasetNameExNormalDM.FindStringSubmatch(name)
-		if len(m) == 0 {
-			return nil
-		}
-
-		m = []string{m[0], m[1], "mvt", "", "", "0", ""}
+		return nil
 	}
 
+	if m[3] == "dm_geometric_attributes" {
+		m[3] = "mvt"
+		if m[6] == "" {
+			m[6] = "0"
+		}
+	}
+
+	nolod := false
 	lod := 0
 	lodex := 0
-	if m[5] != "" {
-		lods := strings.TrimPrefix(m[5], "_lod")
+	if m[6] != "" {
+		lods := strings.TrimPrefix(m[6], "_lod")
 		if len(lods) == 2 {
 			lodex, _ = strconv.Atoi(lods[1:])
 			lods = lods[:1]
 		}
 		lod, _ = strconv.Atoi(lods)
+	} else {
+		nolod = true
 	}
 
 	return &AssetNameExNormal{
 		Type:      m[1],
-		Format:    m[2],
-		WardCode:  m[3],
-		WardName:  m[4],
-		LOD:       lod,
-		LODEx:     lodex,
-		NoTexture: m[6] != "",
-	}
-}
-
-var reAssetNameExUrf = regexp.MustCompile(`^([a-z]+)_([A-Za-z0-9-_]+)_(mvt|3dtiles)(_lod\d+)?(_no_texture)?$`)
-
-func ParseAssetNameExUrf(name string) *AssetNameExUrf {
-	if name == "" {
-		return nil
-	}
-
-	m := reAssetNameExUrf.FindStringSubmatch(name)
-	if len(m) == 0 {
-		return nil
-	}
-
-	lod := 0
-	if m[4] != "" {
-		lod, _ = strconv.Atoi(m[4][4:])
-	}
-
-	return &AssetNameExUrf{
-		Type:      m[1],
 		Name:      m[2],
 		Format:    m[3],
+		WardCode:  m[4],
+		WardName:  m[5],
 		LOD:       lod,
-		NoTexture: m[5] != "",
+		LODEx:     lodex,
+		NoTexture: m[7] != "",
+		NoLOD:     nolod,
 	}
 }
+
+// var reAssetNameExUrf = regexp.MustCompile(`^([a-z]+)_([A-Za-z0-9-_]+)_(mvt|3dtiles)(_lod\d+)?(_no_texture)?$`)
+
+// func ParseAssetNameExUrf(name string) *AssetNameExUrf {
+// 	if name == "" {
+// 		return nil
+// 	}
+
+// 	m := reAssetNameExUrf.FindStringSubmatch(name)
+// 	if len(m) == 0 {
+// 		return nil
+// 	}
+
+// 	lod := 0
+// 	if m[4] != "" {
+// 		lod, _ = strconv.Atoi(m[4][4:])
+// 	}
+
+// 	return &AssetNameExUrf{
+// 		Type:      m[1],
+// 		Name:      m[2],
+// 		Format:    m[3],
+// 		LOD:       lod,
+// 		NoTexture: m[5] != "",
+// 	}
+// }
 
 var reAssetNameExFld = regexp.MustCompile(`^fld_(natl|pref)_([A-Za-z0-9-_]+)_3dtiles_(l\d+)(?:-(.+?))?(_no_texture)?$`)
 

--- a/server/datacatalog/datacatalogv3/conv_asset_test.go
+++ b/server/datacatalog/datacatalogv3/conv_asset_test.go
@@ -205,10 +205,11 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "tnm",
 						Name:   "40_1",
 						Format: "3dtiles",
+						NoLOD:  true,
 					},
 					Ex: "tnm_40_1_3dtiles",
 				},
@@ -225,10 +226,11 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "tnm",
 						Name:   "AAA",
 						Format: "3dtiles",
+						NoLOD:  true,
 					},
 					Ex: "tnm_AAA_3dtiles",
 				},
@@ -245,11 +247,12 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:      "tnm",
 						Name:      "40_1",
 						Format:    "3dtiles",
 						NoTexture: true,
+						NoLOD:     true,
 					},
 					Ex: "tnm_40_1_3dtiles_no_texture",
 				},
@@ -266,7 +269,7 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "urf",
 						Name:   "AreaClassification",
 						Format: "mvt",
@@ -287,10 +290,11 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "urf",
 						Name:   "AreaClassification",
 						Format: "mvt",
+						NoLOD:  true,
 					},
 					Ex: "urf_AreaClassification_mvt",
 				},
@@ -327,7 +331,7 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "veg",
 						Format: "3dtiles",
 						LOD:    3,
@@ -348,7 +352,7 @@ func TestParseAssetName(t *testing.T) {
 				Format:      "citygml",
 				UpdateCount: 1,
 				Ex: AssetNameEx{
-					Urf: &AssetNameExUrf{
+					Normal: &AssetNameExNormal{
 						Type:   "gen",
 						Name:   "00",
 						Format: "mvt",

--- a/server/datacatalog/datacatalogv3/conv_dataset_plateau_seed.go
+++ b/server/datacatalog/datacatalogv3/conv_dataset_plateau_seed.go
@@ -34,6 +34,7 @@ type plateauDatasetSeed struct {
 	Year              int
 	OpenDataURL       string
 	HideTexture       bool
+	HideLOD           bool
 	RegisterationYear int
 }
 
@@ -98,6 +99,7 @@ func plateauDatasetSeedsFrom(i *PlateauFeatureItem, opts ToPlateauDatasetsOption
 		res[i].Year = year
 		res[i].OpenDataURL = opts.Area.CityItem.GetOpenDataURL()
 		res[i].HideTexture = opts.FeatureType.HideTexture
+		res[i].HideLOD = opts.FeatureType.HideLOD
 		res[i].RegisterationYear = opts.Year
 		if res[i].TargetArea == nil {
 			res[i].TargetArea = opts.Area.City
@@ -299,6 +301,7 @@ type plateauDatasetItemSeed struct {
 	FloodingScale       *plateauapi.FloodingScale
 	FloodingScaleSuffix *string
 	HideTexture         bool
+	HideLOD             bool
 }
 
 func (i plateauDatasetItemSeed) GetID(parentID string) string {
@@ -308,7 +311,7 @@ func (i plateauDatasetItemSeed) GetID(parentID string) string {
 
 	ids := []string{parentID, i.ID}
 
-	if i.LOD != nil {
+	if i.LOD != nil && !i.HideLOD {
 		lodex := ""
 		if i.LODEx != nil && *i.LODEx > 0 {
 			lodex = fmt.Sprintf("%d", *i.LODEx)
@@ -329,7 +332,7 @@ func (i plateauDatasetItemSeed) GetName() string {
 	name := i.Name
 	var lod, tex string
 
-	if i.LOD != nil {
+	if i.LOD != nil && !i.HideLOD {
 		lodex := ""
 		if i.LODEx != nil && *i.LODEx > 0 {
 			lodex = fmt.Sprintf(".%d", *i.LODEx)
@@ -372,9 +375,7 @@ func plateauDatasetItemSeedFrom(seed plateauDatasetSeed) (items []plateauDataset
 
 		switch {
 		case assetName.Ex.Normal != nil:
-			item, w = plateauDatasetItemSeedFromNormal(url, assetName.Ex.Normal, seed.LayerNames, cityCode, seed.HideTexture)
-		case assetName.Ex.Urf != nil:
-			item, w = plateauDatasetItemSeedFromUrf(url, assetName.Ex.Urf, seed.Dic, seed.LayerNames, cityCode, seed.HideTexture)
+			item, w = plateauDatasetItemSeedFromNormal(url, assetName.Ex.Normal, seed.LayerNames, cityCode, seed.HideTexture, seed.HideLOD, seed.Dic)
 		case assetName.Ex.Fld != nil:
 			item, w = plateauDatasetItemSeedFromFld(url, assetName.Ex.Fld, seed.Dic, cityCode, seed.HideTexture)
 		default:
@@ -393,51 +394,48 @@ func plateauDatasetItemSeedFrom(seed plateauDatasetSeed) (items []plateauDataset
 	return
 }
 
-func plateauDatasetItemSeedFromNormal(url string, ex *AssetNameExNormal, layerNames LayerNames, cityCode string, hideTexture bool) (res *plateauDatasetItemSeed, w []string) {
+func plateauDatasetItemSeedFromNormal(
+	url string,
+	ex *AssetNameExNormal,
+	layerNames LayerNames,
+	cityCode string,
+	hideTexture bool,
+	hideLOD bool,
+	dic Dic,
+) (res *plateauDatasetItemSeed, w []string) {
 	if !ex.NoTexture && hideTexture {
 		return
 	}
 
+	// format
 	format := datasetFormatFrom(ex.Format)
 	if format == "" {
 		w = append(w, fmt.Sprintf("plateau %s %s: invalid format: %s", cityCode, ex.Type, ex.Format))
 		return
 	}
 
-	return &plateauDatasetItemSeed{
-		ID:          "",
-		Name:        "", // use default
-		URL:         assetURLFromFormat(url, format),
-		Format:      format,
-		LOD:         &ex.LOD,
-		LODEx:       &ex.LODEx,
-		NoTexture:   &ex.NoTexture,
-		Layers:      layerNames.LayerName(nil, ex.LOD, format),
-		HideTexture: hideTexture,
-	}, nil
-}
-
-func plateauDatasetItemSeedFromUrf(url string, ex *AssetNameExUrf, dic Dic, layerNames LayerNames, cityCode string, hideTexture bool) (_ *plateauDatasetItemSeed, w []string) {
-	if !ex.NoTexture && hideTexture {
-		return
-	}
-
-	format := datasetFormatFrom(ex.Format)
-	if format == "" {
-		w = append(w, fmt.Sprintf("plateau %s %s: unknown format: %s", cityCode, ex.Type, ex.Format))
-		return
-	}
-
+	// dic
 	key := ex.DicKey()
-
-	entry, found := dic.FindEntryOrDefault(ex.Type, ex.DicKey())
-	if !found {
-		w = append(w, fmt.Sprintf("plateau %s %s: unknown dic key: %s", cityCode, ex.Type, key))
+	var name string
+	if key != "" {
+		entry, found := dic.FindEntryOrDefault(ex.Type, ex.DicKey())
+		if !found || entry == nil {
+			w = append(w, fmt.Sprintf("plateau %s %s: unknown dic key: %s", cityCode, ex.Type, key))
+		}
+		name = entry.Description
 	}
-	if entry == nil {
-		return
+
+	// lod
+	var lod *int
+	var lodex *int
+	if !ex.NoLOD {
+		lod = &ex.LOD
+		if ex.LODEx > 0 {
+			lodex = &ex.LODEx
+		}
 	}
 
+	// notexture
 	var notexture *bool
 	if ex.Format == "3dtiles" {
 		notexture = &ex.NoTexture
@@ -445,13 +443,15 @@ func plateauDatasetItemSeedFromUrf(url string, ex *AssetNameExUrf, dic Dic, laye
 
 	return &plateauDatasetItemSeed{
 		ID:          key,
-		Name:        entry.Description,
+		Name:        name,
 		URL:         assetURLFromFormat(url, format),
 		Format:      format,
-		LOD:         lo.EmptyableToPtr(ex.LOD),
+		LOD:         lod,
+		LODEx:       lodex,
 		NoTexture:   notexture,
 		Layers:      layerNames.LayerName([]string{key}, ex.LOD, format),
 		HideTexture: hideTexture,
+		HideLOD:     hideLOD,
 	}, w
 }
 

--- a/server/datacatalog/datacatalogv3/conv_dataset_plateau_test.go
+++ b/server/datacatalog/datacatalogv3/conv_dataset_plateau_test.go
@@ -770,7 +770,7 @@ func TestPlateauDataset_ToDatasets_Gen(t *testing.T) {
 				{
 					ID:       plateauapi.NewID("11111_gen_99", plateauapi.TypeDatasetItem),
 					Format:   plateauapi.DatasetFormatMvt,
-					Name:     "GEN",
+					Name:     "GEN LOD0",
 					URL:      "https://example.com/11111_bar-shi_city_2023_citygml_1_op_gen_99_mvt_lod0/{z}/{x}/{y}.mvt",
 					Lod:      lo.ToPtr(0),
 					Layers:   []string{"gen_99"},

--- a/server/datacatalog/datacatalogv3/conv_dataset_plateau_test.go
+++ b/server/datacatalog/datacatalogv3/conv_dataset_plateau_test.go
@@ -112,7 +112,7 @@ func TestPlateauDataset_ToDatasets_Bldg(t *testing.T) {
 					URL:      "https://example.com/11111_bar-shi_city_2023_citygml_1_op_bldg_3dtiles_11112_hoge-ku_lod1/tileset.json",
 					ParentID: plateauapi.NewID("11112_bldg", plateauapi.TypeDataset),
 					Lod:      lo.ToPtr(1),
-					LodEx:    lo.ToPtr(0),
+					LodEx:    nil,
 					Texture:  lo.ToPtr(plateauapi.TextureTexture),
 				},
 				{
@@ -122,7 +122,7 @@ func TestPlateauDataset_ToDatasets_Bldg(t *testing.T) {
 					URL:      "https://example.com/11111_bar-shi_city_2023_citygml_1_op_bldg_3dtiles_11112_hoge-ku_lod1_no_texture/tileset.json",
 					ParentID: plateauapi.NewID("11112_bldg", plateauapi.TypeDataset),
 					Lod:      lo.ToPtr(1),
-					LodEx:    lo.ToPtr(0),
+					LodEx:    nil,
 					Texture:  lo.ToPtr(plateauapi.TextureNone),
 				},
 				{
@@ -132,7 +132,7 @@ func TestPlateauDataset_ToDatasets_Bldg(t *testing.T) {
 					URL:      "https://example.com/11111_bar-shi_city_2023_citygml_1_op_bldg_3dtiles_11112_hoge-ku_lod2/tileset.json",
 					ParentID: plateauapi.NewID("11112_bldg", plateauapi.TypeDataset),
 					Lod:      lo.ToPtr(2),
-					LodEx:    lo.ToPtr(0),
+					LodEx:    nil,
 					Texture:  lo.ToPtr(plateauapi.TextureTexture),
 				},
 			},
@@ -768,11 +768,11 @@ func TestPlateauDataset_ToDatasets_Gen(t *testing.T) {
 			Groups: []string{"group"},
 			Items: []*plateauapi.PlateauDatasetItem{
 				{
-					ID:     plateauapi.NewID("11111_gen_99", plateauapi.TypeDatasetItem),
-					Format: plateauapi.DatasetFormatMvt,
-					Name:   "GEN",
-					URL:    "https://example.com/11111_bar-shi_city_2023_citygml_1_op_gen_99_mvt_lod0/{z}/{x}/{y}.mvt",
-					// Lod:      lo.ToPtr(0),
+					ID:       plateauapi.NewID("11111_gen_99", plateauapi.TypeDatasetItem),
+					Format:   plateauapi.DatasetFormatMvt,
+					Name:     "GEN",
+					URL:      "https://example.com/11111_bar-shi_city_2023_citygml_1_op_gen_99_mvt_lod0/{z}/{x}/{y}.mvt",
+					Lod:      lo.ToPtr(0),
 					Layers:   []string{"gen_99"},
 					ParentID: plateauapi.NewID("11111_gen_99", plateauapi.TypeDataset),
 				},
@@ -823,8 +823,10 @@ func TestPlateauDataset_ToDatasets_Gen(t *testing.T) {
 		Spec:        spec,
 		DatasetType: dts,
 		LayerNames:  layerNames,
-		FeatureType: &FeatureType{},
-		Year:        2023,
+		FeatureType: &FeatureType{
+			HideLOD: true,
+		},
+		Year: 2023,
 	}
 	res, warning := item.toDatasets(opts)
 	assert.Nil(t, warning)

--- a/server/datacatalog/datacatalogv3/conv_internal.go
+++ b/server/datacatalog/datacatalogv3/conv_internal.go
@@ -164,5 +164,9 @@ func (l LayerNames) LayerName(def []string, lod int, format plateauapi.DatasetFo
 		})
 	}
 
+	if len(def) == 0 || def[0] == "" {
+		return nil
+	}
+
 	return def
 }

--- a/server/datacatalog/datacatalogv3/repos_test.go
+++ b/server/datacatalog/datacatalogv3/repos_test.go
@@ -120,7 +120,7 @@ func TestRepos(t *testing.T) {
 							Name:     "LOD1",
 							ParentID: plateauapi.ID("d_" + cityCode + "_bldg"),
 							Lod:      lo.ToPtr(1),
-							LodEx:    lo.ToPtr(0),
+							LodEx:    nil,
 							Texture:  lo.ToPtr(plateauapi.TextureTexture),
 						},
 					},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `HideLOD` field to enhance control over the visibility of Level of Detail (LOD) features across various data structures.
  - Enhanced asset name parsing logic by removing the `Urf` field and adding new fields to improve clarity.
  - Updated dataset item structures to conditionally include LOD information based on the `HideLOD` flag.

- **Bug Fixes**
  - Resolved potential data corruption by ensuring independent copies of group data for datasets.

- **Tests**
  - Updated test cases to reflect changes in asset name structures and LOD handling, ensuring alignment with new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->