### PR TITLE
fix: property value translation logic

### DIFF
--- a/extension/src/prototypes/ui-components/PropertyParameterItem.tsx
+++ b/extension/src/prototypes/ui-components/PropertyParameterItem.tsx
@@ -232,26 +232,24 @@ const Property: FC<{
   ].join("_")}`;
   const attrVal = isPrimitive ? getPropertyAttributeValue(actualName, version) : undefined;
 
+  const displayedValues = useMemo(
+    () =>
+      isPrimitive
+        ? values.map(v => (attrVal ? makePropertyValue(attrVal, v as string | number) : v))
+        : null,
+    [values, attrVal, isPrimitive],
+  );
+
   return isPrimitive ? (
     <TableRow style={{ wordBreak: "break-all" }}>
       <PropertyNameCell variant="head" width="50%" level={level}>
         {makePropertyName(actualName, name, version, attrVal)}
       </PropertyNameCell>
       <TableCell width="50%">
-        {typeof values[0] === "string" ? (
-          <StringValue
-            name={name}
-            values={(values as string[]).map(v =>
-              attrVal ? (makePropertyValue(attrVal, v) as string) : v,
-            )}
-          />
-        ) : typeof values[0] === "number" ? (
-          <NumberValue
-            name={name}
-            values={(values as number[]).map(v =>
-              attrVal ? (makePropertyValue(attrVal, v) as number) : v,
-            )}
-          />
+        {typeof displayedValues?.[0] === "string" ? (
+          <StringValue name={name} values={displayedValues as string[]} />
+        ) : typeof displayedValues?.[0] === "number" ? (
+          <NumberValue name={name} values={displayedValues as number[]} />
         ) : null}
       </TableCell>
     </TableRow>


### PR DESCRIPTION
`建築年` was `NaN` when you click a feature on `交通（道路）モデル（志木市）`. It was due to that I translated the unknown value after checking if it's type is number or string. If it's number and it's the unknown value, then it's translated to string, but it's shown as number, so the displayed value was `NaN`.

|Before|After|
|:--:|:--:|
|<img width="930" alt="Screenshot 2025-02-13 at 13 27 38" src="https://github.com/user-attachments/assets/db5485ff-6c73-4b4c-bab6-9f2820e1ad15" />|<img width="930" alt="Screenshot 2025-02-13 at 12 13 56" src="https://github.com/user-attachments/assets/faec493f-5f15-49be-aadc-f193754c9268" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how property values are processed for display, ensuring that both text and numeric information are consistently formatted.
  - Users will now experience a cleaner and more reliable presentation of property details within the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->