### PR TITLE
refactor(extenstion): UI UX Show more information for "GeoJSON" and "CZML” in web tab

### DIFF
--- a/extension/src/shared/ui-components/MyData/LocalDataTab.tsx
+++ b/extension/src/shared/ui-components/MyData/LocalDataTab.tsx
@@ -97,6 +97,16 @@ const LocalDataTab: React.FC<Props> = ({ onSubmit }) => {
     setProcessedDataItem(undefined);
   }, [onSubmit, selectedLocalItem]);
 
+  const formatTip = useMemo(() => {
+    if (selectedLocalItem?.formatTip) {
+      return selectedLocalItem.formatTip;
+    }
+    if (fileType !== "auto") {
+      return getFormatTip(fileType);
+    }
+    return "";
+  }, [selectedLocalItem, fileType]);
+
   return (
     <FormControl fullWidth size="small">
       <Label>ファイルタイプを選択</Label>
@@ -138,11 +148,9 @@ const LocalDataTab: React.FC<Props> = ({ onSubmit }) => {
           />
         </Box>
       )}
-      {(fileType !== "auto" || selectedLocalItem) && (
+      {formatTip && (
         <Typography id="modal-modal-format-tip" sx={{ mt: 2, mb: 0 }}>
-          {selectedLocalItem
-            ? selectedLocalItem.formatTip
-            : getFormatTip(fileType)}
+          {formatTip}
         </Typography>
       )}
       <Typography id="modal-modal-description" sx={{ mt: 2, mb: 1 }}>

--- a/extension/src/shared/ui-components/MyData/WebDataTab.tsx
+++ b/extension/src/shared/ui-components/MyData/WebDataTab.tsx
@@ -2,7 +2,14 @@ import { Input, inputClasses } from "@mui/base/Input";
 import AddIcon from "@mui/icons-material/Add";
 import { Button, Typography, styled } from "@mui/material";
 import FormControl from "@mui/material/FormControl";
-import { ChangeEvent, Fragment, useCallback, useEffect, useState } from "react";
+import {
+  ChangeEvent,
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { AdditionalData } from "../../../../../tools/plateau-api-migrator/src/types/view2/core";
 import { getExtension } from "../../utils/file";
@@ -107,6 +114,16 @@ const WebDataTab: React.FC<Props> = ({ onSubmit }) => {
     setSelectedWebItem(undefined);
   }, [layers, onSubmit, selectedWebItem]);
 
+  const formatTip = useMemo(() => {
+    if (selectedWebItem?.formatTip) {
+      return selectedWebItem.formatTip;
+    }
+    if (fileType !== "auto") {
+      return getFormatTip(fileType);
+    }
+    return "";
+  }, [selectedWebItem, fileType]);
+
   useEffect(() => {
     handleClick();
   }, [fileType, handleClick]);
@@ -144,11 +161,9 @@ const WebDataTab: React.FC<Props> = ({ onSubmit }) => {
                 />{" "}
               </FormControl>
             )}
-            {(selectedWebItem?.formatTip || fileType !== "auto") && (
+            {formatTip && (
               <Typography id="modal-modal-format-tip" sx={{ mt: 2, mb: 0 }}>
-                {selectedWebItem
-                  ? selectedWebItem.formatTip
-                  : getFormatTip(fileType)}
+                {formatTip}
               </Typography>
             )}
             <Typography id="modal-modal-description" sx={{ mt: 2, mb: 1 }}>


### PR DESCRIPTION
We just add tip for "ローカルのデータから追加" tab for [this task](https://github.com/eukarya-inc/PLATEAU-VIEW-3.0/pull/376).
This PR is adding tip for "Webから追加" tab.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced web data tab rendering logic to support more flexible display conditions.
	- Improved format tip display mechanism with fallback options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->