### PR TITLE
ci(geo/dev): move deploy-geo-dev environment variable to repository

### DIFF
--- a/.github/workflows/deploy-geo-dev.yml
+++ b/.github/workflows/deploy-geo-dev.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [deploy-geo-dev]
-env:
-  IMAGE: ghcr.io/eukarya-inc/plateau-view-3.0/plateauview-geo:latest
-  IMAGE_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau-dev/reearth-plateau/plateauview-geo:latest
 jobs:
   deploy_geo:
     runs-on: ubuntu-latest
@@ -42,13 +39,13 @@ jobs:
         run: docker load < plateauview-geo.tar.gz
       - name: docker push
         run: |
-          docker tag $IMAGE $IMAGE_GCP && \
-          docker push $IMAGE &&
-          docker push $IMAGE_GCP
+          docker tag ${{ vars.GEO_IMAGE }} ${{ vars.GEO_IMAGE_GCP }} && \
+          docker push ${{ vars.GEO_IMAGE }} &&
+          docker push ${{ vars.GEO_IMAGE_GCP }}
       - name: Deploy geo to Cloud Run
         run: |
           gcloud run deploy plateauview-geo \
-            --image $IMAGE_GCP \
+            --image ${{ vars.GEO_IMAGE_GCP }} \
             --region ${{ vars.GCP_REGION }} \
             --platform managed \
             --quiet


### PR DESCRIPTION
Also create two new environment variable in the repository level, GEO_IMAGE and GEO_IMAGE_GCP so that we could delete the environment variable in deploy-geo-dev.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment process to use centralized configuration for image references, enhancing flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->