### PR TITLE
fix: kml polyline issue

### DIFF
--- a/extension/src/shared/layerContainers/myData.tsx
+++ b/extension/src/shared/layerContainers/myData.tsx
@@ -95,6 +95,18 @@ export const MyDataLayerContainer: FC<MyDataContainerProps> = ({
 
   const theme = useTheme();
 
+  const defaultAppearance = useMemo(
+    () => ({
+      ...DEFAULT_MYDATA_APPEARANCES,
+      polyline: {
+        ...DEFAULT_MYDATA_APPEARANCES.polyline,
+        // KML with clampToGround causes an error, so disable it: https://github.com/CesiumGS/cesium/issues/9555
+        clampToGround: format === "kml" ? false : true,
+      },
+    }),
+    [format],
+  );
+
   if (format === "gtfs") {
     return (
       <GTFSLayer
@@ -136,7 +148,7 @@ export const MyDataLayerContainer: FC<MyDataContainerProps> = ({
       onLoad={handleLoad}
       visible={!hidden}
       selectedFeatureColor={theme.palette.primary.main}
-      appearances={DEFAULT_MYDATA_APPEARANCES}
+      appearances={defaultAppearance}
     />
   );
 };


### PR DESCRIPTION
When you set the below KML data to MyData, then it throws an error.
KML: https://assets.cms.plateau.reearth.io/assets/c9/b374d5-e288-44bd-9228-ab4210e6fa90/%E6%BC%81%E6%A5%AD%E6%A8%A9.KML
![image (2)](https://github.com/user-attachments/assets/77103c2a-246c-4ca7-80c5-29276d4af9f2)


It seems the cause is [this issue](https://github.com/CesiumGS/cesium/issues/9555), so I've fixed to avoid using clampToGround in KML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced map layer visuals by dynamically adjusting appearance settings based on the data format, ensuring optimal rendering depending on the input type. This improvement delivers a more consistent and refined visual experience for different formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->