### PR TITLE
feat(extension): add cityGML api & update selection content for spatial id object

### DIFF
--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -58,6 +58,11 @@ const yml = {
                 title: "Admin用データカタログURL",
               },
               {
+                id: "cityGMLURL",
+                type: "string",
+                title: "CityGMLサーバーバックエンドURL",
+              },
+              {
                 id: "geoURL",
                 type: "string",
                 title: "GeoサーバーバックエンドURL",

--- a/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
@@ -96,14 +96,14 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
   const [files, setFiles] = useState<object | undefined>();
   const [_loading, setLoading] = useState<boolean>(true);
   const [_error, setError] = useState<string | null>(null);
-  const conditions = useMemo(() => {
+  const spaceZFXYStr = useMemo(() => {
     const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return;
-    return `s:${feature.data.zfxyStr}`;
+    return feature.data.zfxyStr;
   }, [features, values]);
 
   useEffect(() => {
-    if (!conditions) {
+    if (!spaceZFXYStr) {
       setFiles(undefined);
       setLoading(false);
       setError(null);
@@ -115,7 +115,7 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
       setError(null);
 
       try {
-        const data = await cityGMLClient?.getFiles(conditions);
+        const data = await cityGMLClient?.getFiles({ spaceZFXYStr });
         setFiles(data);
       } catch (err: any) {
         setError(err.message || "An error occurred while fetching files.");
@@ -125,7 +125,7 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
     };
 
     fetchFiles();
-  }, [conditions]);
+  }, [spaceZFXYStr]);
 
   return (
     <List disablePadding>

--- a/extension/src/shared/api/citygml/client.ts
+++ b/extension/src/shared/api/citygml/client.ts
@@ -1,5 +1,7 @@
 import { fetchWithGet } from "../fetch";
 
+import { CityGMLGetFilesParams } from "./types";
+
 export class CityGMLClient {
   url: string;
 
@@ -17,9 +19,31 @@ export class CityGMLClient {
     return obj;
   }
 
-  async getFiles(conditions: string) {
-    return this.handleError(await fetchWithGet(`${this.url}/${conditions}`)).catch((e: any) => {
-      console.error(e);
-    });
+  async getFiles(params: CityGMLGetFilesParams) {
+    const conditions = makeFileAPIConditionsByParams(params);
+    return this.handleError(
+      await fetchWithGet(`${this.url}/${conditions}`).catch((e: any) => {
+        console.error(e);
+      }),
+    );
   }
+}
+
+function makeFileAPIConditionsByParams(params: CityGMLGetFilesParams) {
+  const { meshId, spaceZFXYStr, spaceId, centerCoordinate, rangeCoordinates, geoName, cityIds } =
+    params;
+  if (meshId) return `m:${meshId}`;
+  if (spaceZFXYStr) return `s:${spaceZFXYStr}`;
+  if (spaceId) return `s:${spaceId}`;
+  if (centerCoordinate) {
+    const { lng, lat } = centerCoordinate;
+    return `r:${lng},${lat}`;
+  }
+  if (rangeCoordinates) {
+    const { lng1, lat1, lng2, lat2 } = rangeCoordinates;
+    return `r:${lng1},${lat1},${lng2},${lat2}`;
+  }
+  if (geoName) return `g:${geoName}`;
+  if (cityIds && cityIds.length > 0) return cityIds.join(",");
+  return;
 }

--- a/extension/src/shared/api/citygml/client.ts
+++ b/extension/src/shared/api/citygml/client.ts
@@ -1,0 +1,23 @@
+import { fetchWithGet } from "../fetch";
+
+export class CityGMLClient {
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  handleError(obj: any) {
+    if (!obj) return;
+    if (typeof obj !== "object") return;
+    if ("error" in obj) {
+      console.error(obj.error);
+      return;
+    }
+    return obj;
+  }
+
+  async getFiles(conditions: string) {
+    return this.handleError(await fetchWithGet(`${this.url}/${conditions}`));
+  }
+}

--- a/extension/src/shared/api/citygml/client.ts
+++ b/extension/src/shared/api/citygml/client.ts
@@ -18,6 +18,8 @@ export class CityGMLClient {
   }
 
   async getFiles(conditions: string) {
-    return this.handleError(await fetchWithGet(`${this.url}/${conditions}`));
+    return this.handleError(await fetchWithGet(`${this.url}/${conditions}`)).catch((e: any) => {
+      console.error(e);
+    });
   }
 }

--- a/extension/src/shared/api/citygml/index.ts
+++ b/extension/src/shared/api/citygml/index.ts
@@ -1,0 +1,7 @@
+import { CityGMLClient } from "./client";
+
+export let cityGMLClient: CityGMLClient | undefined;
+
+export const createCityGMLClient = (url: string) => {
+  cityGMLClient = new CityGMLClient(url);
+};

--- a/extension/src/shared/api/citygml/types.ts
+++ b/extension/src/shared/api/citygml/types.ts
@@ -1,0 +1,17 @@
+export type CityGMLGetFilesParams = {
+  meshId?: string;
+  spaceZFXYStr?: string;
+  spaceId?: string;
+  centerCoordinate?: {
+    lng: number;
+    lat: number;
+  };
+  rangeCoordinates?: {
+    lng1: number;
+    lat1: number;
+    lng2: number;
+    lat2: number;
+  };
+  geoName?: string;
+  cityIds?: string[];
+};

--- a/extension/src/shared/context/WidgetContext.tsx
+++ b/extension/src/shared/context/WidgetContext.tsx
@@ -5,6 +5,7 @@ import { SnackbarProvider } from "notistack";
 import { FC, PropsWithChildren, useEffect, useState } from "react";
 
 import { lightTheme, lightThemeOptions } from "../../prototypes/ui-components";
+import { cityGMLClient, createCityGMLClient } from "../api/citygml";
 import {
   createSettingClient,
   settingClient,
@@ -33,12 +34,14 @@ import {
   useIsEnable,
   useStartTime,
   useFinishTime,
+  useCityGMLApiUrl,
 } from "../states/environmentVariables";
 
 type Props = {
   inEditor?: boolean;
   // Default settings
   geoUrl?: string;
+  cityGMLUrl?: string;
   gsiTileURL?: string;
   plateauUrl?: string;
   projectId?: string;
@@ -67,6 +70,7 @@ type Props = {
 
 export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   geoUrl,
+  cityGMLUrl,
   gsiTileURL,
   plateauUrl,
   projectId,
@@ -119,6 +123,13 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
       setGeoApiUrlState(geoUrl);
     }
   }, [geoUrl, geoApiUrlState, setGeoApiUrlState]);
+
+  const [cityGMLApiUrlState, setCityGMLApiUrlState] = useCityGMLApiUrl();
+  useEffect(() => {
+    if (!cityGMLApiUrlState && cityGMLUrl) {
+      setCityGMLApiUrlState(cityGMLUrl);
+    }
+  }, [cityGMLUrl, cityGMLApiUrlState, setCityGMLApiUrlState]);
 
   const [gsiTileURLState, setGSITileURLState] = useGsiTileUrl();
   useEffect(() => {
@@ -204,6 +215,12 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
       createGeoClient(geoUrl);
     }
   }, [geoUrl]);
+
+  useEffect(() => {
+    if (!cityGMLClient && cityGMLUrl) {
+      createCityGMLClient(cityGMLUrl);
+    }
+  }, [cityGMLUrl]);
 
   useEffect(() => {
     const url = inEditor ? catalogURLForAdmin || catalogUrl : catalogUrl;

--- a/extension/src/shared/states/environmentVariables.ts
+++ b/extension/src/shared/states/environmentVariables.ts
@@ -12,6 +12,9 @@ export const useProjectId = () => useAtom(projectId);
 const geoApiUrl = atom<string | undefined>(undefined);
 export const useGeoApiUrl = () => useAtom(geoApiUrl);
 
+const cityGMLApiUrl = atom<string | undefined>(undefined);
+export const useCityGMLApiUrl = () => useAtom(cityGMLApiUrl);
+
 const gsiTileUrl = atom<string | undefined>(undefined);
 export const useGsiTileUrl = () => useAtom(gsiTileUrl);
 

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -38,6 +38,7 @@ import { useSelectSpatialIdFeature } from "./hooks/useSelectSpatialIdFeature";
 
 type DefaultProps = {
   geoURL?: string;
+  cityGMLURL?: string;
   gsiTileURL?: string;
   arURL?: string;
   plateauURL?: string;
@@ -84,6 +85,7 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
         catalogUrl={widget.property.default.catalogURL}
         catalogURLForAdmin={widget.property.default.catalogURLForAdmin}
         geoUrl={widget.property.default.geoURL}
+        cityGMLUrl={widget.property.default.cityGMLURL}
         gsiTileURL={widget.property.default.gsiTileURL}
         googleStreetViewAPIKey={
           widget.property.default.googleStreetViewAPIKey ||


### PR DESCRIPTION
## Overview

This PR added one single cityGML api for fetch the files by space id, and show the data on spatial id object's selection panel.

Note: there's a new widget property on Toolbar, `cityGMLURL`, please enter this url: `https://api.plateauview.mlit.go.jp/datacatalog/citygml`

![image](https://github.com/user-attachments/assets/74dc6c01-6f22-42f6-9749-192b78bb497f)


## What i didn't do

- Didn't implement all the cityGML apis.
- The UI on spatial id object's selection needs re-design, current one is temporary.