### PR TITLE
ci(flow): publish/promote plateau5 actions schema to plateau buckets

### DIFF
--- a/.github/workflows/deploy-flow-dev.yml
+++ b/.github/workflows/deploy-flow-dev.yml
@@ -287,6 +287,25 @@ jobs:
           cache-from: type=gha,scope=flow-worker
           cache-to: type=gha,mode=max,scope=flow-worker
 
+  upload_actions_schema:
+    runs-on: ubuntu-latest
+    environment: dev
+    if: ${{ inputs.only_policies != 'true' && github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: ${{ env.FLOW_REPO }}
+          ref: ${{ env.FLOW_BRANCH }}
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Upload actions schema to GCS
+        run: gsutil -m cp engine/schema/actions*.json gs://${{ vars.REEARTH_FLOW_GCS_BUCKET_NAME }}/actions/
+
   update-policies:
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW'

--- a/.github/workflows/deploy-flow-dev.yml
+++ b/.github/workflows/deploy-flow-dev.yml
@@ -288,6 +288,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=flow-worker
 
   upload_actions_schema:
+    needs: [deploy_api, deploy_worker]
     runs-on: ubuntu-latest
     environment: dev
     if: ${{ inputs.only_policies != 'true' && github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW' }}
@@ -303,6 +304,7 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Upload actions schema to GCS
         run: gsutil -m cp engine/schema/actions*.json gs://${{ vars.REEARTH_FLOW_GCS_BUCKET_NAME }}/actions/
 

--- a/.github/workflows/deploy-flow-prod.yml
+++ b/.github/workflows/deploy-flow-prod.yml
@@ -201,6 +201,21 @@ jobs:
       - name: Tag and push docker image
         run: docker tag $WORKER_IMAGE_NAME_GHCR $WORKER_IMAGE_NAME_GCP && docker push $WORKER_IMAGE_NAME_GCP
 
+  upload_actions_schema:
+    runs-on: ubuntu-latest
+    environment: prod
+    if: ${{ inputs.only_policies != 'true' && github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Promote actions schema from plateau-dev bucket
+        run: gsutil -m cp "gs://${{ vars.UPSTREAM_BUCKET }}/actions/actions*.json" "gs://${{ vars.REEARTH_FLOW_GCS_BUCKET_NAME }}/actions/"
+
   update-policies:
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW'

--- a/.github/workflows/deploy-flow-prod.yml
+++ b/.github/workflows/deploy-flow-prod.yml
@@ -202,9 +202,10 @@ jobs:
         run: docker tag $WORKER_IMAGE_NAME_GHCR $WORKER_IMAGE_NAME_GCP && docker push $WORKER_IMAGE_NAME_GCP
 
   upload_actions_schema:
+    needs: [deploy_api, deploy_worker]
     runs-on: ubuntu-latest
     environment: prod
-    if: ${{ inputs.only_policies != 'true' && github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW' }}
+    if: ${{ !inputs.web_run_id && inputs.only_policies != 'true' && github.event.repository.full_name == 'eukarya-inc/PLATEAU-VIEW' }}
     permissions:
       contents: read
       id-token: write
@@ -213,6 +214,7 @@ jobs:
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Promote actions schema from plateau-dev bucket
         run: gsutil -m cp "gs://${{ vars.UPSTREAM_BUCKET }}/actions/actions*.json" "gs://${{ vars.REEARTH_FLOW_GCS_BUCKET_NAME }}/actions/"
 


### PR DESCRIPTION
## Overview

Publish the reearth-flow **actions schema** (branch `plateau5`) to the plateau flow buckets during deploy, so the plateau API serves the actions matching its deployed engine (companion to reearth/reearth-flow#2196).

## What I've done

- **`deploy-flow-dev.yml`** → new `upload_actions_schema` job: the `plateau5` checkout is already present (it builds from source), so it `gsutil cp`s `engine/schema/actions*.json` into `plateau-dev-reearth-flow-bucket/actions/` — branch-exact.
- **`deploy-flow-prod.yml`** → new `upload_actions_schema` job: promotes the schema from the plateau-dev bucket into `plateau-reearth-flow-bucket/actions/` (prod runs plateau-dev's promoted image).

Reuses the existing workload-identity auth; reads of the public plateau-dev bucket need no extra IAM.

## Required GitHub environment variables (per env, not secrets)

- **dev**: `REEARTH_FLOW_GCS_BUCKET_NAME=plateau-dev-reearth-flow-bucket`
- **prod**: `REEARTH_FLOW_GCS_BUCKET_NAME=plateau-reearth-flow-bucket`, `UPSTREAM_BUCKET=plateau-dev-reearth-flow-bucket`

## Depends on

reearth/reearth-flow#2196 (API reads the schema from the bucket).
