### PR TITLE
fix(extension): flyto tile height

### DIFF
--- a/extension/src/shared/reearth/utils/camera.ts
+++ b/extension/src/shared/reearth/utils/camera.ts
@@ -73,5 +73,4 @@ export const lookAtTileFeature = (properties: Record<string, any> | undefined) =
       { duration: 2 },
     );
   });
-  window.reearth?.camera?.flyTo({ lng: x, lat: y, height: 500 });
 };


### PR DESCRIPTION
When you search buildings and fly to a searched building, the camera is moved to underground. I've fixed this issue.

**Before**

https://github.com/user-attachments/assets/e3452c0e-cc1f-4419-922a-9a755f551572

**After**

https://github.com/user-attachments/assets/b9b8fa79-c731-44c4-8388-afc7dfa9f692



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the camera behavior so that when focusing on a feature, the view no longer automatically transitions to a fixed preset position. Now, the camera retains its current perspective, offering a more stable experience and enhanced control over navigation. This refinement ensures a consistent viewing experience and empowers users to adjust the view manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->