### PR TITLE
feat(extension): always request terrain vertex normals; remove the option

### DIFF
--- a/extension/reearth-yml.ts
+++ b/extension/reearth-yml.ts
@@ -170,13 +170,6 @@ const yml = {
                 description:
                   "Cesium ion の代わりに任意の quantized-mesh 地形 (layer.json) を読み込みます。CORS 許可が必要です。",
               },
-              {
-                id: "terrainNormal",
-                type: "bool",
-                title: "地形の法線を有効化",
-                description:
-                  "地形の陰影表現に必要な法線データを要求します（デフォルト有効）。法線非対応の地形を読み込む場合は無効にしてください。",
-              },
             ],
           },
         ],

--- a/extension/src/shared/context/WidgetContext.tsx
+++ b/extension/src/shared/context/WidgetContext.tsx
@@ -37,7 +37,6 @@ import {
   useDatasetAttributesURL,
   useCityGMLApiUrl,
   useTerrainUrl,
-  useTerrainNormal,
 } from "../states/environmentVariables";
 
 type Props = {
@@ -66,7 +65,6 @@ type Props = {
   customPedestrian?: CameraPosition;
   customSiteUrl?: string;
   terrainUrl?: string;
-  terrainNormal?: boolean;
   // Notification setting
   isEnable?: boolean;
   content?: string;
@@ -98,7 +96,6 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   customPedestrian,
   customSiteUrl,
   terrainUrl,
-  terrainNormal,
   geojsonURL,
   isEnable,
   content,
@@ -121,7 +118,7 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
   // has the value and the widgets that don't endlessly write value/undefined back over each
   // other — an infinite atom ping-pong that re-renders the whole map every frame. This bit
   // us with terrainUrl: it manifested as an endless terrain reload loop (overrideProperty
-  // fired ~28x/second). See the terrainUrl/terrainNormal effects below for the correct shape.
+  // fired ~28x/second). See the terrainUrl effect below for the correct shape.
   const [hideFeedbackState, setHideFeedbackState] = useHideFeedback();
   useEffect(() => {
     if (hideFeedback !== undefined && hideFeedback !== hideFeedbackState) {
@@ -237,22 +234,15 @@ export const WidgetContext: FC<PropsWithChildren<Props>> = ({
 
   // Only write when this widget actually carries a value. Every widget mounts its own
   // WidgetContext sharing these atoms, but only the widget that defines the terrain
-  // setting has terrainUrl/terrainNormal; without this guard the others keep writing
-  // `undefined` over the configured value, causing an endless atom ping-pong (and a
-  // matching overrideProperty / terrain reload loop). Mirrors the guarded settings above.
+  // setting has terrainUrl; without this guard the others keep writing `undefined` over
+  // the configured value, causing an endless atom ping-pong (and a matching
+  // overrideProperty / terrain reload loop). Mirrors the guarded settings above.
   const [terrainUrlState, setTerrainUrlState] = useTerrainUrl();
   useEffect(() => {
     if (terrainUrl && terrainUrl !== terrainUrlState) {
       setTerrainUrlState(terrainUrl);
     }
   }, [terrainUrl, terrainUrlState, setTerrainUrlState]);
-
-  const [terrainNormalState, setTerrainNormalState] = useTerrainNormal();
-  useEffect(() => {
-    if (terrainNormal != null && terrainNormal !== terrainNormalState) {
-      setTerrainNormalState(terrainNormal);
-    }
-  }, [terrainNormal, terrainNormalState, setTerrainNormalState]);
 
   const [datasetAttributesURLState, setDatasetAttributesURLState] = useDatasetAttributesURL();
   useEffect(() => {

--- a/extension/src/shared/reearth/scene/Scene.tsx
+++ b/extension/src/shared/reearth/scene/Scene.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useEffect, useMemo, useRef } from "react";
 
-import { useTerrainNormal, useTerrainUrl } from "../../states/environmentVariables";
+import { useTerrainUrl } from "../../states/environmentVariables";
 import { AmbientOcclusion, Antialias, CameraPosition, Tile, TileLabels } from "../types";
 import { isReEarthAPIv2 } from "../utils/reearth";
 
@@ -107,7 +107,6 @@ export const Scene: FC<SceneProps> = ({
   initialCamera,
 }) => {
   const [terrainUrl] = useTerrainUrl();
-  const [terrainNormal] = useTerrainNormal();
   // CesiumTerrainProvider.fromUrl appends "/layer.json" to the given URL, so we
   // must pass the terrain base URL (e.g. ".../terrain"), not the layer.json URL
   // itself. Otherwise it requests ".../terrain/layer.json/layer.json" (404),
@@ -208,7 +207,7 @@ export const Scene: FC<SceneProps> = ({
         terrain: {
           enabled: true,
           type: "cesiumion",
-          normal: terrainNormal ?? true,
+          normal: true,
           ...(terrainHeatmap
             ? {
                 elevationHeatMap: {
@@ -306,7 +305,7 @@ export const Scene: FC<SceneProps> = ({
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJiODVhMmQ5OS1hOWZjLTQ3YmYtODlmNi1lNWUwY2MwOGUxYTMiLCJpZCI6MTQ5ODk3LCJpYXQiOjE2ODc5MzQ3NDN9.OG0mc3i7ZxGwHQjlMv3TRjiOvKWpzxglxmJRaUIykTY",
           terrainCesiumIonAsset: "4195264",
           ...(terrainBaseUrl ? { terrainCesiumIonUrl: terrainBaseUrl } : {}),
-          terrainNormal: terrainNormal ?? true,
+          terrainNormal: true,
           ...(terrainHeatmap
             ? {
                 heatmapType: "custom",
@@ -359,7 +358,6 @@ export const Scene: FC<SceneProps> = ({
     enterUnderground,
     hideUnderground,
     terrainBaseUrl,
-    terrainNormal,
   ]);
 
   useEffect(() => {

--- a/extension/src/shared/states/environmentVariables.ts
+++ b/extension/src/shared/states/environmentVariables.ts
@@ -59,9 +59,6 @@ export const useDatasetAttributesURL = () => useAtom(datasetAttributesURL);
 const terrainUrl = atom<string | undefined>(undefined);
 export const useTerrainUrl = () => useAtom(terrainUrl);
 
-const terrainNormal = atom<boolean | undefined>(undefined);
-export const useTerrainNormal = () => useAtom(terrainNormal);
-
 // notification setting
 export const isEnableAtom = atom(false);
 export const useIsEnable = () => useAtom(isEnableAtom);

--- a/extension/src/toolbar/Widget.tsx
+++ b/extension/src/toolbar/Widget.tsx
@@ -65,7 +65,6 @@ type OptionalProps = {
   pedestrian?: CameraPosition;
   siteUrl?: string;
   terrainUrl?: string;
-  terrainNormal?: boolean;
 };
 
 type Props = WidgetProps<DefaultProps, OptionalProps>;
@@ -109,8 +108,7 @@ export const Widget: FC<Props> = memo(function WidgetPresenter({ widget, inEdito
         customMenuLogo={widget.property.optional?.menuLogo}
         customPedestrian={widget.property.optional?.pedestrian}
         customSiteUrl={widget.property.optional?.siteUrl}
-        terrainUrl={widget.property.optional?.terrainUrl}
-        terrainNormal={widget.property.optional?.terrainNormal}>
+        terrainUrl={widget.property.optional?.terrainUrl}>
         <InitializeApp />
         <AppFrame header={<AppHeader arURL={widget.property.default.arURL} />} />
         {/* TODO(ReEarth): Support initial layer loading(Splash screen) */}


### PR DESCRIPTION
## What

Terrain vertex normals are now **always enabled** instead of being a per-project widget setting. The `terrainNormal` option is removed end to end.

## Why

Normals are needed for terrain shading and we always want them on; exposing it as a toggle added surface area (and was part of the recently-fixed shared-atom sync) for no real benefit.

## Change (extension only)

- `reearth-yml.ts`: remove the `terrainNormal` widget schema field.
- `toolbar/Widget.tsx`: remove the `terrainNormal` OptionalProp and the prop passed to `WidgetContext`.
- `shared/context/WidgetContext.tsx`: remove the `terrainNormal` prop, the `useTerrainNormal` import, and its atom-sync effect.
- `shared/states/environmentVariables.ts`: remove the `terrainNormal` atom / `useTerrainNormal` hook.
- `shared/reearth/scene/Scene.tsx`: hardcode `normal: true` (v2) / `terrainNormal: true` (v1); drop the `terrainNormal` state and dep.

## Verification
- `yarn typecheck`: 0 / `eslint` (changed files): 0
- `yarn build:config` regenerates `reearth.yml` with no `terrainNormal` field