### PR TITLE
fix(extension): unbreak deploy build on modern Node

### DIFF
--- a/.github/workflows/deploy-extension-dev.yml
+++ b/.github/workflows/deploy-extension-dev.yml
@@ -27,6 +27,9 @@ jobs:
         working-directory: extension
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 18.x
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/deploy-extension-prod.yml
+++ b/.github/workflows/deploy-extension-prod.yml
@@ -24,6 +24,9 @@ jobs:
         working-directory: extension
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 18.x
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io

--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -1,9 +1,10 @@
 import { writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 
 import { stringify } from "yaml";
 
-import pkg from "./package.json" assert { type: "json" };
+const pkg = createRequire(import.meta.url)("./package.json") as { version: string };
 
 const yml = {
   id: "plateau-view-3",


### PR DESCRIPTION
## What

Fixes the extension dev/prod deploy **Build** step failing (surfaced by the dev auto-deploy after #509 merged).

Error:
```
extension/reearth-yml.ts:4
import pkg from "./package.json" assert { type: "json" };
SyntaxError: Unexpected identifier 'assert'
```

## Cause

- `reearth-yml.ts` used the now-removed import assertion syntax (`assert { type: "json" }`).
- The deploy workflows (dev/prod) had **no `setup-node` step**, so they ran `yarn build:config` on the runner's default (newer) Node where that syntax no longer exists.
- `ci-extension` passed because it pins **Node 18.x** via `setup-node` (an environment mismatch).

Unrelated to the terrain work (#509); a pre-existing toolchain/CI configuration issue.

## Change

- `extension/reearth-yml.ts`: load `package.json` via `createRequire` (Node-version agnostic; removes the `assert`/`with` syntax landmine).
- `deploy-extension-dev.yml` / `deploy-extension-prod.yml`: add `setup-node@v6 (node 18.x)` to match `ci-extension`.

## Verification

- Local Node v25.2.1: `yarn build:config` succeeds (failed before with the same syntax).
- `tsc --noEmit`: exit 0 / `eslint reearth-yml.ts`: exit 0