### PR TITLE
feat(extension): support mesh code layer (basic)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -45,6 +45,7 @@
     "file-saver": "2.0.5",
     "framer-motion": "10.16.1",
     "graphql": "16.8.0",
+    "jismesh-js": "0.2.0",
     "jotai": "2.3.1",
     "jotai-xstate": "0.3.0",
     "jsonpath": "1.1.1",

--- a/extension/src/prototypes/ui-components/icons/MeshLevel2Icon.tsx
+++ b/extension/src/prototypes/ui-components/icons/MeshLevel2Icon.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+export const MeshLevel2Icon = createSvgIcon(
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="2.5" y="2.5" width="19" height="19" stroke="currentColor" strokeDasharray="2 2" />
+    <rect x="2.5" y="2.5" width="14" height="14" stroke="currentColor" />
+  </svg>,
+  "Map",
+);

--- a/extension/src/prototypes/ui-components/icons/MeshLevel3Icon.tsx
+++ b/extension/src/prototypes/ui-components/icons/MeshLevel3Icon.tsx
@@ -1,0 +1,10 @@
+import { createSvgIcon } from "@mui/material";
+
+export const MeshLevel3Icon = createSvgIcon(
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="2.5" y="2.5" width="19" height="19" stroke="currentColor" strokeDasharray="2 2" />
+    <rect x="2.5" y="2.5" width="15" height="15" stroke="currentColor" strokeDasharray="2 2" />
+    <rect x="2.5" y="2.5" width="8" height="8" stroke="currentColor" />
+  </svg>,
+  "Map",
+);

--- a/extension/src/prototypes/ui-components/icons/index.ts
+++ b/extension/src/prototypes/ui-components/icons/index.ts
@@ -23,6 +23,8 @@ export * from "./LandUseIcon";
 export * from "./LayerIcon";
 export * from "./LocationIcon";
 export * from "./MapIcon";
+export * from "./MeshLevel2Icon";
+export * from "./MeshLevel3Icon";
 export * from "./MinusIcon";
 export * from "./ParkIcon";
 export * from "./PedestrianIcon";

--- a/extension/src/prototypes/view-layers/layerTypeIcons.ts
+++ b/extension/src/prototypes/view-layers/layerTypeIcons.ts
@@ -14,6 +14,7 @@ import {
   LandmarkIcon,
   LandSlideRiskIcon,
   LandUseIcon,
+  LayerIcon,
   ParkIcon,
   PedestrianIcon,
   RailwayIcon,
@@ -47,6 +48,7 @@ import {
   LAND_SLIDE_RISK_LAYER,
   LAND_USE_LAYER,
   LANDMARK_LAYER,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PARK_LAYER,
   PEDESTRIAN_LAYER,
@@ -71,6 +73,7 @@ export const layerTypeIcons: Record<LayerType, ComponentType<SvgIconProps>> = {
   [PEDESTRIAN_LAYER]: PedestrianIcon,
   [SKETCH_LAYER]: SketchIcon,
   [SPATIAL_ID_LAYER]: SketchRectangleIcon,
+  [MESH_CODE_LAYER]: LayerIcon,
   [MY_DATA_LAYER]: UseCaseIcon,
   [STORY_LAYER]: StoryIcon,
 

--- a/extension/src/prototypes/view-layers/layerTypeNames.ts
+++ b/extension/src/prototypes/view-layers/layerTypeNames.ts
@@ -33,6 +33,7 @@ import {
   WATERWAY_LAYER,
   SPATIAL_ID_LAYER,
   RESERVOIR_FLOODING_RISK_LAYER,
+  MESH_CODE_LAYER,
 } from "./layerTypes";
 
 // Undefined means using the name from API.
@@ -41,6 +42,7 @@ export const layerTypeNames: Record<LayerType, string | undefined> = {
   [PEDESTRIAN_LAYER]: "歩行者視点",
   [SKETCH_LAYER]: "作図",
   [SPATIAL_ID_LAYER]: "空間ID",
+  [MESH_CODE_LAYER]: "メッシュコレクション",
   [MY_DATA_LAYER]: "マイデータ",
   [STORY_LAYER]: "ストーリー",
 

--- a/extension/src/prototypes/view-layers/layerTypes.ts
+++ b/extension/src/prototypes/view-layers/layerTypes.ts
@@ -2,6 +2,7 @@ export const HEATMAP_LAYER = "HEATMAP_LAYER";
 export const PEDESTRIAN_LAYER = "PEDESTRIAN_LAYER";
 export const SKETCH_LAYER = "SKETCH_LAYER";
 export const SPATIAL_ID_LAYER = "SPATIAL_ID_LAYER";
+export const MESH_CODE_LAYER = "MESH_CODE_LAYER";
 export const MY_DATA_LAYER = "MY_DATA_LAYER";
 export const STORY_LAYER = "STORY_LAYER";
 

--- a/extension/src/prototypes/view-layers/states.ts
+++ b/extension/src/prototypes/view-layers/states.ts
@@ -3,10 +3,12 @@ import { atom } from "jotai";
 import { fromPairs, uniq, without } from "lodash-es";
 import invariant from "tiny-invariant";
 
+import { MESH_CODE_OBJECT, meshCodeSelectionAtom } from "../../shared/meshCode";
 import { SPATIAL_ID_OBJECT } from "../../shared/spatialId";
 import { spatialIdSelectionAtom } from "../../shared/spatialId/status";
 import { rootLayersAtom, rootLayersLayersAtom } from "../../shared/states/rootLayer";
 import { RootLayerAtom, StoryLayerModel } from "../../shared/view-layers";
+import { MeshCodeLayerModel } from "../../shared/view-layers/meshCode";
 import { SpatialIdLayerModel } from "../../shared/view-layers/spatialId";
 import { matchIdentifier, parseIdentifier } from "../cesium-helpers";
 import { featureSelectionAtom } from "../datasets";
@@ -17,7 +19,13 @@ import { atomsWithSelection } from "../shared-states";
 import { SKETCH_OBJECT, sketchSelectionAtom } from "../sketch";
 import { isNotNullish } from "../type-helpers";
 
-import { PEDESTRIAN_LAYER, SKETCH_LAYER, SPATIAL_ID_LAYER, STORY_LAYER } from "./layerTypes";
+import {
+  MESH_CODE_LAYER,
+  PEDESTRIAN_LAYER,
+  SKETCH_LAYER,
+  SPATIAL_ID_LAYER,
+  STORY_LAYER,
+} from "./layerTypes";
 import { SketchLayerModel } from "./SketchLayer";
 
 // import { PEDESTRIAN_LAYER } from "./layerTypes";
@@ -50,6 +58,12 @@ export const sketchLayersAtom = atom(get =>
 export const spatialIdLayersAtom = atom(get =>
   get(rootLayersLayersAtom).filter(
     (layer): layer is SpatialIdLayerModel => layer.type === SPATIAL_ID_LAYER,
+  ),
+);
+
+export const meshCodeLayersAtom = atom(get =>
+  get(rootLayersLayersAtom).filter(
+    (layer): layer is MeshCodeLayerModel => layer.type === MESH_CODE_LAYER,
   ),
 );
 
@@ -110,12 +124,30 @@ export const highlightedSpatialIdLayersAtom = atom(get => {
   });
 });
 
+export const highlightedMeshCodeLayersAtom = atom(get => {
+  const entityIds = get(meshCodeSelectionAtom).map(({ value }) => value);
+  const meshCodeLayers = get(meshCodeLayersAtom);
+  return meshCodeLayers.filter(layer => {
+    const features = get(layer.featuresAtom);
+    return entityIds.some(entityId =>
+      features.some(feature =>
+        matchIdentifier(entityId, {
+          type: "MeshCode",
+          subtype: MESH_CODE_OBJECT,
+          key: feature.id,
+        }),
+      ),
+    );
+  });
+});
+
 export const highlightedLayersAtom = atom(get => {
   const screenSpaceSelection = get(screenSpaceSelectionAtom);
   const layers = get(rootLayersLayersAtom);
   const result: LayerModel[] = [];
   const highlightedSketchLayers = get(highlightedSketchLayersAtom);
   const highlightedSpatialIdLayers = get(highlightedSpatialIdLayersAtom);
+  const highlightedMeshCodeLayers = get(highlightedMeshCodeLayersAtom);
   for (const layer of layers) {
     const layerId = get(layer.layerIdAtom);
     const selection = screenSpaceSelection.some(v => {
@@ -126,6 +158,8 @@ export const highlightedLayersAtom = atom(get => {
           return highlightedSketchLayers.some(v => v.id === layer.id);
         case SPATIAL_ID_OBJECT:
           return highlightedSpatialIdLayers.some(v => v.id === layer.id);
+        case MESH_CODE_OBJECT:
+          return highlightedMeshCodeLayers.some(v => v.id === layer.id);
         default:
           return layerId === v.value.layerId;
       }

--- a/extension/src/prototypes/view/constants/datasetTypeLayers.ts
+++ b/extension/src/prototypes/view/constants/datasetTypeLayers.ts
@@ -15,6 +15,7 @@ import {
   LAND_SLIDE_RISK_LAYER,
   LAND_USE_LAYER,
   LANDMARK_LAYER,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PARK_LAYER,
   PEDESTRIAN_LAYER,
@@ -100,6 +101,7 @@ export const layerDatasetTypes = {
   [PEDESTRIAN_LAYER]: undefined,
   [SKETCH_LAYER]: undefined,
   [SPATIAL_ID_LAYER]: undefined,
+  [MESH_CODE_LAYER]: undefined,
   [MY_DATA_LAYER]: undefined,
   [STORY_LAYER]: undefined,
 } as const satisfies Record<LayerType, PlateauDatasetType | undefined>;

--- a/extension/src/prototypes/view/containers/KeyBindings.tsx
+++ b/extension/src/prototypes/view/containers/KeyBindings.tsx
@@ -67,6 +67,14 @@ export const KeyBindings: FC = () => {
           event.preventDefault();
           send({ type: "PEDESTRIAN" });
           return;
+        case "i":
+          event.preventDefault();
+          send({ type: "SPATIAL_ID" });
+          return;
+        case "m":
+          event.preventDefault();
+          send({ type: "MESH_CODE" });
+          return;
       }
     }
     if (

--- a/extension/src/prototypes/view/selection/LayerContent.tsx
+++ b/extension/src/prototypes/view/selection/LayerContent.tsx
@@ -36,6 +36,7 @@ import { DatasetDialog } from "../ui-containers/DatasetDialog";
 import { LayerHeatmapSection } from "./LayerHeatmapSection";
 import { LayerHiddenFeaturesSection } from "./LayerHiddenFeaturesSection";
 // import { LayerShowWireframeSection } from "./LayerShowWireframeSection";
+import { LayerMeshCodeSection } from "./LayerMeshCodeSection";
 import { LayerSketchSection } from "./LayerSketchSection";
 import { LayerSpatialIdSection } from "./LayerSpatialIdSection";
 
@@ -224,6 +225,7 @@ export function LayerContent<T extends SupportedLayerType>({
         {/* <LayerShowWireframeSection layers={values} />*/}
         <LayerSketchSection layers={values} />
         <LayerSpatialIdSection layers={values} />
+        <LayerMeshCodeSection layers={values} />
         {/* </InspectorItem> */}
       </List>
       {rootLayerConfig && (

--- a/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
+++ b/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
@@ -1,0 +1,43 @@
+import { useAtomValue } from "jotai";
+import { FC, useMemo } from "react";
+
+import { LayerModel } from "../../layers";
+import { ParameterList, PropertyParameterItem } from "../../ui-components";
+import { MESH_CODE_LAYER } from "../../view-layers";
+
+export interface LayerMeshCodeSectionProps {
+  layers: readonly LayerModel[];
+}
+
+export const LayerMeshCodeSection: FC<LayerMeshCodeSectionProps> = ({ layers }) => {
+  const meshCodeLayers = useMemo(
+    () =>
+      layers.filter(
+        (layer): layer is LayerModel<typeof MESH_CODE_LAYER> => layer.type === MESH_CODE_LAYER,
+      ),
+    [layers],
+  );
+
+  const features = useAtomValue(meshCodeLayers[0].featuresAtom);
+
+  const properties = useMemo(() => {
+    if (!features) return [];
+    const meshCodesStr = features.map(feature => feature.meshCode).join(" ");
+    return [
+      {
+        id: "meshCode",
+        name: "メッシュコード",
+        values: [meshCodesStr],
+      },
+    ];
+  }, [features]);
+
+  if (meshCodeLayers.length === 0) {
+    return null;
+  }
+  return (
+    <ParameterList>
+      <PropertyParameterItem properties={properties} featureType="meshCode" />
+    </ParameterList>
+  );
+};

--- a/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
@@ -1,0 +1,159 @@
+import { Divider, IconButton, List, Tooltip } from "@mui/material";
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { uniq } from "lodash-es";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import ReactJson from "react-json-view";
+
+import { cityGMLClient } from "../../../shared/api/citygml";
+import { MESH_CODE_OBJECT } from "../../../shared/meshCode";
+import { parseIdentifier } from "../../cesium-helpers";
+import { layerSelectionAtom } from "../../layers";
+import { screenSpaceSelectionAtom } from "../../screen-space-selection";
+import { isNotNullish } from "../../type-helpers";
+import {
+  InspectorHeader,
+  InspectorItem,
+  LayerIcon,
+  ParameterList,
+  PropertyParameterItem,
+  TrashIcon,
+} from "../../ui-components";
+import { highlightedMeshCodeLayersAtom, MESH_CODE_LAYER } from "../../view-layers";
+import { SCREEN_SPACE_SELECTION, SelectionGroup } from "../states/selection";
+
+export interface MeshCodeObjectContentProps {
+  values: (SelectionGroup & {
+    type: typeof SCREEN_SPACE_SELECTION;
+    subtype: typeof MESH_CODE_OBJECT;
+  })["values"];
+}
+
+export const MeshCodeObjectContent: FC<MeshCodeObjectContentProps> = ({ values }) => {
+  const setSelection = useSetAtom(screenSpaceSelectionAtom);
+  const handleClose = useCallback(() => {
+    setSelection([]);
+  }, [setSelection]);
+
+  const meshCodeLayers = useAtomValue(highlightedMeshCodeLayersAtom);
+  const setLayerSelection = useSetAtom(layerSelectionAtom);
+  const handleSelectLayers = useCallback(() => {
+    setLayerSelection(meshCodeLayers.map(layer => ({ id: layer.id, type: MESH_CODE_LAYER })));
+  }, [meshCodeLayers, setLayerSelection]);
+
+  const removeFeatures = useSetAtom(
+    useMemo(
+      () =>
+        atom(null, (get, set, featureIds: readonly string[]) => {
+          meshCodeLayers.forEach(meshCodeLayer => {
+            const featureAtoms = get(meshCodeLayer.featureAtomsAtom);
+            featureIds.forEach(featureId => {
+              const featureAtom = featureAtoms.find(
+                featureAtom => get(featureAtom).id === featureId,
+              );
+              if (featureAtom != null) {
+                set(meshCodeLayer.featureAtomsAtom, {
+                  type: "remove",
+                  atom: featureAtom,
+                });
+              }
+            });
+          });
+        }),
+      [meshCodeLayers],
+    ),
+  );
+  const handleRemove = useCallback(() => {
+    const featureIds = uniq(values.map(value => parseIdentifier(value).key).filter(isNotNullish));
+    removeFeatures(featureIds);
+    setSelection([]);
+  }, [values, removeFeatures, setSelection]);
+
+  const features = useAtomValue(meshCodeLayers[0].featuresAtom);
+
+  const properties = useMemo(() => {
+    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    if (!feature) return [];
+    return [
+      {
+        id: "meshCode",
+        name: "メッシュコード",
+        values: [feature.meshCode],
+      },
+    ];
+  }, [features, values]);
+
+  const [files, setFiles] = useState<object | undefined>();
+  const [_loading, setLoading] = useState<boolean>(true);
+  const [_error, setError] = useState<string | null>(null);
+  const meshCode = useMemo(() => {
+    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    if (!feature) return;
+    return feature.meshCode;
+  }, [features, values]);
+
+  useEffect(() => {
+    if (!meshCode) {
+      setFiles(undefined);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const fetchFiles = async () => {
+      setLoading(true);
+      setFiles(undefined);
+      setError(null);
+
+      try {
+        const data = await cityGMLClient?.getFiles({ meshId: meshCode });
+        setFiles(data);
+      } catch (err: any) {
+        setError(err.message || "An error occurred while fetching files.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFiles();
+  }, [meshCode]);
+
+  return (
+    <List disablePadding>
+      <InspectorHeader
+        title={`${values.length}個のメッシュコレクション`}
+        iconComponent={LayerIcon}
+        actions={
+          <>
+            <Tooltip title="レイヤーを選択">
+              <IconButton aria-label="レイヤーを選択" onClick={handleSelectLayers}>
+                <LayerIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="削除">
+              <IconButton aria-label="削除" onClick={handleRemove}>
+                <TrashIcon />
+              </IconButton>
+            </Tooltip>
+          </>
+        }
+        onClose={handleClose}
+      />
+      <Divider />
+      <InspectorItem>
+        <ParameterList>
+          <PropertyParameterItem properties={properties} featureType="meshCode" />
+        </ParameterList>
+        {files && (
+          <ReactJson
+            src={files}
+            displayDataTypes={false}
+            enableClipboard={false}
+            displayObjectSize={false}
+            quotesOnKeys={false}
+            indentWidth={2}
+            style={{ wordBreak: "break-all", lineHeight: 1.2 }}
+          />
+        )}
+      </InspectorItem>
+    </List>
+  );
+};

--- a/extension/src/prototypes/view/states/tool.ts
+++ b/extension/src/prototypes/view/states/tool.ts
@@ -2,11 +2,12 @@
 import { atom } from "jotai";
 import { atomWithMachine } from "jotai-xstate";
 
+import { MeshCodeType } from "../../../shared/meshCode/types";
 import { SketchGeometryType } from "../../sketch";
 
 import { createToolMachine, type ToolMachineState } from "./toolMachine";
 
-export type ToolType = "hand" | "select" | "sketch" | "pedestrian" | "spatialId";
+export type ToolType = "hand" | "select" | "sketch" | "pedestrian" | "spatialId" | "meshCode";
 
 export interface Tool {
   type: ToolType;
@@ -34,6 +35,8 @@ export function getModalTool(state: ToolMachineState): Tool | undefined {
     ? "pedestrian"
     : matchModal("spatialId", state)
     ? "spatialId"
+    : matchModal("meshCode", state)
+    ? "meshCode"
     : undefined;
   return modal != null
     ? {
@@ -73,3 +76,5 @@ export const sketchTypeAtom = atom<SketchGeometryType>("rectangle");
 export const preventToolKeyDownAtom = atom(false);
 
 export const spatialIdZoomAtom = atom<number>(18);
+
+export const meshCodeTypeAtom = atom<MeshCodeType>("2x");

--- a/extension/src/prototypes/view/states/toolMachine.ts
+++ b/extension/src/prototypes/view/states/toolMachine.ts
@@ -6,6 +6,7 @@ export type EventObject =
   | { type: "SKETCH" }
   | { type: "PEDESTRIAN" }
   | { type: "SPATIAL_ID" }
+  | { type: "MESH_CODE" }
   | { type: "MOUSE_UP" }
   | { type: "MOUSE_DOWN" }
   | { type: "PRESS_SPACE" }
@@ -53,6 +54,11 @@ export function createToolMachine() {
                   MOUSE_DOWN: "#tool.modal.active.spatialId",
                 },
               },
+              meshCode: {
+                on: {
+                  MOUSE_DOWN: "#tool.modal.active.meshCode",
+                },
+              },
               history: {
                 type: "history",
               },
@@ -63,6 +69,7 @@ export function createToolMachine() {
               PEDESTRIAN: ".pedestrian",
               SKETCH: ".sketch",
               SPATIAL_ID: ".spatialId",
+              MESH_CODE: ".meshCode",
               PRESS_SPACE: "#tool.momentary.selected.hand",
               PRESS_COMMAND: "#tool.momentary.selected.select",
             },
@@ -75,6 +82,7 @@ export function createToolMachine() {
               pedestrian: {},
               sketch: {},
               spatialId: {},
+              meshCode: {},
             },
             on: {
               MOUSE_UP: "selected.history",

--- a/extension/src/prototypes/view/states/toolMachine.typegen.ts
+++ b/extension/src/prototypes/view/states/toolMachine.typegen.ts
@@ -24,12 +24,14 @@ export interface Typegen0 {
     | "modal.active.select"
     | "modal.active.sketch"
     | "modal.active.spatialId"
+    | "modal.active.meshCode"
     | "modal.selected"
     | "modal.selected.hand"
     | "modal.selected.pedestrian"
     | "modal.selected.select"
     | "modal.selected.sketch"
     | "modal.selected.spatialId"
+    | "modal.selected.meshCode"
     | "momentary"
     | "momentary.active"
     | "momentary.active.hand"
@@ -43,8 +45,8 @@ export interface Typegen0 {
           | "active"
           | "selected"
           | {
-              active?: "hand" | "pedestrian" | "select" | "sketch";
-              selected?: "hand" | "pedestrian" | "select" | "sketch";
+              active?: "hand" | "pedestrian" | "select" | "sketch" | "spatialId" | "meshCode";
+              selected?: "hand" | "pedestrian" | "select" | "sketch" | "spatialId" | "meshCode";
             };
         momentary?:
           | "active"

--- a/extension/src/prototypes/view/ui-containers/SelectionPanel.tsx
+++ b/extension/src/prototypes/view/ui-containers/SelectionPanel.tsx
@@ -3,6 +3,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { type ResizeCallback } from "re-resizable";
 import { useCallback, type FC } from "react";
 
+import { MESH_CODE_OBJECT } from "../../../shared/meshCode";
 import { GENERAL_FEATURE, TILESET_FEATURE } from "../../../shared/reearth/layers";
 import { SPATIAL_ID_OBJECT } from "../../../shared/spatialId";
 import { findRootLayerAtom } from "../../../shared/states/rootLayer";
@@ -19,6 +20,7 @@ import { ColorSchemeContent } from "../selection/ColorSchemeContent";
 import { CustomLegendSchemeContent } from "../selection/CustomLegendSchemeContent";
 import { ImageSchemeContent } from "../selection/ImageSchemeContent";
 import { LayerContent } from "../selection/LayerContent";
+import { MeshCodeObjectContent } from "../selection/MeshCodeObjectContent";
 import { PedestrianLayerContent } from "../selection/PedestrianLayerContent";
 import { SketchObjectContent } from "../selection/SketchObjectContent";
 import { SpatialIdObjectContent } from "../selection/SpatialIdObjectContent";
@@ -99,6 +101,9 @@ export const SelectionPanel: FC = () => {
             break;
           case SPATIAL_ID_OBJECT:
             content = <SpatialIdObjectContent values={selectionGroup.values} />;
+            break;
+          case MESH_CODE_OBJECT:
+            content = <MeshCodeObjectContent values={selectionGroup.values} />;
             break;
         }
         break;

--- a/extension/src/prototypes/view/ui-containers/ToolButtons.tsx
+++ b/extension/src/prototypes/view/ui-containers/ToolButtons.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, type FC } from "react";
 
+import { isMeshCodeType } from "../../../shared/meshCode/types";
 import { isSketchGeometryType } from "../../sketch";
 import {
   AppToggleButton,
@@ -12,10 +13,13 @@ import {
   SketchRectangleIcon,
   SketchCircleIcon,
   SketchPolygonIcon,
+  MeshLevel2Icon,
+  MeshLevel3Icon,
 } from "../../ui-components";
 import { AppToggleButtonSlider } from "../../ui-components/AppToggleButtonSlider";
 import { SpatialIdIcon } from "../../ui-components/icons/SpatialIdIcon";
 import {
+  meshCodeTypeAtom,
   sketchTypeAtom,
   spatialIdZoomAtom,
   toolAtom,
@@ -30,12 +34,18 @@ const eventTypes: Record<ToolType, EventObject["type"]> = {
   sketch: "SKETCH",
   pedestrian: "PEDESTRIAN",
   spatialId: "SPATIAL_ID",
+  meshCode: "MESH_CODE",
 };
 
 const sketchItems = [
   { value: "rectangle", title: "立方体", icon: <SketchRectangleIcon /> },
   { value: "circle", title: "円柱", icon: <SketchCircleIcon /> },
   { value: "polygon", title: "自由形状", icon: <SketchPolygonIcon /> },
+];
+
+const meshCodeItems = [
+  { value: "2x", title: "２次メッシュ", icon: <MeshLevel2Icon /> },
+  { value: "3x", title: "３次メッシュ", icon: <MeshLevel3Icon /> },
 ];
 
 export const ToolButtons: FC = () => {
@@ -64,6 +74,17 @@ export const ToolButtons: FC = () => {
 
   const [spatialIdZoom, setSpatialIdZoom] = useAtom(spatialIdZoomAtom);
 
+  const [meshCodeType, setMeshCodeType] = useAtom(meshCodeTypeAtom);
+  const handleMeshCodeTypeChange = useCallback(
+    (_: unknown, value: string) => {
+      if (isMeshCodeType(value)) {
+        send({ type: "MESH_CODE" });
+        setMeshCodeType(value);
+      }
+    },
+    [send, setMeshCodeType],
+  );
+
   return (
     <AppToggleButtonGroup value={tool?.type} onChange={handleChange}>
       <AppToggleButton value="hand" title="移動" shortcutKey="H">
@@ -86,7 +107,7 @@ export const ToolButtons: FC = () => {
       <AppToggleButtonSlider
         value="spatialId"
         title="空間 ID"
-        shortcutKey="S"
+        shortcutKey="I"
         item={{
           title: "Zoom Level",
           value: spatialIdZoom,
@@ -96,6 +117,14 @@ export const ToolButtons: FC = () => {
         }}>
         <SpatialIdIcon fontSize="medium" />
       </AppToggleButtonSlider>
+      <AppToggleButtonSelect
+        value="meshCode"
+        title="Mesh"
+        shortcutKey="M"
+        items={meshCodeItems}
+        selectedValue={meshCodeType}
+        onValueChange={handleMeshCodeTypeChange}
+      />
     </AppToggleButtonGroup>
   );
 };

--- a/extension/src/shared/meshCode/MeshCode.tsx
+++ b/extension/src/shared/meshCode/MeshCode.tsx
@@ -1,0 +1,41 @@
+import { PrimitiveAtom, useAtomValue } from "jotai";
+import { FC, useMemo } from "react";
+
+import { MeshCodeLayer } from "../reearth/layers";
+import { LayerAppearanceTypes } from "../reearth/types";
+
+import { MeshCodeObject } from "./MeshCodeObject";
+import { MeshCodeFeature } from "./types";
+
+export interface MeshCodeProps {
+  featuresAtom: PrimitiveAtom<MeshCodeFeature[]>;
+  onLoad: (layerId: string) => void;
+}
+
+export const MeshCode: FC<MeshCodeProps> = ({ featuresAtom, onLoad }) => {
+  const features = useAtomValue(featuresAtom);
+
+  const appearances: Partial<LayerAppearanceTypes> = useMemo(
+    () => ({
+      polygon: {
+        fill: true,
+        fillColor: "#00bebe22",
+        stroke: true,
+        strokeColor: "#00bebe",
+        heightReference: "clamp" as const,
+        hideIndicator: true,
+        selectedFeatureColor: "#00bebe99",
+      },
+    }),
+    [],
+  );
+
+  return (
+    <>
+      {features.map((feature, i) => (
+        <MeshCodeObject key={i} id={feature.id} />
+      ))}
+      <MeshCodeLayer features={features} appearances={appearances} onLoad={onLoad} />
+    </>
+  );
+};

--- a/extension/src/shared/meshCode/MeshCodeDrawer.tsx
+++ b/extension/src/shared/meshCode/MeshCodeDrawer.tsx
@@ -1,0 +1,125 @@
+import jismesh from "jismesh-js";
+import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
+import { nanoid } from "nanoid";
+import { FC, useCallback, useState } from "react";
+
+import { composeIdentifier } from "../../prototypes/cesium-helpers";
+import { LayerModel, layerSelectionAtom, useAddLayer } from "../../prototypes/layers";
+import { screenSpaceSelectionAtom } from "../../prototypes/screen-space-selection";
+import { meshCodeTypeAtom } from "../../prototypes/view/states/tool";
+import { highlightedMeshCodeLayersAtom, MESH_CODE_LAYER } from "../../prototypes/view-layers";
+import { useReEarthEvent } from "../reearth/hooks";
+import { MeshCodeIndicator } from "../reearth/layers";
+import { MouseEvent } from "../reearth/types";
+import { rootLayersLayersAtom } from "../states/rootLayer";
+import { createRootLayerForLayerAtom } from "../view-layers";
+
+import { MESH_CODE_OBJECT, MeshCodeFeature } from "./types";
+import { getCoordinatesFromMeshCode, getMeshCodeLevelByType } from "./utils";
+
+const targetMeshCodeLayerAtom = atom<LayerModel<typeof MESH_CODE_LAYER> | null>(get => {
+  const layers = get(rootLayersLayersAtom);
+  const selection = get(layerSelectionAtom);
+  const selectedMeshCodeLayers = layers.filter(
+    (layer): layer is LayerModel<typeof MESH_CODE_LAYER> =>
+      layer.type === MESH_CODE_LAYER && selection.map(s => s.id).includes(layer.id),
+  );
+  const highlightedMeshCodeLayers = get(highlightedMeshCodeLayersAtom);
+  if (selectedMeshCodeLayers.length === 0) {
+    return highlightedMeshCodeLayers[0] ?? null;
+  }
+  return selectedMeshCodeLayers[0] ?? null;
+});
+
+const existMeshCodeFeaturesAtom = atom(get => {
+  const layer = get(targetMeshCodeLayerAtom);
+  return layer?.featuresAtom ? get(layer.featuresAtom) : [];
+});
+
+const addFeatureAtom = atom(null, (get, set, value: MeshCodeFeature) => {
+  const layer = get(targetMeshCodeLayerAtom);
+  if (layer == null) {
+    return;
+  }
+  set(layer.featureAtomsAtom, {
+    type: "insert",
+    value,
+  });
+});
+
+const MeshCodeDrawer: FC = () => {
+  const layer = useAtomValue(targetMeshCodeLayerAtom);
+  const addFeature = useSetAtom(addFeatureAtom);
+  const addLayer = useAddLayer();
+  const setScreenSpaceSelection = useSetAtom(screenSpaceSelectionAtom);
+
+  const existFeatures = useAtomValue(existMeshCodeFeaturesAtom);
+
+  const handleCreate = useCallback(
+    (meshCode: string) => {
+      if (existFeatures?.some(f => f.meshCode === meshCode)) {
+        return;
+      }
+
+      const id = nanoid();
+      const feature: MeshCodeFeature = {
+        id,
+        meshCode,
+      };
+      if (layer != null) {
+        addFeature(feature);
+      } else {
+        const layer = createRootLayerForLayerAtom({
+          id,
+          type: MESH_CODE_LAYER,
+          features: [feature],
+        });
+        addLayer(layer, { autoSelect: false });
+      }
+
+      setTimeout(() => {
+        setScreenSpaceSelection([
+          {
+            type: MESH_CODE_OBJECT,
+            value: composeIdentifier({
+              type: "MeshCode",
+              subtype: MESH_CODE_OBJECT,
+              key: feature.id,
+            }),
+          },
+        ]);
+      }, 120);
+    },
+    [addFeature, addLayer, setScreenSpaceSelection, layer, existFeatures],
+  );
+
+  const [meshCodeType] = useAtom(meshCodeTypeAtom);
+  const [coordinates, setCoordinates] = useState<[number, number][][] | undefined>();
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!e.lat || !e.lng) return;
+      const meshCode = jismesh.toMeshCode(e.lat, e.lng, getMeshCodeLevelByType(meshCodeType));
+      if (!meshCode) return;
+      setCoordinates(getCoordinatesFromMeshCode(meshCode));
+    },
+    [meshCodeType],
+  );
+
+  const handleMouseClick = useCallback(
+    (e: MouseEvent) => {
+      if (!e.lat || !e.lng) return;
+      const meshCode = jismesh.toMeshCode(e.lat, e.lng, getMeshCodeLevelByType(meshCodeType));
+      if (!meshCode) return;
+      handleCreate(meshCode);
+    },
+    [meshCodeType, handleCreate],
+  );
+
+  useReEarthEvent("mousemove", handleMouseMove);
+  useReEarthEvent("click", handleMouseClick);
+
+  return coordinates ? <MeshCodeIndicator coordinates={coordinates} /> : null;
+};
+
+export default MeshCodeDrawer;

--- a/extension/src/shared/meshCode/MeshCodeObject.tsx
+++ b/extension/src/shared/meshCode/MeshCodeObject.tsx
@@ -1,0 +1,44 @@
+import { FC } from "react";
+
+import { composeIdentifier } from "../../prototypes/cesium-helpers";
+import {
+  ScreenSpaceSelectionEntry,
+  useScreenSpaceSelectionResponder,
+} from "../../prototypes/screen-space-selection";
+
+import { MESH_CODE_OBJECT } from "./types";
+
+export interface MeshCodeObjectProps {
+  id: string;
+}
+
+export const MeshCodeObject: FC<MeshCodeObjectProps> = ({ id }) => {
+  const objectId = composeIdentifier({
+    type: "MeshCode",
+    subtype: MESH_CODE_OBJECT,
+    key: id,
+  });
+
+  useScreenSpaceSelectionResponder({
+    type: MESH_CODE_OBJECT,
+    convertToSelection: object => {
+      return "properties" in object &&
+        object.properties &&
+        typeof object.properties === "object" &&
+        "id" in object.properties &&
+        object.properties.id === id
+        ? {
+            type: MESH_CODE_OBJECT,
+            value: objectId,
+          }
+        : undefined;
+    },
+    shouldRespondToSelection: (
+      value,
+    ): value is ScreenSpaceSelectionEntry<typeof MESH_CODE_OBJECT> => {
+      return value.type === MESH_CODE_OBJECT && value.value === objectId;
+    },
+  });
+
+  return null;
+};

--- a/extension/src/shared/meshCode/index.ts
+++ b/extension/src/shared/meshCode/index.ts
@@ -1,0 +1,4 @@
+export * from "./MeshCode";
+export * from "./MeshCodeDrawer";
+export * from "./types";
+export * from "./status";

--- a/extension/src/shared/meshCode/jismesh-js.d.ts
+++ b/extension/src/shared/meshCode/jismesh-js.d.ts
@@ -1,0 +1,9 @@
+declare module "jismesh-js" {
+  export function toMeshCode(latitude: number, longitude: number, zoomLevel: number): string;
+  export function toMeshPoint(
+    meshCode: string,
+    index1: number,
+    index2: number,
+  ): [latitude: number, longitude: number];
+  export function toMeshLevel(meshCode: string): number;
+}

--- a/extension/src/shared/meshCode/status.ts
+++ b/extension/src/shared/meshCode/status.ts
@@ -1,0 +1,15 @@
+import { atom } from "jotai";
+
+import {
+  screenSpaceSelectionAtom,
+  ScreenSpaceSelectionEntry,
+} from "../../prototypes/screen-space-selection";
+
+import { MESH_CODE_OBJECT } from "./types";
+
+export const meshCodeSelectionAtom = atom(get => {
+  return get(screenSpaceSelectionAtom).filter(
+    (entry): entry is ScreenSpaceSelectionEntry<typeof MESH_CODE_OBJECT> =>
+      entry.type === MESH_CODE_OBJECT,
+  );
+});

--- a/extension/src/shared/meshCode/types.ts
+++ b/extension/src/shared/meshCode/types.ts
@@ -1,0 +1,18 @@
+export function isMeshCodeType(value: string): value is MeshCodeType {
+  return value === "2x" || value === "3x";
+}
+
+export const MESH_CODE_OBJECT = "MESH_CODE_OBJECT";
+
+export type MeshCodeType = "2x" | "3x";
+
+export type MeshCodeFeature = {
+  id: string;
+  meshCode: string;
+};
+
+declare module "../../prototypes/screen-space-selection" {
+  interface ScreenSpaceSelectionOverrides {
+    [MESH_CODE_OBJECT]: string;
+  }
+}

--- a/extension/src/shared/meshCode/utils.ts
+++ b/extension/src/shared/meshCode/utils.ts
@@ -1,0 +1,19 @@
+import jismesh from "jismesh-js";
+
+export const getCoordinatesFromMeshCode = (meshCode: string): [number, number][][] => {
+  const [latSW, lonSW] = jismesh.toMeshPoint(meshCode, 0, 0);
+  const [latSE, lonSE] = jismesh.toMeshPoint(meshCode, 0, 1);
+  const [latNE, lonNE] = jismesh.toMeshPoint(meshCode, 1, 1);
+  const [latNW, lonNW] = jismesh.toMeshPoint(meshCode, 1, 0);
+  return [
+    [
+      [lonSW, latSW],
+      [lonSE, latSE],
+      [lonNE, latNE],
+      [lonNW, latNW],
+      [lonSW, latSW],
+    ],
+  ];
+};
+
+export const getMeshCodeLevelByType = (type: "2x" | "3x"): number => (type === "2x" ? 2 : 3);

--- a/extension/src/shared/reearth/layers/index.ts
+++ b/extension/src/shared/reearth/layers/index.ts
@@ -5,3 +5,6 @@ export * from "./pedestrian";
 export * from "./heatmap";
 export * from "./highlightPolygon";
 export * from "./polygon";
+export * from "./spatialId";
+export * from "./meshCode";
+export * from "./meshCodeIndicator";

--- a/extension/src/shared/reearth/layers/meshCode.ts
+++ b/extension/src/shared/reearth/layers/meshCode.ts
@@ -1,0 +1,55 @@
+import { FC, useMemo } from "react";
+
+import { MeshCodeFeature } from "../../meshCode";
+import { getCoordinatesFromMeshCode } from "../../meshCode/utils";
+import { useLayer } from "../hooks";
+import { Data, LayerAppearanceTypes } from "../types";
+
+export type MeshCodeLayerProps = {
+  features: MeshCodeFeature[];
+  appearances: Partial<LayerAppearanceTypes>;
+  visible?: boolean;
+  onLoad?: (layerId: string) => void;
+};
+
+export const MeshCodeLayer: FC<MeshCodeLayerProps> = ({
+  features,
+  appearances,
+  visible,
+  onLoad,
+}) => {
+  const data: Data = useMemo(() => {
+    const geojsonFeatures = [];
+    for (const feature of features) {
+      const coordinates = getCoordinatesFromMeshCode(feature.meshCode);
+      geojsonFeatures.push({
+        type: "Feature",
+        id: feature.id,
+        properties: {
+          id: feature.id,
+          meshCode: feature.meshCode,
+        },
+        geometry: {
+          coordinates,
+          type: "Polygon",
+        },
+      });
+    }
+    return {
+      type: "geojson",
+      value: {
+        type: "FeatureCollection",
+        features: geojsonFeatures,
+      },
+    };
+  }, [features]);
+
+  useLayer({
+    data,
+    visible,
+    appearances,
+    onLoad,
+  });
+
+  return null;
+};

--- a/extension/src/shared/reearth/layers/meshCodeIndicator.ts
+++ b/extension/src/shared/reearth/layers/meshCodeIndicator.ts
@@ -1,0 +1,47 @@
+import { FC, useMemo } from "react";
+
+import { useLayer } from "../hooks";
+import { Data } from "../types";
+
+type Props = {
+  coordinates?: [number, number][][];
+};
+
+const appearances = {
+  polygon: {
+    fill: true,
+    fillColor: "#00bebe22",
+    stroke: true,
+    strokeColor: "#00bebe",
+    heightReference: "clamp" as const,
+  },
+};
+
+export const MeshCodeIndicator: FC<Props> = ({ coordinates }) => {
+  const data: Data = useMemo(
+    () => ({
+      type: "geojson",
+      value: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates,
+            },
+          },
+        ],
+      },
+    }),
+    [coordinates],
+  );
+
+  useLayer({
+    data,
+    appearances,
+    visible: true,
+  });
+
+  return null;
+};

--- a/extension/src/shared/states/share.ts
+++ b/extension/src/shared/states/share.ts
@@ -4,6 +4,7 @@ import { isNotNullish } from "../../prototypes/type-helpers";
 import {
   HEATMAP_LAYER,
   HeatmapLayerModel,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PEDESTRIAN_LAYER,
   PedestrianLayerModel,
@@ -24,6 +25,7 @@ import {
   SharedStoryLayer,
   StoryLayerModel,
 } from "../view-layers";
+import { MeshCodeLayerModel, SharedMeshCodeLayer } from "../view-layers/meshCode";
 import { SharedSpatialIdLayer, SpatialIdLayerModel } from "../view-layers/spatialId";
 
 import { rootLayersAtom } from "./rootLayer";
@@ -59,6 +61,7 @@ export type SharedRootLayer = (
   | SharedMyDataLayer
   | SharedSketchLayer
   | SharedSpatialIdLayer
+  | SharedMeshCodeLayer
   | SharedStoryLayer
 ) & { hidden?: boolean };
 
@@ -125,6 +128,16 @@ const shareRootLayerAtom = atom(undefined, async get => {
               const l = layer as SpatialIdLayerModel;
               return {
                 type: "spatialId",
+                id: l.id,
+                title: l.title,
+                features: get(l.featuresAtom),
+                hidden: get(l.hiddenAtom),
+              };
+            }
+            case MESH_CODE_LAYER: {
+              const l = layer as MeshCodeLayerModel;
+              return {
+                type: "meshCode",
                 id: l.id,
                 title: l.title,
                 features: get(l.featuresAtom),

--- a/extension/src/shared/view-layers/createViewLayer.ts
+++ b/extension/src/shared/view-layers/createViewLayer.ts
@@ -21,6 +21,7 @@ import {
   LAND_SLIDE_RISK_LAYER,
   LAND_USE_LAYER,
   LANDMARK_LAYER,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PARK_LAYER,
   PEDESTRIAN_LAYER,
@@ -42,6 +43,7 @@ import {
 } from "../../prototypes/view-layers";
 
 import { GeneralLayerModelParams, createGeneralDatasetLayer } from "./general";
+import { createMeshCodeLayer, MeshCodeLayerModelParams } from "./meshCode";
 import { MyDataLayerModelParams, createMyDataLayer } from "./myData";
 import {
   createBuildingLayer,
@@ -68,6 +70,7 @@ export type ViewLayerModelParams<T extends LayerType> =
   T extends typeof PEDESTRIAN_LAYER ? PedestrianLayerModelParams :
   T extends typeof SKETCH_LAYER ? SketchLayerModelParams :
   T extends typeof SPATIAL_ID_LAYER ? SpatialIdLayerModelParams :
+  T extends typeof MESH_CODE_LAYER ? MeshCodeLayerModelParams :
   T extends typeof MY_DATA_LAYER ? MyDataLayerModelParams :
   T extends typeof STORY_LAYER ? StoryLayerModelParams :
 
@@ -111,6 +114,7 @@ export function createViewLayer<T extends LayerType>(
     case PEDESTRIAN_LAYER: return createPedestrianLayer(params as PedestrianLayerModelParams)
     case SKETCH_LAYER: return createSketchLayer(params as SketchLayerModelParams)
     case SPATIAL_ID_LAYER: return createSpatialIdLayer(params as SpatialIdLayerModelParams)
+    case MESH_CODE_LAYER: return createMeshCodeLayer(params as MeshCodeLayerModelParams)
     case MY_DATA_LAYER: return createMyDataLayer(params as MyDataLayerModelParams)
     case STORY_LAYER: return createStoryLayer(params as StoryLayerModelParams)
 

--- a/extension/src/shared/view-layers/layerComponents.ts
+++ b/extension/src/shared/view-layers/layerComponents.ts
@@ -20,6 +20,7 @@ import {
   LAND_SLIDE_RISK_LAYER,
   LAND_USE_LAYER,
   LANDMARK_LAYER,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PARK_LAYER,
   PEDESTRIAN_LAYER,
@@ -39,6 +40,7 @@ import {
   WATERWAY_LAYER,
 } from "../../prototypes/view-layers/layerTypes";
 
+import { MeshCodeLayer } from "./meshCode";
 import { FloodLayer } from "./plateau-3dtiles/FloodLayer";
 import { SpatialIdLayer } from "./spatialId";
 
@@ -54,6 +56,7 @@ export const layerComponents: LayerComponents = {
   [PEDESTRIAN_LAYER]: PedestrianLayer,
   [SKETCH_LAYER]: SketchLayer,
   [SPATIAL_ID_LAYER]: SpatialIdLayer,
+  [MESH_CODE_LAYER]: MeshCodeLayer,
   [MY_DATA_LAYER]: MyDataLayer,
   [STORY_LAYER]: StoryLayer,
 

--- a/extension/src/shared/view-layers/meshCode/MeshCodeLayer.tsx
+++ b/extension/src/shared/view-layers/meshCode/MeshCodeLayer.tsx
@@ -1,0 +1,71 @@
+import { atom, PrimitiveAtom, useAtomValue, useSetAtom } from "jotai";
+import { splitAtom } from "jotai/utils";
+import { FC, useCallback } from "react";
+
+import { LayerProps } from "../../../prototypes/layers";
+import { SplitAtom } from "../../../prototypes/type-helpers";
+import {
+  ConfigurableLayerModel,
+  createViewLayerModel,
+  MESH_CODE_LAYER,
+  ViewLayerModel,
+  ViewLayerModelParams,
+} from "../../../prototypes/view-layers";
+import { MeshCode, MeshCodeFeature } from "../../meshCode";
+
+let nextLayerIndex = 1;
+
+export interface MeshCodeLayerModelParams extends ViewLayerModelParams {
+  features?: readonly MeshCodeFeature[];
+}
+
+export interface MeshCodeLayerModel extends ViewLayerModel {
+  title: string;
+  featuresAtom: PrimitiveAtom<MeshCodeFeature[]>;
+  featureAtomsAtom: SplitAtom<MeshCodeFeature>;
+}
+
+export type SharedMeshCodeLayer = {
+  type: "meshCode";
+  id: string;
+  title: string;
+  features: MeshCodeFeature[];
+};
+
+export function createMeshCodeLayer(
+  params: MeshCodeLayerModelParams,
+): ConfigurableLayerModel<MeshCodeLayerModel> {
+  const featuresAtom = atom<MeshCodeFeature[]>([...(params.features ?? [])]);
+  const title = `メッシュコレクション ${nextLayerIndex++}`;
+  return {
+    ...createViewLayerModel({
+      ...params,
+      title,
+    }),
+    title,
+    type: MESH_CODE_LAYER,
+    featuresAtom,
+    featureAtomsAtom: splitAtom(featuresAtom),
+  };
+}
+
+export const MeshCodeLayer: FC<LayerProps<typeof MESH_CODE_LAYER>> = ({
+  featuresAtom,
+  hiddenAtom,
+  layerIdAtom,
+}) => {
+  const hidden = useAtomValue(hiddenAtom);
+
+  const setLayerId = useSetAtom(layerIdAtom);
+  const handleLoad = useCallback(
+    (layerId: string) => {
+      setLayerId(layerId);
+    },
+    [setLayerId],
+  );
+
+  if (hidden) {
+    return null;
+  }
+  return <MeshCode featuresAtom={featuresAtom} onLoad={handleLoad} />;
+};

--- a/extension/src/shared/view-layers/meshCode/index.ts
+++ b/extension/src/shared/view-layers/meshCode/index.ts
@@ -1,0 +1,1 @@
+export * from "./MeshCodeLayer";

--- a/extension/src/shared/view-layers/types.ts
+++ b/extension/src/shared/view-layers/types.ts
@@ -32,11 +32,13 @@ import {
   CITY_LAYER,
   SPATIAL_ID_LAYER,
   RESERVOIR_FLOODING_RISK_LAYER,
+  MESH_CODE_LAYER,
 } from "../../prototypes/view-layers";
 import { PedestrianLayerModel } from "../../prototypes/view-layers/PedestrianLayer";
 import { SketchLayerModel } from "../../prototypes/view-layers/SketchLayer";
 
 import { GeneralLayerModel } from "./general";
+import { MeshCodeLayerModel } from "./meshCode";
 import { MyDataLayerModel } from "./myData";
 import { BuildingLayerModel } from "./plateau-3dtiles";
 import { FloodLayerModel } from "./plateau-3dtiles/FloodLayer";
@@ -48,6 +50,7 @@ export interface LayerModelOverrides {
   [PEDESTRIAN_LAYER]: PedestrianLayerModel;
   [SKETCH_LAYER]: SketchLayerModel;
   [SPATIAL_ID_LAYER]: SpatialIdLayerModel;
+  [MESH_CODE_LAYER]: MeshCodeLayerModel;
   [MY_DATA_LAYER]: MyDataLayerModel;
   [STORY_LAYER]: StoryLayerModel;
 

--- a/extension/src/shared/view/containers/InitialLayers.tsx
+++ b/extension/src/shared/view/containers/InitialLayers.tsx
@@ -13,6 +13,7 @@ import {
 import { readyAtom } from "../../../prototypes/view/states/app";
 import {
   HEATMAP_LAYER,
+  MESH_CODE_LAYER,
   MY_DATA_LAYER,
   PEDESTRIAN_LAYER,
   SKETCH_LAYER,
@@ -239,6 +240,14 @@ export const InitialLayers: FC = () => {
               id: l.id,
               title: l.title,
               type: SPATIAL_ID_LAYER,
+              features: l.features,
+              hidden: l.hidden,
+            };
+          case "meshCode":
+            return {
+              id: l.id,
+              title: l.title,
+              type: MESH_CODE_LAYER,
               features: l.features,
               hidden: l.hidden,
             };

--- a/extension/src/shared/view/containers/MeshCodeTool.tsx
+++ b/extension/src/shared/view/containers/MeshCodeTool.tsx
@@ -1,0 +1,12 @@
+import { useAtom } from "jotai";
+import { FC, useMemo } from "react";
+
+import { toolAtom } from "../../../prototypes/view/states/tool";
+import MeshCodeDrawer from "../../meshCode/MeshCodeDrawer";
+
+export const MeshCodeTool: FC = () => {
+  const [toolType] = useAtom(toolAtom);
+  const enabled = useMemo(() => toolType?.type === "meshCode", [toolType?.type]);
+
+  return enabled ? <MeshCodeDrawer /> : null;
+};

--- a/extension/src/shared/view/containers/SpatialIdTool.tsx
+++ b/extension/src/shared/view/containers/SpatialIdTool.tsx
@@ -13,7 +13,6 @@ import { SpatialIdSpaceData } from "../../reearth/types/reearthPluginAPIv2/spati
 import { SPATIAL_ID_OBJECT, SpatialIdFeature } from "../../spatialId";
 import { rootLayersLayersAtom } from "../../states/rootLayer";
 import { createRootLayerForLayerAtom } from "../../view-layers";
-// import useSpatialIdTool from "../hooks/useSpatialIdTool";
 
 const targetSpatialIdLayerAtom = atom<LayerModel<typeof SPATIAL_ID_LAYER> | null>(get => {
   const layers = get(rootLayersLayersAtom);
@@ -75,8 +74,6 @@ export const SpatialIdTool: FC = () => {
     },
     [addFeature, addLayer, setScreenSpaceSelection, layer],
   );
-
-  // useSpatialIdTool();
 
   const [toolType] = useAtom(toolAtom);
   const spatialIdZoom = useAtomValue(spatialIdZoomAtom);

--- a/extension/src/shared/view/selection/LegendDescriptionSection.tsx
+++ b/extension/src/shared/view/selection/LegendDescriptionSection.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../prototypes/view/states/selection";
 import {
   HEATMAP_LAYER,
+  MESH_CODE_LAYER,
   PEDESTRIAN_LAYER,
   SKETCH_LAYER,
   SPATIAL_ID_LAYER,
@@ -28,7 +29,11 @@ export const LegendDescriptionSection: FC<LegendDescriptionSectionProps> = ({ va
   const layer = values[0] as LayerModel<
     Exclude<
       LayerType,
-      typeof PEDESTRIAN_LAYER | typeof HEATMAP_LAYER | typeof SKETCH_LAYER | typeof SPATIAL_ID_LAYER
+      | typeof PEDESTRIAN_LAYER
+      | typeof HEATMAP_LAYER
+      | typeof SKETCH_LAYER
+      | typeof SPATIAL_ID_LAYER
+      | typeof MESH_CODE_LAYER
     >
   >;
   const legendDescriptionAtom = useFindComponent(

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -25,6 +25,7 @@ import { WidgetProps } from "../shared/types/widget";
 import { PLATEAUVIEW_TOOLBAR_DOM_ID } from "../shared/ui-components/common/ViewClickAwayListener";
 import { InitialLayers } from "../shared/view/containers/InitialLayers";
 import JapanPlateauPolygon from "../shared/view/containers/JapanPlateauPolygon";
+import { MeshCodeTool } from "../shared/view/containers/MeshCodeTool";
 import { SpatialIdTool } from "../shared/view/containers/SpatialIdTool";
 import FeedBack from "../shared/view/ui-container/Feedback";
 import Help from "../shared/view/ui-container/Help";
@@ -129,6 +130,7 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
         <PedestrianTool />
         <SketchTool />
         <SpatialIdTool />
+        <MeshCodeTool />
         <MyData />
         <Help />
         <AutoRotateCamera />

--- a/extension/src/toolbar/hooks/useInteractionMode.ts
+++ b/extension/src/toolbar/hooks/useInteractionMode.ts
@@ -12,6 +12,7 @@ const TOOL_TO_INTERACTIONMODE: Record<ToolType, InteractionModeType> = {
   sketch: "sketch",
   pedestrian: "move", // TODO: Check later
   spatialId: "spatialId",
+  meshCode: "move",
 };
 
 export const useInteractionMode = () => {

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -10187,6 +10187,11 @@ jest-worker@^29.6.2:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jismesh-js@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/jismesh-js/-/jismesh-js-0.2.0.tgz#1d6e4b3df78cb5aa8c35305f2b5228bb66fb42d7"
+  integrity sha512-Cdsekn6BFKROPasiEonIR+1dynOFerSstWnM4V6YhWV1XXWPgbN2HZ1Y/u5AQvzXIp75UO0cbUpofo9SYcKJlg==
+
 jiti@^1.17.1, jiti@^1.18.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"


### PR DESCRIPTION
## Overview

This PR adds the basic support for mesh code layer.

![image](https://github.com/user-attachments/assets/1e3de3db-df1d-40d1-9529-538cd4625a1d)

## What did i do

- Add mesh code layer tool on tool bar.
- Add draw mesh code functions.
- Add new layer type MESH_CODE_LAYER and object type MESH_CODE_OBJECT
- Add selection content `LayerMeshCodeSection` and `MeshCodeObjectContent`
- Add hotkeys for SpatialId tool and MeshCode tool (not confirmed).

## What haven't been done

- The UI and further logic on selection panel is waiting for confirm on design.
- Didn't add more CityGML APIs in this PR.