### PR TITLE
fix(extension): route custom terrain URL through cesiumion ionUrl

### DIFF
--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -182,8 +182,7 @@ export const Scene: FC<SceneProps> = ({
         tileLabels,
         terrain: {
           enabled: true,
-          type: terrainUrl ? "cesium" : "cesiumion",
-          ...(terrainUrl ? { url: terrainUrl } : {}),
+          type: "cesiumion",
           normal: terrainNormal ?? true,
           ...(terrainHeatmap
             ? {
@@ -208,13 +207,12 @@ export const Scene: FC<SceneProps> = ({
         },
         assets: {
           cesium: {
-            terrain: terrainUrl
-              ? {}
-              : {
-                  ionAccessToken:
-                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
-                  ionAsset: "4195264",
-                },
+            terrain: {
+              ionAccessToken:
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
+              ionAsset: "4195264",
+              ...(terrainUrl ? { ionUrl: terrainUrl } : {}),
+            },
           },
         },
       });
@@ -275,15 +273,12 @@ export const Scene: FC<SceneProps> = ({
         tileLabels,
         terrain: {
           terrain: true,
-          terrainType: terrainUrl ? "cesium" : "cesiumion",
+          terrainType: "cesiumion",
           depthTestAgainstTerrain: hideUnderground,
-          ...(terrainUrl
-            ? { terrainUrl }
-            : {
-                terrainCesiumIonAccessToken:
-                  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
-                terrainCesiumIonAsset: "4195264",
-              }),
+          terrainCesiumIonAccessToken:
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
+          terrainCesiumIonAsset: "4195264",
+          ...(terrainUrl ? { terrainCesiumIonUrl: terrainUrl } : {}),
           terrainNormal: terrainNormal ?? true,
           ...(terrainHeatmap
             ? {


### PR DESCRIPTION
## What

Fixes the massive re-rendering in the Editor/Visualizer Cesium view when a custom terrain `layer.json` URL is set in the widget settings.

## Cause

When a terrain URL was set, the extension sent the terrain config as `type: "cesium"` + `terrain.url`. However, the core terrain factory (`editor/core/src/engines/Cesium/core/Globe.tsx`) `"cesium"` branch **never reads `url`** — it hardcodes `IonResource.fromAssetId(1)` (Cesium World Terrain). (`terrain.url` is referenced nowhere in core, and it is not even in the `terrainProvider` `useMemo` deps.)

As a result the configured URL was ignored and the Editor loaded the wrong, mis-tokened ion asset, thrashing the renderer.

The only core path that honors a raw external URL is `type: "cesiumion"` + `assets.cesium.terrain.ionUrl`, which calls `CesiumTerrainProvider.fromUrl(ionUrl)` directly — the same code path as the (working) default ion asset.

## Change (extension only)

`extension/src/shared/reearth/scene/Scene.tsx`:
- Always use `type: "cesiumion"` (v2) / `terrainType: "cesiumion"` (v1); drop the dead `terrain.url`.
- Deliver the custom URL via `assets.cesium.terrain.ionUrl` (v2) / `terrainCesiumIonUrl` (v1, mapped to `assets.cesium.terrain.ionUrl` by convert-object), keeping a truthy `ionAsset` so the core ternary gate passes.

No core changes.

## Verification

- `tsc --noEmit`: exit 0
- `eslint Scene.tsx`: exit 0