### PR TITLE
feat(extension): support custom terrain layer.json URL on toolbar widget

### DIFF
--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -162,6 +162,20 @@ const yml = {
                 type: "camera",
                 title: "歩行者視点",
               },
+              {
+                id: "terrainUrl",
+                type: "string",
+                title: "地形 layer.json URL",
+                description:
+                  "Cesium ion の代わりに任意の quantized-mesh 地形 (layer.json) を読み込みます。CORS 許可が必要です。",
+              },
+              {
+                id: "terrainNormal",
+                type: "bool",
+                title: "地形の法線を有効化",
+                description:
+                  "地形の陰影表現に必要な法線データを要求します（デフォルト有効）。法線非対応の地形を読み込む場合は無効にしてください。",
+              },
             ],
           },
         ],

--- a/extension/src/shared/context/WidgetContext.tsx
+++ b/extension/src/shared/context/WidgetContext.tsx
@@ -36,6 +36,8 @@ import {
   useFinishTime,
   useDatasetAttributesURL,
   useCityGMLApiUrl,
+  useTerrainUrl,
+  useTerrainNormal,
 } from "../states/environmentVariables";
 
 type Props = {
@@ -63,6 +65,8 @@ type Props = {
   customMenuLogo?: string;
   customPedestrian?: CameraPosition;
   customSiteUrl?: string;
+  terrainUrl?: string;
+  terrainNormal?: boolean;
   // Notification setting
   isEnable?: boolean;
   content?: string;
@@ -93,6 +97,8 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   customMenuLogo,
   customPedestrian,
   customSiteUrl,
+  terrainUrl,
+  terrainNormal,
   geojsonURL,
   isEnable,
   content,
@@ -211,6 +217,20 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
       setPlateauGeojsonUrlState(geojsonURL);
     }
   }, [geojsonURL, geojsonURLState, setPlateauGeojsonUrlState]);
+
+  const [terrainUrlState, setTerrainUrlState] = useTerrainUrl();
+  useEffect(() => {
+    if (terrainUrl !== terrainUrlState) {
+      setTerrainUrlState(terrainUrl);
+    }
+  }, [terrainUrl, terrainUrlState, setTerrainUrlState]);
+
+  const [terrainNormalState, setTerrainNormalState] = useTerrainNormal();
+  useEffect(() => {
+    if (terrainNormal !== terrainNormalState) {
+      setTerrainNormalState(terrainNormal);
+    }
+  }, [terrainNormal, terrainNormalState, setTerrainNormalState]);
 
   const [datasetAttributesURLState, setDatasetAttributesURLState] = useDatasetAttributesURL();
   useEffect(() => {

--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useEffect } from "react";
 
+import { useTerrainNormal, useTerrainUrl } from "../../states/environmentVariables";
 import { AmbientOcclusion, Antialias, CameraPosition, Tile, TileLabels } from "../types";
 import { isReEarthAPIv2 } from "../utils/reearth";
 
@@ -105,6 +106,8 @@ export const Scene: FC<SceneProps> = ({
   antialias,
   initialCamera,
 }) => {
+  const [terrainUrl] = useTerrainUrl();
+  const [terrainNormal] = useTerrainNormal();
   useEffect(() => {
     if (isReEarthAPIv2(window?.reearth)) {
       window.reearth?.viewer?.overrideProperty?.({
@@ -179,8 +182,9 @@ export const Scene: FC<SceneProps> = ({
         tileLabels,
         terrain: {
           enabled: true,
-          type: "cesiumion",
-          normal: true,
+          type: terrainUrl ? "cesium" : "cesiumion",
+          ...(terrainUrl ? { url: terrainUrl } : {}),
+          normal: terrainNormal ?? true,
           ...(terrainHeatmap
             ? {
                 elevationHeatMap: {
@@ -204,11 +208,13 @@ export const Scene: FC<SceneProps> = ({
         },
         assets: {
           cesium: {
-            terrain: {
-              ionAccessToken:
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
-              ionAsset: "4195264",
-            },
+            terrain: terrainUrl
+              ? {}
+              : {
+                  ionAccessToken:
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
+                  ionAsset: "4195264",
+                },
           },
         },
       });
@@ -269,12 +275,16 @@ export const Scene: FC<SceneProps> = ({
         tileLabels,
         terrain: {
           terrain: true,
-          terrainType: "cesiumion",
+          terrainType: terrainUrl ? "cesium" : "cesiumion",
           depthTestAgainstTerrain: hideUnderground,
-          terrainCesiumIonAccessToken:
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
-          terrainCesiumIonAsset: "4195264",
-          terrainNormal: true,
+          ...(terrainUrl
+            ? { terrainUrl }
+            : {
+                terrainCesiumIonAccessToken:
+                  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
+                terrainCesiumIonAsset: "4195264",
+              }),
+          terrainNormal: terrainNormal ?? true,
           ...(terrainHeatmap
             ? {
                 heatmapType: "custom",
@@ -325,6 +335,8 @@ export const Scene: FC<SceneProps> = ({
     initialCamera,
     enterUnderground,
     hideUnderground,
+    terrainUrl,
+    terrainNormal,
   ]);
 
   useEffect(() => {

--- a/extension/src/shared/states/environmentVariables.ts
+++ b/extension/src/shared/states/environmentVariables.ts
@@ -56,6 +56,12 @@ export const usePlateauGeojsonUrl = () => useAtom(plateauGeojsonUrl);
 const datasetAttributesURL = atom<string | undefined>(undefined);
 export const useDatasetAttributesURL = () => useAtom(datasetAttributesURL);
 
+const terrainUrl = atom<string | undefined>(undefined);
+export const useTerrainUrl = () => useAtom(terrainUrl);
+
+const terrainNormal = atom<boolean | undefined>(undefined);
+export const useTerrainNormal = () => useAtom(terrainNormal);
+
 // notification setting
 export const isEnableAtom = atom(false);
 export const useIsEnable = () => useAtom(isEnableAtom);

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -64,6 +64,8 @@ type OptionalProps = {
   menuLogo?: string;
   pedestrian?: CameraPosition;
   siteUrl?: string;
+  terrainUrl?: string;
+  terrainNormal?: boolean;
 };
 
 type Props = WidgetProps<DefaultProps, OptionalProps>;
@@ -106,7 +108,9 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
         customMainLogo={widget.property.optional?.mainLogo}
         customMenuLogo={widget.property.optional?.menuLogo}
         customPedestrian={widget.property.optional?.pedestrian}
-        customSiteUrl={widget.property.optional?.siteUrl}>
+        customSiteUrl={widget.property.optional?.siteUrl}
+        terrainUrl={widget.property.optional?.terrainUrl}
+        terrainNormal={widget.property.optional?.terrainNormal}>
         <InitializeApp />
         <AppFrame header={<AppHeader arURL={widget.property.default.arURL} />} />
         {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}


### PR DESCRIPTION
## Summary
- Toolbar widget の optional プロパティに `terrainUrl` / `terrainNormal` を追加し、Cesium ion の代わりに任意の quantized-mesh `layer.json` URL から地形を読み込めるようにする。
- `terrainUrl` 未設定時は従来通り Cesium ion 地形（既存トークン・アセット）にフォールバック。
- reearth v1 / v2 両方の API パスで分岐対応（v2: `terrain.type="cesium"` + `url`、v1: `terrainType="cesium"` + `terrainUrl`）。

## Implementation
- `shared/states/environmentVariables.ts`: `useTerrainUrl` / `useTerrainNormal` atom を追加
- `toolbar/Widget.tsx`: `OptionalProps` に `terrainUrl` / `terrainNormal` を追加し WidgetContext へ伝搬
- `shared/context/WidgetContext.tsx`: props を受け取り atom にミラーリング
- `shared/reearth/scene/Scene.tsx`: atom を読み terrain ブロックを分岐、`assets.cesium.terrain` の ion 認証情報も terrainUrl 設定時は外す

## Test plan
- [ ] `terrainUrl` 未設定で従来通り Cesium ion 地形が表示されること
- [ ] `terrainUrl` に有効な `layer.json` URL を設定して地形が差し替わること
- [ ] `terrainNormal: false` 設定時に法線無し地形でもエラーなく描画されること
- [ ] terrain heatmap オプションが従来通り動作すること

## Notes
- 任意 URL の `layer.json` および各 `.terrain` タイルは CORS 許可が必須。
- 法線非対応の `layer.json` を読み込む場合は `terrainNormal: false` を指定する必要あり。