### PR TITLE
ci: remove GCS upload job and unnecessary `gcloud` setup

### DIFF
--- a/.github/workflows/deploy-cms-dev.yml
+++ b/.github/workflows/deploy-cms-dev.yml
@@ -27,10 +27,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -53,11 +51,9 @@ jobs:
         run: |
           gcloud run deploy reearth-cms-web \
             --image $CMS_WEB_IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
 
   deploy_server_worker:
     runs-on: ubuntu-latest
@@ -70,10 +66,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -100,13 +94,12 @@ jobs:
         run: |
           gcloud run deploy reearth-cms-api \
             --image $CMS_IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
           gcloud run deploy reearth-cms-worker \
             --image $CMS_WORKER_IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
+

--- a/.github/workflows/deploy-cms-prod.yml
+++ b/.github/workflows/deploy-cms-prod.yml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -54,11 +54,9 @@ jobs:
         run: |
           gcloud run deploy reearth-cms-web \
             --image $CMS_WEB_IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
 
   deploy_server:
     runs-on: ubuntu-latest
@@ -71,10 +69,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -100,11 +96,10 @@ jobs:
             --quiet
           gcloud run deploy reearth-cms-worker \
             --image $WORKER_IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
+  
   push_hub:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-extension-dev.yml
+++ b/.github/workflows/deploy-extension-dev.yml
@@ -27,10 +27,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/deploy-extension-prod.yml
+++ b/.github/workflows/deploy-extension-prod.yml
@@ -24,10 +24,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/deploy-geo-dev.yml
+++ b/.github/workflows/deploy-geo-dev.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -51,8 +51,6 @@ jobs:
         run: |
           gcloud run deploy plateauview-geo \
             --image $IMAGE_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}

--- a/.github/workflows/deploy-geo-prod.yml
+++ b/.github/workflows/deploy-geo-prod.yml
@@ -18,10 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -40,11 +38,10 @@ jobs:
         run: |
           gcloud run deploy plateauview-geo \
             --image $IMAGE_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
+
   push_hub:
     runs-on: ubuntu-latest
     environment: prod

--- a/.github/workflows/deploy-reearth-classic-dev.yml
+++ b/.github/workflows/deploy-reearth-classic-dev.yml
@@ -18,59 +18,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 jobs:
-  # TODO: Remove after Cloud Run migration
-  deploy_web_gcs:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      # TODO: allow to specify which version to release
-      - name: Download reearth-web
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: reearth/reearth
-          version: tags/rc
-          file: reearth-web_rc.tar.gz
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract
-        run: mv reearth-web{_rc,}.tar.gz && tar -xvf reearth-web.tar.gz
-      - name: Replace favicon / App name
-        env:
-          PLATEAU_FAVICON: https://www.mlit.go.jp/plateau/assets/img/icons/favicon.svg
-          APP_PATH: reearth-web/index.html
-          PUBLISH_PATH: reearth-web/published.html
-          APP_NAME: PLATEAU VIEW(Ver2.0)
-        run: |
-          SOURCE=$(cat $APP_PATH)
-          SOURCE=${SOURCE/\/static\/favicon*.ico/$PLATEAU_FAVICON}
-          SOURCE=${SOURCE/\<title\>*\<\/title\>/<title>$APP_NAME</title>}
-          echo $SOURCE > $APP_PATH
-
-          SOURCE=$(cat $PUBLISH_PATH)
-          SOURCE=${SOURCE/\/static\/favicon*.ico/$PLATEAU_FAVICON}
-          SOURCE=${SOURCE/\<title\>*\<\/title\>/<title>$APP_NAME</title>}
-          echo $SOURCE > $PUBLISH_PATH
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^cloud/.*$|^reearth_config\\.json$|^extension/.*$" -dr reearth-web/ ${{ env.GCS_DEST }}
-      - name: Pack web
-        run: |
-          rm reearth-web.tar.gz
-          tar -zcvf reearth-web.tar.gz reearth-web
-      - name: Save as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: reearth-web
-          path: reearth-web.tar.gz
-
   deploy_server:
     runs-on: ubuntu-latest
     environment: dev

--- a/.github/workflows/deploy-reearth-classic-prod.yml
+++ b/.github/workflows/deploy-reearth-classic-prod.yml
@@ -7,9 +7,6 @@ on:
         description: Deploy the specific version of web to specify the run ID. If specified, deployment of the server will be skipped. (Optional)
         required: false
 env:
-  # TODO: Remove after Cloud Run migration
-  GCS_DEST: gs://plateau-prod-reearth-app-bucket
-
   IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth:latest
   IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth:latest
   IMAGE_NAME_HUB: eukarya/plateauview2-reearth:latest
@@ -19,41 +16,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 jobs:
-  # TODO: Remove after Cloud Run migration
-  deploy_web_gcs:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
-    environment: prod
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow: deploy-reearth-dev.yml
-          branch: ${{ !github.event.inputs.web_run_id && 'main' || '' }}
-          name: reearth-web
-          check_artifacts: true
-          search_artifacts: true
-          run_id: ${{ github.event.inputs.web_run_id }}
-      - name: Extract
-        run: tar -xvf reearth-web.tar.gz
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^cloud/.*$|^reearth_config\\.json$|^extension/.*$" -dr reearth-web/ ${{ env.GCS_DEST }}
-      # TODO: purge CDN cache
   deploy_server:
     runs-on: ubuntu-latest
     environment: prod

--- a/.github/workflows/deploy-reearth-flow-dev.yml
+++ b/.github/workflows/deploy-reearth-flow-dev.yml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -66,8 +66,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -100,8 +100,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -134,8 +134,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-reearth-flow-prod.yml
+++ b/.github/workflows/deploy-reearth-flow-prod.yml
@@ -40,10 +40,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -60,11 +58,9 @@ jobs:
         run: |
           gcloud run deploy reearth-flow-api \
             --image $IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
 
   deploy_web:
     runs-on: ubuntu-latest
@@ -76,8 +72,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -110,8 +106,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -142,8 +138,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-reearth-visualizer-dev.yml
+++ b/.github/workflows/deploy-reearth-visualizer-dev.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -57,8 +57,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-reearth-visualizer-prod.yml
+++ b/.github/workflows/deploy-reearth-visualizer-prod.yml
@@ -7,9 +7,6 @@ on:
         description: Deploy the specific version of web to specify the run ID. If specified, deployment of the server will be skipped. (Optional)
         required: false
 env:
-  # TODO: Remove after migrating to Cloud Run
-  GCS_DEST: gs://plateau-prod-reearth-visualizer-static-bucket
-
   IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-visualizer-api:latest
   IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-visualizer-api:latest
   IMAGE_NAME_HUB: eukarya/plateauview2-reearth-visualizer-api:latest
@@ -20,41 +17,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 jobs:
-  # TODO: Remove after migrating to Cloud Run
-  deploy_web_gcs:
-    runs-on: ubuntu-latest
-    if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW-3.0'
-    environment: prod
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow: deploy-reearth-visualizer-dev.yml
-          branch: ${{ !github.event.inputs.web_run_id && 'main' || '' }}
-          name: reearth-visualizer-web
-          check_artifacts: true
-          search_artifacts: true
-          run_id: ${{ github.event.inputs.web_run_id }}
-      - name: Extract
-        run: tar -xvf reearth-visualizer-web.tar.gz
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^cloud/.*$|^reearth_config\\.json$|^extension/.*$" -dr reearth-web/ ${{ env.GCS_DEST }}
-      # TODO: purge CDN cache
   deploy_server:
     runs-on: ubuntu-latest
     environment: prod
@@ -66,10 +28,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry
@@ -86,11 +46,9 @@ jobs:
         run: |
           gcloud run deploy reearth-visualizer-api \
             --image $IMAGE_NAME_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
 
   deploy_web:
     runs-on: ubuntu-latest
@@ -102,8 +60,8 @@ jobs:
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-server-dev.yml
+++ b/.github/workflows/deploy-server-dev.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -51,8 +51,6 @@ jobs:
         run: |
           gcloud run deploy plateauview-api \
             --image $IMAGE_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}

--- a/.github/workflows/deploy-server-prod.yml
+++ b/.github/workflows/deploy-server-prod.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -40,11 +40,9 @@ jobs:
         run: |
           gcloud run deploy plateauview-api \
             --image $IMAGE_GCP \
-            --region $GCP_REGION \
+            --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
 
   push_hub:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-tiles-dev.yml
+++ b/.github/workflows/deploy-tiles-dev.yml
@@ -19,10 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-tiles-prod.yml
+++ b/.github/workflows/deploy-tiles-prod.yml
@@ -15,13 +15,11 @@ jobs:
       id-token: write
       packages: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-worker-dev.yml
+++ b/.github/workflows/deploy-worker-dev.yml
@@ -21,10 +21,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-worker-prod.yml
+++ b/.github/workflows/deploy-worker-prod.yml
@@ -21,10 +21,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
# Why

Already migrated to Cloud Run and we don't need to run `setup-gcloud`, the `auth` action will do it for us.