### PR TITLE
fix(extension): fix clear input can not change tip problem for web tab

### DIFF
--- a/extension/src/shared/ui-components/MyData/WebDataTab.tsx
+++ b/extension/src/shared/ui-components/MyData/WebDataTab.tsx
@@ -38,6 +38,9 @@ const WebDataTab: React.FC<Props> = ({ onSubmit }) => {
   }, []);
 
   const handleSetUrl = useCallback((value: string) => {
+    if (!value) {
+      setSelectedWebItem(undefined);
+    }
     setDataUrl(value);
   }, []);
 


### PR DESCRIPTION
Fix the issue where clearing the input doesn't update the tip in the web tab. This bug originated from the previous implementation, which did not reset selectedWebItem when the user cleared the input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL input handling by resetting selected web item when input is cleared or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->