### PR TITLE
ci(editor): disable cache for core build)

### DIFF
--- a/.github/workflows/build-editor.yml
+++ b/.github/workflows/build-editor.yml
@@ -46,17 +46,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.9.1 --activate
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "path=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.path }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Run install
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable --immutable-cache
       - name: Run build
         run: yarn build
       - name: Push build results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to use Yarn's immutable install mode with cache validation.
  - Removed explicit caching of Yarn's cache directory in the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->