### PR TITLE
fix(terraform): close unclosed dynamic env block in plateauview_api

### DIFF
--- a/terraform/gcp/modules/plateauview_api/google_cloud_run_v2_service.tf
+++ b/terraform/gcp/modules/plateauview_api/google_cloud_run_v2_service.tf
@@ -83,7 +83,8 @@ resource "google_cloud_run_v2_service" "plateauview_api" {
         for_each = var.plateauview.datacatalog_cache_size != "" ? [""] : []
         content {
           name  = "REEARTH_PLATEAUVIEW_DATACATALOG_CACHESIZE"
-        value = var.plateauview.datacatalog_cache_size
+          value = var.plateauview.datacatalog_cache_size
+        }
       }
 
       env {


### PR DESCRIPTION
## Summary

The `plateauview_api` Terraform module failed `terraform validate` with an `Unclosed configuration block` error. The `REEARTH_PLATEAUVIEW_DATACATALOG_CACHESIZE` `dynamic "env"` block had mismatched braces — the `content` block was missing its closing brace and the `value` line was mis-indented — leaving the entire `google_cloud_run_v2_service` resource unclosed.

This fixes the brace nesting and indentation to match the adjacent `CACHEGCPARCENT` block.

## Notes
- This module under `terraform/gcp` is the OSS reference configuration and is **not** the source of truth for the live `plateauview-api` Cloud Run service (its env vars are managed out-of-band). This is a surface-level syntax fix only — no attempt was made to reconcile the module with live infrastructure.

## Test
- `terraform fmt -check` passes (exit 0); the previous parse error is resolved.