### PR TITLE
fix: cache bytes for general layer

### DIFF
--- a/extension/src/shared/reearth/layers/general.ts
+++ b/extension/src/shared/reearth/layers/general.ts
@@ -89,6 +89,7 @@ export const GeneralLayer: FC<GeneralProps> = ({
       },
       "3dtiles": {
         selectedFeatureColor,
+        cacheBytes: Infinity,
         ...(appearances?.["3dtiles"] ?? {}),
       },
     }),


### PR DESCRIPTION
Cesium has changed 3D tiles behavior before. They added `cacheBytes` property to restrict cached features. I've specified `Infinity` to `BuildingLayer`, but I forgot to add it to `GeneralLayer` 's 3D tiles. Therefore use-case data weren't loaded completely.
I've fixed it in this PR.

|Before|After|
|:--:|:--:|
|![Screenshot 2025-02-12 at 10 12 01](https://github.com/user-attachments/assets/937ffa14-e156-4f7d-8d59-6412a01c3e2a)|![Screenshot 2025-02-12 at 10 11 09](https://github.com/user-attachments/assets/997baac6-5e89-4209-8771-2a5b908a073f)|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced caching for 3D tile layers: We have upgraded the caching mechanism in 3D tile visualizations to allow for unlimited retention of appearance settings. This update improves visual consistency and ensures that 3D content renders more smoothly, offering a more stable and reliable viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->