### PR TITLE
ci: remove unnecessary `setup-gcloud`

### DIFF
--- a/.github/workflows/deploy-cms-prod.yml
+++ b/.github/workflows/deploy-cms-prod.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-geo-dev.yml
+++ b/.github/workflows/deploy-geo-dev.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-server-dev.yml
+++ b/.github/workflows/deploy-server-dev.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/deploy-server-prod.yml
+++ b/.github/workflows/deploy-server-prod.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
## Why

`google-github-actions/auth@v2` can do it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
	- Removed Google Cloud SDK setup step from multiple deployment workflows
	- Affects deployment processes for CMS, Geo, and Server environments (dev and prod)
	- No changes to core deployment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->