### PR TITLE
fix(server): make spec search index init retryable

### DIFF
--- a/server/mcp/plateauspecmcp/search.go
+++ b/server/mcp/plateauspecmcp/search.go
@@ -5,32 +5,65 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/eukarya-inc/plateau-spec/plateaudocsearch"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// searchInitTimeout bounds a single attempt to download and open the search
+// index. It is deliberately independent of any caller's request context so a
+// client disconnect cannot abort — and permanently break — initialization.
+const searchInitTimeout = 6 * time.Minute
+
 var (
-	searchClient     *plateaudocsearch.Client
-	searchClientOnce sync.Once
-	searchClientErr  error
+	searchMu     sync.Mutex
+	searchClient *plateaudocsearch.Client // non-nil only after a successful Init
 )
 
-// getSearchClient returns the singleton search client, initializing it if necessary.
-// The search client downloads the search index on first use.
+// getSearchClient returns the singleton search client, initializing it on first
+// use. The search client downloads the search index on first use, which can take
+// several seconds.
+//
+// Initialization is retryable: unlike a sync.Once, a failed attempt (transient
+// network error, a 5xx from the index host, a cancelled download, etc.) is NOT
+// cached, so the next call tries again instead of failing forever. The download
+// also runs on a context detached from the caller, so a single client that
+// disconnects mid-download cannot abort initialization for everyone else.
 func getSearchClient(ctx context.Context) (*plateaudocsearch.Client, error) {
-	searchClientOnce.Do(func() {
-		searchClient = plateaudocsearch.New()
-		_, searchClientErr = searchClient.Init(ctx)
-		if searchClientErr != nil {
-			searchClient = nil
-		}
-	})
+	searchMu.Lock()
+	defer searchMu.Unlock()
 
-	if searchClientErr != nil {
-		return nil, searchClientErr
+	if searchClient != nil {
+		return searchClient, nil
 	}
+
+	c := plateaudocsearch.New()
+
+	// Detach from the caller's context: downloading the index is a shared,
+	// one-time cost, so a single request's cancellation (client disconnect or a
+	// per-request timeout) must not cancel it for every other caller. Bound it
+	// with our own timeout instead.
+	initCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), searchInitTimeout)
+	defer cancel()
+
+	if _, err := c.Init(initCtx); err != nil {
+		// Do not cache the failure: the next call retries from scratch.
+		return nil, err
+	}
+
+	searchClient = c
 	return searchClient, nil
+}
+
+// Prewarm eagerly initializes the search client so the first real request does
+// not pay the index-download cost and a transient startup failure does not
+// surface to that first user. It is safe to call from a background goroutine and
+// to call more than once; initialization is serialized and retried by
+// getSearchClient.
+func Prewarm(ctx context.Context) error {
+	_, err := getSearchClient(ctx)
+	return err
 }
 
 // searchClientFactory allows overriding getSearchClient for testing

--- a/server/service.go
+++ b/server/service.go
@@ -290,6 +290,18 @@ func Spec(conf *Config) (*Service, error) {
 			sg := g.Group("/spec")
 			sg.Use(middleware.CORS(), middleware.Gzip())
 			plateauspecmcp.RegisterEcho(sg)
+
+			// Eagerly warm the search index in the background so the first
+			// request doesn't pay the multi-second download cost and a
+			// transient startup failure doesn't surface to that first user.
+			// Initialization is retryable, so a failure here is recovered on
+			// the next request.
+			go func() {
+				if err := plateauspecmcp.Prewarm(context.Background()); err != nil {
+					log.Errorf("spec: failed to prewarm search index: %v", err)
+				}
+			}()
+
 			return nil
 		},
 	}, nil


### PR DESCRIPTION
## 問題

`getSearchClient` (`server/mcp/plateauspecmcp/search.go`) が `sync.Once` を使って初回の `Init` エラーを永遠にキャッシュしていた。

新設の認証不要な Spec サービス (`/spec/search`) により匿名クライアントが初回 `Init` をキャンセル可能なコンテキストで駆動できるため、

- デプロイ直後の最初の `/spec/search` がリクエストのコンテキスト下で数秒のインデックスダウンロードを実行
- 途中でクライアント切断 / インデックスホストの一時的な 503 → `Init` が失敗
- `searchClientErr` がキャッシュされ `sync.Once` は二度と再実行されない

結果、以降すべての `/spec/search` が 500 を返し、同じシングルトンを使う `plateau_spec_search` MCP ツールも壊れ、**プロセス再起動までスペック全文検索が全ユーザーに対して永久に壊れる**。

## 修正

- `sync.Once` + キャッシュされるエラーを、**失敗をキャッシュしない** mutex ガードの初期化に置き換え。失敗時は次のリクエストでリトライする。
- インデックスダウンロードを呼び出し元のコンテキストから切り離し (`context.WithoutCancel` + 6 分タイムアウト)、1 クライアントの切断が全員の初期化を中断しないように。
- `Prewarm()` を追加し、`/spec` サービス登録時にバックグラウンドで先行初期化。最初のリクエストがダウンロードコストを払わず、起動時の一時的失敗も次のリクエストで回復する。

## テスト

- `go build ./...` ✅
- `go test ./mcp/plateauspecmcp/` ✅
- `golangci-lint run ./mcp/plateauspecmcp/` → 0 issues ✅