### PR TITLE
fix: default condition

### DIFF
--- a/extension/src/shared/helpers/expression.ts
+++ b/extension/src/shared/helpers/expression.ts
@@ -25,7 +25,7 @@ export const isNumber = (prop: string) =>
   `!(${variable(prop)} === "" || ${variable(prop)} === null || isNaN(Number(${variable(prop)})))`;
 
 export const defaultConditionalNumber = (prop: string, defaultValue?: number) =>
-  `(${isNumber(prop)} ? Number(${variable(prop)}) : ${defaultValue ?? 1})`;
+  `(${isNumber(prop)} ? Number(${variable(prop)}) : ${defaultValue ?? "null"})`;
 
 export const condition = (cond: string, v: string, el: string) => {
   return `((${cond}) ? ${v} : ${el})`;


### PR DESCRIPTION
I fixed the issue that the color condition component doesn't work when the property value is undefined like below.

You can use `建築物モデル（東京都サンプルデータ（竹芝モデル））` to test it.

|Before|After|
|:--:|:--:|
|![Screenshot 2025-01-14 at 11 58 59](https://github.com/user-attachments/assets/04b109ca-b94e-4a4d-9aea-fd019a7a402c)|![Screenshot 2025-01-14 at 11 58 07](https://github.com/user-attachments/assets/77fe16d7-515a-4621-9bfa-2b3b43d3c197)|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved default value handling in numeric expressions to provide more precise fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->