### PR TITLE
ci: deploy dev GAR image to prod for Visualizer web

### DIFF
--- a/.github/workflows/deploy-reearth-visualizer-prod.yml
+++ b/.github/workflows/deploy-reearth-visualizer-prod.yml
@@ -11,7 +11,6 @@ env:
   IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-visualizer-api:latest
   IMAGE_NAME_HUB: eukarya/plateauview2-reearth-visualizer-api:latest
 
-  WEB_IMAGE_NAME: reearth/reearth-visualizer-web:nightly
   WEB_IMAGE_NAME_GHCR: ghcr.io/eukarya-inc/plateau-view-3.0/reearth-visualizer-web:latest
   WEB_IMAGE_NAME_GCP: asia-northeast1-docker.pkg.dev/reearth-plateau/reearth-plateau/reearth-visualizer-web:latest
 concurrency:
@@ -71,11 +70,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull docker images
-        run: docker pull $WEB_IMAGE_NAME
-      - name: Tag docker images
-        run: docker tag $WEB_IMAGE_NAME $WEB_IMAGE_NAME_GHCR && docker tag $WEB_IMAGE_NAME $WEB_IMAGE_NAME_GCP
-      - name: Push docker images
-        run: docker push $WEB_IMAGE_NAME_GHCR && docker push $WEB_IMAGE_NAME_GCP
+        run: docker pull $WEB_IMAGE_NAME_GHCR
+      - name: Push docker image
+        run: docker tag $WEB_IMAGE_NAME_GHCR $WEB_IMAGE_NAME_GCP && docker push $WEB_IMAGE_NAME_GCP
       - name: Deploy
         run: |
           gcloud run deploy reearth-visualizer-web \


### PR DESCRIPTION
# Why

This was a copy-and-paste issue... 
Like other workflows, the images that were deployed and tested on the development environment should be deployed to production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized the deployment workflow by consolidating image management steps.
	- Now using the latest web image for deployments, simplifying the overall process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->