### PR TITLE
fix(extension): useAtomValue with undefined

### DIFF
--- a/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
+++ b/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
@@ -1,11 +1,10 @@
-import { atom, useAtomValue } from "jotai";
 import { FC, useMemo } from "react";
 
+import { useOptionalAtomValue } from "../../../shared/hooks";
 import { LayerModel } from "../../layers";
 import { ParameterList, PropertyParameterItem } from "../../ui-components";
 import { MESH_CODE_LAYER } from "../../view-layers";
 
-const fallbackAtom = atom([]);
 export interface LayerMeshCodeSectionProps {
   layers: readonly LayerModel[];
 }
@@ -19,7 +18,7 @@ export const LayerMeshCodeSection: FC<LayerMeshCodeSectionProps> = ({ layers }) 
     [layers],
   );
 
-  const features = useAtomValue(meshCodeLayers[0]?.featuresAtom ?? fallbackAtom);
+  const features = useOptionalAtomValue(meshCodeLayers[0]?.featuresAtom);
 
   const properties = useMemo(() => {
     if (!features) return [];

--- a/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
+++ b/extension/src/prototypes/view/selection/LayerMeshCodeSection.tsx
@@ -1,10 +1,11 @@
-import { useAtomValue } from "jotai";
+import { atom, useAtomValue } from "jotai";
 import { FC, useMemo } from "react";
 
 import { LayerModel } from "../../layers";
 import { ParameterList, PropertyParameterItem } from "../../ui-components";
 import { MESH_CODE_LAYER } from "../../view-layers";
 
+const fallbackAtom = atom([]);
 export interface LayerMeshCodeSectionProps {
   layers: readonly LayerModel[];
 }
@@ -18,7 +19,7 @@ export const LayerMeshCodeSection: FC<LayerMeshCodeSectionProps> = ({ layers }) 
     [layers],
   );
 
-  const features = useAtomValue(meshCodeLayers[0].featuresAtom);
+  const features = useAtomValue(meshCodeLayers[0]?.featuresAtom ?? fallbackAtom);
 
   const properties = useMemo(() => {
     if (!features) return [];

--- a/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
@@ -21,6 +21,7 @@ import {
 import { highlightedMeshCodeLayersAtom, MESH_CODE_LAYER } from "../../view-layers";
 import { SCREEN_SPACE_SELECTION, SelectionGroup } from "../states/selection";
 
+const fallbackAtom = atom([]);
 export interface MeshCodeObjectContentProps {
   values: (SelectionGroup & {
     type: typeof SCREEN_SPACE_SELECTION;
@@ -68,7 +69,7 @@ export const MeshCodeObjectContent: FC<MeshCodeObjectContentProps> = ({ values }
     setSelection([]);
   }, [values, removeFeatures, setSelection]);
 
-  const features = useAtomValue(meshCodeLayers[0].featuresAtom);
+  const features = useAtomValue(meshCodeLayers[0]?.featuresAtom ?? fallbackAtom);
 
   const properties = useMemo(() => {
     const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);

--- a/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/MeshCodeObjectContent.tsx
@@ -5,6 +5,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import ReactJson from "react-json-view";
 
 import { cityGMLClient } from "../../../shared/api/citygml";
+import { useOptionalAtomValue } from "../../../shared/hooks";
 import { MESH_CODE_OBJECT } from "../../../shared/meshCode";
 import { parseIdentifier } from "../../cesium-helpers";
 import { layerSelectionAtom } from "../../layers";
@@ -21,7 +22,6 @@ import {
 import { highlightedMeshCodeLayersAtom, MESH_CODE_LAYER } from "../../view-layers";
 import { SCREEN_SPACE_SELECTION, SelectionGroup } from "../states/selection";
 
-const fallbackAtom = atom([]);
 export interface MeshCodeObjectContentProps {
   values: (SelectionGroup & {
     type: typeof SCREEN_SPACE_SELECTION;
@@ -69,10 +69,10 @@ export const MeshCodeObjectContent: FC<MeshCodeObjectContentProps> = ({ values }
     setSelection([]);
   }, [values, removeFeatures, setSelection]);
 
-  const features = useAtomValue(meshCodeLayers[0]?.featuresAtom ?? fallbackAtom);
+  const features = useOptionalAtomValue(meshCodeLayers[0]?.featuresAtom);
 
   const properties = useMemo(() => {
-    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    const feature = features?.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return [];
     return [
       {
@@ -87,7 +87,7 @@ export const MeshCodeObjectContent: FC<MeshCodeObjectContentProps> = ({ values }
   const [_loading, setLoading] = useState<boolean>(true);
   const [_error, setError] = useState<string | null>(null);
   const meshCode = useMemo(() => {
-    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    const feature = features?.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return;
     return feature.meshCode;
   }, [features, values]);

--- a/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
@@ -22,6 +22,7 @@ import {
 import { highlightedSpatialIdLayersAtom, SPATIAL_ID_LAYER } from "../../view-layers";
 import { SCREEN_SPACE_SELECTION, SelectionGroup } from "../states/selection";
 
+const fallbackAtom = atom([]);
 export interface SpatialIdObjectContentProps {
   values: (SelectionGroup & {
     type: typeof SCREEN_SPACE_SELECTION;
@@ -69,7 +70,7 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
     setSelection([]);
   }, [values, removeFeatures, setSelection]);
 
-  const features = useAtomValue(spatialIdLayers[0].featuresAtom);
+  const features = useAtomValue(spatialIdLayers[0]?.featuresAtom ?? fallbackAtom);
 
   const properties = useMemo(() => {
     const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);

--- a/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
+++ b/extension/src/prototypes/view/selection/SpatialIdObjectContent.tsx
@@ -5,6 +5,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import ReactJson from "react-json-view";
 
 import { cityGMLClient } from "../../../shared/api/citygml";
+import { useOptionalAtomValue } from "../../../shared/hooks";
 import { SPATIAL_ID_OBJECT } from "../../../shared/spatialId";
 import { parseIdentifier } from "../../cesium-helpers";
 import { layerSelectionAtom } from "../../layers";
@@ -22,7 +23,6 @@ import {
 import { highlightedSpatialIdLayersAtom, SPATIAL_ID_LAYER } from "../../view-layers";
 import { SCREEN_SPACE_SELECTION, SelectionGroup } from "../states/selection";
 
-const fallbackAtom = atom([]);
 export interface SpatialIdObjectContentProps {
   values: (SelectionGroup & {
     type: typeof SCREEN_SPACE_SELECTION;
@@ -70,10 +70,10 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
     setSelection([]);
   }, [values, removeFeatures, setSelection]);
 
-  const features = useAtomValue(spatialIdLayers[0]?.featuresAtom ?? fallbackAtom);
+  const features = useOptionalAtomValue(spatialIdLayers[0]?.featuresAtom);
 
   const properties = useMemo(() => {
-    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    const feature = features?.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return [];
     return [
       {
@@ -98,7 +98,7 @@ export const SpatialIdObjectContent: FC<SpatialIdObjectContentProps> = ({ values
   const [_loading, setLoading] = useState<boolean>(true);
   const [_error, setError] = useState<string | null>(null);
   const spaceZFXYStr = useMemo(() => {
-    const feature = features.find(feature => parseIdentifier(values[0]).key === feature.id);
+    const feature = features?.find(feature => parseIdentifier(values[0]).key === feature.id);
     if (!feature) return;
     return feature.data.zfxyStr;
   }, [features, values]);

--- a/extension/src/prototypes/view/states/tool.ts
+++ b/extension/src/prototypes/view/states/tool.ts
@@ -77,4 +77,4 @@ export const preventToolKeyDownAtom = atom(false);
 
 export const spatialIdZoomAtom = atom<number>(18);
 
-export const meshCodeTypeAtom = atom<MeshCodeType>("2x");
+export const meshCodeTypeAtom = atom<MeshCodeType>("3x");

--- a/extension/src/shared/meshCode/MeshCodeDrawer.tsx
+++ b/extension/src/shared/meshCode/MeshCodeDrawer.tsx
@@ -77,18 +77,16 @@ const MeshCodeDrawer: FC = () => {
         addLayer(layer, { autoSelect: false });
       }
 
-      setTimeout(() => {
-        setScreenSpaceSelection([
-          {
-            type: MESH_CODE_OBJECT,
-            value: composeIdentifier({
-              type: "MeshCode",
-              subtype: MESH_CODE_OBJECT,
-              key: feature.id,
-            }),
-          },
-        ]);
-      }, 120);
+      setScreenSpaceSelection([
+        {
+          type: MESH_CODE_OBJECT,
+          value: composeIdentifier({
+            type: "MeshCode",
+            subtype: MESH_CODE_OBJECT,
+            key: feature.id,
+          }),
+        },
+      ]);
     },
     [addFeature, addLayer, setScreenSpaceSelection, layer, existFeatures],
   );

--- a/extension/src/shared/reearth/layers/meshCodeIndicator.ts
+++ b/extension/src/shared/reearth/layers/meshCodeIndicator.ts
@@ -10,8 +10,9 @@ type Props = {
 const appearances = {
   polygon: {
     fill: true,
-    fillColor: "#00bebe22",
+    fillColor: "#00bebe00",
     stroke: true,
+    strokeWidth: 2,
     strokeColor: "#00bebe",
     heightReference: "clamp" as const,
   },


### PR DESCRIPTION
## Overview

This PR fixes the useAtomValue for mesh code layer feature and spatial id layer feature.
Also:
- update the indicator style for mesh code layer.
- set default mesh code level to 3.
- remove the setTimeout of select new created mesh code object.