### PR TITLE
fix(extension): stop terrain reload loop from overrideProperty spam

### DIFF
--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -1,6 +1,6 @@
 /** Correspond to https://github.com/takram-design-engineering/plateau-view/blob/main/libs/cesium/src/Environment.tsx */
 
-import { FC, useEffect } from "react";
+import { FC, useEffect, useMemo, useRef } from "react";
 
 import { useTerrainNormal, useTerrainUrl } from "../../states/environmentVariables";
 import { AmbientOcclusion, Antialias, CameraPosition, Tile, TileLabels } from "../types";
@@ -108,7 +108,67 @@ export const Scene: FC<SceneProps> = ({
 }) => {
   const [terrainUrl] = useTerrainUrl();
   const [terrainNormal] = useTerrainNormal();
+  // CesiumTerrainProvider.fromUrl appends "/layer.json" to the given URL, so we
+  // must pass the terrain base URL (e.g. ".../terrain"), not the layer.json URL
+  // itself. Otherwise it requests ".../terrain/layer.json/layer.json" (404),
+  // which makes Cesium retry the terrain load endlessly. Strip a trailing
+  // "/layer.json" (and slashes) so either form configured in the widget works.
+  const terrainBaseUrl = useMemo(
+    () => terrainUrl?.replace(/\/+$/, "").replace(/\/layer\.json$/i, "") || undefined,
+    [terrainUrl],
+  );
+  // Some of this effect's dependencies (tiles, tileLabels, shadows, initialCamera,
+  // sphericalHarmonicCoefficients, ...) may be recreated with a new identity on every
+  // render by parents, which re-runs this effect dozens of times per second even when
+  // the actual values are unchanged. Each overrideProperty call makes Re:Earth rebuild
+  // the engine's ViewerProperty, which re-creates the terrain provider and triggers an
+  // endless terrain reload loop. Gate on a value-based signature so we only push when
+  // the resolved property actually changes.
+  const lastPropertySigRef = useRef<string | undefined>(undefined);
   useEffect(() => {
+    const propertySig = JSON.stringify([
+      isReEarthAPIv2(window?.reearth),
+      antialias,
+      ambientOcclusion,
+      atmosphereBrightnessShift,
+      atmosphereSaturationShift,
+      backgroundColor,
+      debugSphericalHarmonics,
+      enableFog,
+      enableGlobeLighting,
+      fogDensity,
+      globeImageBasedLightingFactor,
+      groundAtmosphereBrightnessShift,
+      groundAtmosphereSaturationShift,
+      imageBasedLightingIntensity,
+      lightColor,
+      lightIntensity,
+      shadowDarkness,
+      showGroundAtmosphere,
+      showSkyAtmosphere,
+      showSkyBox,
+      showSun,
+      showMoon,
+      sphericalHarmonicCoefficients,
+      tiles,
+      tileLabels,
+      shadows,
+      globeBaseColor,
+      skyAtmosphereBrightnessShift,
+      skyAtmosphereSaturationShift,
+      terrainHeatmap,
+      terrainHeatmapLogarithmic,
+      terrainHeatmapMaxHeight,
+      terrainHeatmapMinHeight,
+      initialCamera,
+      enterUnderground,
+      hideUnderground,
+      terrainBaseUrl,
+      terrainNormal,
+    ]);
+    if (propertySig === lastPropertySigRef.current) return;
+    lastPropertySigRef.current = propertySig;
+
     if (isReEarthAPIv2(window?.reearth)) {
       window.reearth?.viewer?.overrideProperty?.({
         camera: {
@@ -211,7 +271,7 @@ export const Scene: FC<SceneProps> = ({
               ionAccessToken:
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
               ionAsset: "4195264",
-              ...(terrainUrl ? { ionUrl: terrainUrl } : {}),
+              ...(terrainBaseUrl ? { ionUrl: terrainBaseUrl } : {}),
             },
           },
         },
@@ -278,7 +338,7 @@ export const Scene: FC<SceneProps> = ({
           terrainCesiumIonAccessToken:
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
           terrainCesiumIonAsset: "4195264",
-          ...(terrainUrl ? { terrainCesiumIonUrl: terrainUrl } : {}),
+          ...(terrainBaseUrl ? { terrainCesiumIonUrl: terrainBaseUrl } : {}),
           terrainNormal: terrainNormal ?? true,
           ...(terrainHeatmap
             ? {
@@ -330,7 +390,7 @@ export const Scene: FC<SceneProps> = ({
     initialCamera,
     enterUnderground,
     hideUnderground,
-    terrainUrl,
+    terrainBaseUrl,
     terrainNormal,
   ]);
 


### PR DESCRIPTION
## Symptom

Setting a terrain `layer.json` URL in the widget settings made the Editor/Visualizer Cesium view **reload the terrain endlessly** (`layer.json` + root tiles re-fetched ~19x/second).

## Cause (confirmed by runtime instrumentation)

Hooking `overrideProperty` in the browser showed **`Scene`'s effect calling `overrideProperty` ~28x/second** (560 calls in 20s), with virtually identical values each time.

Several of the effect's deps (`tiles` / `tileLabels` / `shadows` / `initialCamera` / `sphericalHarmonicCoefficients`, ...) get a **fresh identity** on every parent render, so the effect kept re-running even though the values were unchanged. Each `overrideProperty` call makes Re:Earth rebuild the engine `ViewerProperty`, which re-creates the Cesium terrain provider — the reload loop.

(HAR: `https://tiles.plateau.city/terrain/plateau-terrain-2024/layer.json` returns 200; URL, data and CORS are fine. Not a 404 or missing-tile issue.)

## Change (extension only)

`extension/src/shared/reearth/scene/Scene.tsx`:

1. **Gate `overrideProperty` on a value-based signature** — don't call it when the resolved property values are unchanged. The deps' identity churn no longer triggers a push.
2. **Normalize the terrain URL** — strip a trailing `/layer.json` (and slashes) and pass the base URL. `CesiumTerrainProvider.fromUrl` appends `/layer.json` itself, so passing the layer.json URL produced `/layer.json/layer.json` → 404. Either configured form now works.

## Verification

- `tsc --noEmit`: exit 0 / `eslint Scene.tsx`: exit 0
- Instrumentation: the previously-spamming `overrideProperty` should no longer fire unless values change (to be re-measured after deploy).