### PR TITLE
refactor(extension): auto quit after drawing clipping finished

### DIFF
--- a/extension/src/shared/view/fields/3dtiles/LayerTilesetDrawClippingField.tsx
+++ b/extension/src/shared/view/fields/3dtiles/LayerTilesetDrawClippingField.tsx
@@ -183,9 +183,10 @@ export const LayerTilesetDrawClippingField: FC<LayerTilesetDrawClippingFieldProp
             bottom: e.feature.properties.extrudedHeight ? 0 : DEFAULT_BOTTOM,
           },
         });
+        handleSetType(undefined);
       }
     },
-    [component, setComponent],
+    [component, setComponent, handleSetType],
   );
 
   useReEarthEvent("sketchfeaturecreated", handleSketchFeatureCreated);


### PR DESCRIPTION
## Overview

This PR adds the logic to reset sketch tool after draw clipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sketch feature creation process by resetting type after feature is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->