### PR TITLE
feat(tile): support Web Mercator and JGD2011 COGs

### DIFF
--- a/tile/README.md
+++ b/tile/README.md
@@ -432,6 +432,13 @@ Fetches tiles from a remote XYZ tile server.
 
 Generates tiles from a Cloud Optimized GeoTIFF file.
 
+Supported CRS (from the GeoTIFF EPSG key):
+
+- **Geographic degrees** — WGS84 (EPSG:4326) and JGD2011 / JGD2000 geographic (EPSG:6668 / 4612). The latter are treated as WGS84; the datum shift over Japan is sub-pixel, so the error is negligible. A COG with no EPSG key is assumed to be WGS84.
+- **Web Mercator meters** — EPSG:3857 (and the legacy `3785` alias). Since XYZ tiles *are* Web Mercator, requests map to a perfect square in this space and sampling is exact (no latitude distortion). Bounds are reprojected to WGS84 only for catalog/intersection bookkeeping.
+
+Any other CRS (e.g. a JGD2011 *plane rectangular* system in meters, or UTM) is rejected at open time.
+
 ```json
 {
   "type": "cog",

--- a/tile/src/cog/bounds.rs
+++ b/tile/src/cog/bounds.rs
@@ -58,13 +58,13 @@ pub fn mercator_y_to_lat(y: f64) -> f64 {
 /// min/max edges along each axis.
 #[derive(Debug, Clone, Copy)]
 pub struct TileBounds {
-    /// Western longitude (degrees)
+    /// Western edge (longitude degrees, or Web Mercator easting meters)
     pub west: f64,
-    /// Southern latitude (degrees)
+    /// Southern edge (latitude degrees, or Web Mercator northing meters)
     pub south: f64,
-    /// Eastern longitude (degrees)
+    /// Eastern edge (longitude degrees, or Web Mercator easting meters)
     pub east: f64,
-    /// Northern latitude (degrees)
+    /// Northern edge (latitude degrees, or Web Mercator northing meters)
     pub north: f64,
 }
 

--- a/tile/src/cog/bounds.rs
+++ b/tile/src/cog/bounds.rs
@@ -1,6 +1,61 @@
 //! Geographic bounds handling.
 
-/// Geographic bounding box in WGS84 coordinates.
+use std::f64::consts::PI;
+
+/// Semi-major axis of the WGS84 / Web Mercator sphere (meters).
+const EARTH_RADIUS: f64 = 6_378_137.0;
+/// Half the Web Mercator world extent (meters) — `PI * EARTH_RADIUS`.
+pub const MERCATOR_HALF_WORLD: f64 = PI * EARTH_RADIUS;
+
+/// Coordinate reference system of a COG, as far as this server cares about it.
+///
+/// The rendering pipeline samples linearly between the requested tile bounds and
+/// the COG bounds, so all it needs to know is which *space* those numbers live
+/// in. Two cases cover every COG we accept:
+///
+/// - [`CogCrs::Geographic`]: lon/lat in degrees. WGS84 (EPSG:4326) and JGD2011
+///   geographic (EPSG:6668) are treated identically — the datum shift in Japan
+///   is sub-meter, far below a raster pixel, so the error is negligible.
+/// - [`CogCrs::WebMercator`]: easting/northing in meters (EPSG:3857). XYZ tiles
+///   *are* Web Mercator, so a requested tile maps to a perfect square in this
+///   space and the linear sampling becomes exact (no latitude distortion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CogCrs {
+    /// Geographic lon/lat degrees (EPSG:4326 WGS84, EPSG:6668 JGD2011).
+    Geographic,
+    /// Web Mercator meters (EPSG:3857 and legacy aliases).
+    WebMercator,
+}
+
+impl CogCrs {
+    /// Classify an EPSG code into a supported [`CogCrs`], or `None` if we can't
+    /// render it (e.g. a JGD2011 *plane rectangular* CRS in meters, which is a
+    /// completely different projection from the negligible-error geographic one).
+    pub fn from_epsg(epsg: u16) -> Option<Self> {
+        match epsg {
+            // WGS84 geographic, JGD2011 geographic, JGD2000 geographic.
+            4326 | 6668 | 4612 => Some(Self::Geographic),
+            // Web Mercator and its legacy alias (the ESRI 90091x/10210x aliases
+            // exceed u16 and can't appear in a GeoTIFF EPSG key, so they're moot).
+            3857 | 3785 => Some(Self::WebMercator),
+            _ => None,
+        }
+    }
+}
+
+/// Convert a Web Mercator easting (meters) to WGS84 longitude (degrees).
+pub fn mercator_x_to_lon(x: f64) -> f64 {
+    (x / EARTH_RADIUS).to_degrees()
+}
+
+/// Convert a Web Mercator northing (meters) to WGS84 latitude (degrees).
+pub fn mercator_y_to_lat(y: f64) -> f64 {
+    (2.0 * (y / EARTH_RADIUS).exp().atan() - PI / 2.0).to_degrees()
+}
+
+/// Geographic bounding box. Coordinates are degrees for [`CogCrs::Geographic`]
+/// and meters for [`CogCrs::WebMercator`]; the field names still denote the
+/// min/max edges along each axis.
 #[derive(Debug, Clone, Copy)]
 pub struct TileBounds {
     /// Western longitude (degrees)
@@ -49,6 +104,43 @@ impl TileBounds {
     pub fn contains_point(&self, lon: f64, lat: f64) -> bool {
         lon >= self.west && lon <= self.east && lat >= self.south && lat <= self.north
     }
+
+    /// Reproject Web Mercator meter bounds into WGS84 degrees.
+    ///
+    /// Web Mercator's axes are monotonic with lon/lat, so reprojecting the
+    /// corners yields a correct degree bounding box. Used to report a COG's
+    /// extent and to intersection-test against WGS84 XYZ tiles, while sampling
+    /// stays in the COG's native meter space.
+    pub fn mercator_to_wgs84(&self) -> TileBounds {
+        TileBounds {
+            west: mercator_x_to_lon(self.west),
+            east: mercator_x_to_lon(self.east),
+            north: mercator_y_to_lat(self.north),
+            south: mercator_y_to_lat(self.south),
+        }
+    }
+}
+
+/// Web Mercator XYZ tile → bounding box in **meters** (EPSG:3857).
+///
+/// Unlike the WGS84 [`crate::tile::xyz_to_bounds`], the result is a perfect
+/// square in projected space, so sampling a Web Mercator COG with these bounds
+/// is exact rather than an approximation.
+pub fn mercator_tile_bounds(z: u32, x: u32, y: u32) -> TileBounds {
+    let n = 2.0_f64.powi(z as i32);
+    let tile_size = (2.0 * MERCATOR_HALF_WORLD) / n;
+
+    let west = -MERCATOR_HALF_WORLD + x as f64 * tile_size;
+    let east = west + tile_size;
+    let north = MERCATOR_HALF_WORLD - y as f64 * tile_size;
+    let south = north - tile_size;
+
+    TileBounds {
+        west,
+        south,
+        east,
+        north,
+    }
 }
 
 /// Convert geographic longitude to pixel X coordinate
@@ -89,5 +181,43 @@ mod tests {
         assert!((geo_to_pixel_y(10.0, &bounds, 100) - 0.0).abs() < 1e-6);
         assert!((geo_to_pixel_y(5.0, &bounds, 100) - 50.0).abs() < 1e-6);
         assert!((geo_to_pixel_y(0.0, &bounds, 100) - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_crs_from_epsg() {
+        assert_eq!(CogCrs::from_epsg(4326), Some(CogCrs::Geographic));
+        assert_eq!(CogCrs::from_epsg(6668), Some(CogCrs::Geographic)); // JGD2011 geographic
+        assert_eq!(CogCrs::from_epsg(3857), Some(CogCrs::WebMercator));
+        assert_eq!(CogCrs::from_epsg(3785), Some(CogCrs::WebMercator)); // legacy mercator alias
+        assert_eq!(CogCrs::from_epsg(6677), None); // JGD2011 plane rectangular (meters) - unsupported
+        assert_eq!(CogCrs::from_epsg(32654), None); // UTM zone 54N - unsupported
+    }
+
+    #[test]
+    fn test_mercator_tile_bounds_z0() {
+        let b = mercator_tile_bounds(0, 0, 0);
+        assert!((b.west + MERCATOR_HALF_WORLD).abs() < 1e-6);
+        assert!((b.east - MERCATOR_HALF_WORLD).abs() < 1e-6);
+        assert!((b.north - MERCATOR_HALF_WORLD).abs() < 1e-6);
+        assert!((b.south + MERCATOR_HALF_WORLD).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_mercator_roundtrip_to_wgs84() {
+        // The whole-world mercator tile maps to the full ±180° / ±85.0511°.
+        let wgs = mercator_tile_bounds(0, 0, 0).mercator_to_wgs84();
+        assert!((wgs.west + 180.0).abs() < 1e-6);
+        assert!((wgs.east - 180.0).abs() < 1e-6);
+        assert!((wgs.north - 85.051_128_78).abs() < 1e-4);
+        assert!((wgs.south + 85.051_128_78).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_mercator_to_wgs84_tokyo() {
+        // Tokyo ~ (139.6917, 35.6895) round-trips through mercator meters.
+        let x = 139.6917_f64.to_radians() * EARTH_RADIUS;
+        let y = (PI / 4.0 + 35.6895_f64.to_radians() / 2.0).tan().ln() * EARTH_RADIUS;
+        assert!((mercator_x_to_lon(x) - 139.6917).abs() < 1e-6);
+        assert!((mercator_y_to_lat(y) - 35.6895).abs() < 1e-6);
     }
 }

--- a/tile/src/cog/error.rs
+++ b/tile/src/cog/error.rs
@@ -14,7 +14,9 @@ pub enum CogError {
     TiffError(String),
     #[error("No IFD available")]
     NoIfd,
-    #[error("Unsupported CRS: expected WGS84 (EPSG:4326), got EPSG:{0}")]
+    #[error(
+        "Unsupported CRS: expected geographic (EPSG:4326/6668) or Web Mercator (EPSG:3857), got EPSG:{0}"
+    )]
     UnsupportedCrs(u16),
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),

--- a/tile/src/cog/error.rs
+++ b/tile/src/cog/error.rs
@@ -15,7 +15,7 @@ pub enum CogError {
     #[error("No IFD available")]
     NoIfd,
     #[error(
-        "Unsupported CRS: expected geographic (EPSG:4326/6668) or Web Mercator (EPSG:3857), got EPSG:{0}"
+        "Unsupported CRS: expected geographic degrees (WGS84 4326, JGD2011 6668, JGD2000 4612) or Web Mercator meters (3857, 3785), got EPSG:{0}"
     )]
     UnsupportedCrs(u16),
     #[error("Invalid URL: {0}")]

--- a/tile/src/cog/mod.rs
+++ b/tile/src/cog/mod.rs
@@ -9,7 +9,7 @@ mod interpolate;
 mod reader;
 mod resample;
 
-pub use bounds::TileBounds;
+pub use bounds::{CogCrs, TileBounds, mercator_tile_bounds};
 pub use decode::MAX_PHYSICAL_ELEVATION_M;
 pub use error::CogError;
 pub use reader::CogReader;

--- a/tile/src/cog/reader.rs
+++ b/tile/src/cog/reader.rs
@@ -13,7 +13,7 @@ use async_tiff::{TagValue, tags::Tag};
 use object_store::{ObjectStore, path::Path as ObjectPath};
 
 use super::{
-    bounds::TileBounds,
+    bounds::{CogCrs, TileBounds},
     decode::{decode_elevation, decode_rgba, get_pixel_values},
     error::CogError,
     interpolate::{bilinear_f64, bilinear_rgba},
@@ -26,7 +26,10 @@ pub struct CogReader {
     tiff: TIFF,
     store: Arc<dyn ObjectStore>,
     path: ObjectPath,
+    /// Bounds in the COG's native CRS units (degrees or Web Mercator meters).
     bounds: Option<TileBounds>,
+    /// Coordinate reference system the bounds and pixel grid live in.
+    crs: CogCrs,
     samples_per_pixel: u16,
 }
 
@@ -46,10 +49,10 @@ impl CogReader {
             .await
             .map_err(|e| CogError::OpenError(format!("{e:?}")))?;
 
-        // Validate CRS
-        Self::check_crs(&tiff)?;
+        // Detect and validate CRS
+        let crs = Self::detect_crs(&tiff)?;
 
-        // Extract bounds from GeoTIFF metadata
+        // Extract bounds from GeoTIFF metadata (in the COG's native CRS units)
         let bounds = Self::extract_bounds(&tiff);
 
         // Get samples per pixel
@@ -80,12 +83,16 @@ impl CogReader {
             store,
             path,
             bounds,
+            crs,
             samples_per_pixel,
         })
     }
 
     /// Read only the first IFD to extract bounds (much faster than reading all IFDs).
     /// Use this for preloading bounds without reading the entire metadata.
+    ///
+    /// The returned bounds are always in **WGS84 degrees** (reprojected when the
+    /// COG is Web Mercator), so callers can intersection-test against XYZ tiles.
     pub async fn read_bounds_only(
         store: Arc<dyn ObjectStore>,
         path: ObjectPath,
@@ -107,31 +114,31 @@ impl CogReader {
             return Err(CogError::NoIfd);
         };
 
-        // Check CRS
-        Self::check_crs_ifd(&ifd)?;
+        // Detect and validate CRS
+        let crs = Self::detect_crs_ifd(&ifd)?;
 
-        // Extract bounds
-        Ok(Self::extract_bounds_from_ifd(&ifd))
+        // Extract bounds and normalize to WGS84 degrees for the caller.
+        Ok(Self::extract_bounds_from_ifd(&ifd).map(|b| match crs {
+            CogCrs::Geographic => b,
+            CogCrs::WebMercator => b.mercator_to_wgs84(),
+        }))
     }
 
-    fn check_crs(tiff: &TIFF) -> Result<(), CogError> {
+    fn detect_crs(tiff: &TIFF) -> Result<CogCrs, CogError> {
         let ifd = tiff.ifds().first().ok_or(CogError::NoIfd)?;
-        Self::check_crs_ifd(ifd)
+        Self::detect_crs_ifd(ifd)
     }
 
-    fn check_crs_ifd(ifd: &ImageFileDirectory) -> Result<(), CogError> {
+    fn detect_crs_ifd(ifd: &ImageFileDirectory) -> Result<CogCrs, CogError> {
         if let Some(geo_keys) = ifd.geo_key_directory()
             && let Some(epsg) = geo_keys.epsg_code()
         {
-            if epsg == 4326 {
-                return Ok(());
-            }
-            return Err(CogError::UnsupportedCrs(epsg));
+            return CogCrs::from_epsg(epsg).ok_or(CogError::UnsupportedCrs(epsg));
         }
 
         // If no EPSG code found, assume WGS84
         tracing::warn!("No EPSG code found in GeoTIFF metadata, assuming WGS84");
-        Ok(())
+        Ok(CogCrs::Geographic)
     }
 
     fn extract_bounds(tiff: &TIFF) -> Option<TileBounds> {
@@ -163,9 +170,27 @@ impl CogReader {
         }
     }
 
-    /// Get the geographic bounds of the COG.
+    /// Get the COG bounds in the COG's **native CRS units** (degrees for
+    /// geographic, Web Mercator meters for Web Mercator). Used internally for
+    /// sampling against the matching native requested-tile bounds.
     pub fn bounds(&self) -> Option<&TileBounds> {
         self.bounds.as_ref()
+    }
+
+    /// The COG's coordinate reference system. Callers use this to build the
+    /// requested-tile bounds in the same space the COG was sampled in.
+    pub fn crs(&self) -> CogCrs {
+        self.crs
+    }
+
+    /// Get the COG bounds normalized to **WGS84 degrees**, regardless of the
+    /// COG's native CRS. Use for intersection tests against XYZ tiles and for
+    /// reporting the extent to the catalog/API.
+    pub fn wgs84_bounds(&self) -> Option<TileBounds> {
+        self.bounds.map(|b| match self.crs {
+            CogCrs::Geographic => b,
+            CogCrs::WebMercator => b.mercator_to_wgs84(),
+        })
     }
 
     /// Read the `GDAL_NODATA` tag (TIFF tag 42113) from the first IFD.
@@ -249,6 +274,11 @@ impl CogReader {
     }
 
     /// Read a tile as RGBA image data.
+    ///
+    /// `bounds` must be in the COG's **native CRS** (see [`Self::crs`]): degrees
+    /// for geographic COGs, Web Mercator meters for Web Mercator COGs. Build it
+    /// with [`crate::tile::xyz_to_bounds`] or
+    /// [`crate::cog::mercator_tile_bounds`] accordingly.
     pub async fn read_tile_rgba(
         &self,
         bounds: &TileBounds,
@@ -393,6 +423,9 @@ impl CogReader {
     }
 
     /// Read a tile as elevation (f64) data.
+    ///
+    /// `bounds` must be in the COG's **native CRS** (see [`Self::crs`]): degrees
+    /// for geographic COGs, Web Mercator meters for Web Mercator COGs.
     pub async fn read_tile_elevation(
         &self,
         bounds: &TileBounds,

--- a/tile/src/terrain/cog_dem.rs
+++ b/tile/src/terrain/cog_dem.rs
@@ -18,7 +18,7 @@ use url::Url;
 use xxhash_rust::xxh64::xxh64;
 
 use super::dem::{DemError, DemProvider, DemTile, GeoBounds};
-use crate::cog::{CogReader, TileBounds};
+use crate::cog::{CogCrs, CogReader, TileBounds, mercator_tile_bounds};
 
 /// How long to wait before retrying a failed `upstream_etag` HEAD. A transient
 /// network blip during `preload()` shouldn't poison the per-tile etag for the
@@ -193,17 +193,23 @@ impl DemProvider for CogDemSource {
             return Err(DemError::OutOfRange);
         }
         let reader = self.reader().await?;
-        let bounds = mercator_xyz_to_bounds(z, x, y);
+        // WGS84 bounds of the requested tile, for the overlap short-circuit.
+        let wgs84_tile = mercator_xyz_to_bounds(z, x, y);
 
         // Short-circuit when the COG bounds don't overlap this tile.
-        if let Some(cog_bounds) = reader.bounds() {
+        if let Some(cog_bounds) = reader.wgs84_bounds() {
             let g = GeoBounds::new(
                 cog_bounds.west,
                 cog_bounds.south,
                 cog_bounds.east,
                 cog_bounds.north,
             );
-            let req = GeoBounds::new(bounds.west, bounds.south, bounds.east, bounds.north);
+            let req = GeoBounds::new(
+                wgs84_tile.west,
+                wgs84_tile.south,
+                wgs84_tile.east,
+                wgs84_tile.north,
+            );
             if !g.intersects(&req) {
                 return Ok(DemTile {
                     elevations: vec![f64::NAN; (tile_size * tile_size) as usize],
@@ -211,6 +217,12 @@ impl DemProvider for CogDemSource {
                 });
             }
         }
+
+        // Sample in the COG's native CRS (exact for Web Mercator COGs).
+        let bounds = match reader.crs() {
+            CogCrs::Geographic => wgs84_tile,
+            CogCrs::WebMercator => mercator_tile_bounds(z as u32, x, y),
+        };
 
         // Prefer the explicit `nodata` from config, but fall back to the
         // COG's own `GDAL_NODATA` tag. Without this fallback, sentinel pixels
@@ -253,7 +265,7 @@ impl DemProvider for CogDemSource {
 
     async fn preload(&self) -> Result<(), DemError> {
         let reader = self.reader().await?;
-        if let Some(b) = reader.bounds() {
+        if let Some(b) = reader.wgs84_bounds() {
             let _ = self
                 .bounds_cell
                 .set(Some(GeoBounds::new(b.west, b.south, b.east, b.north)));

--- a/tile/src/tile/cog.rs
+++ b/tile/src/tile/cog.rs
@@ -15,7 +15,7 @@ use super::{
     source::{TileError, TileSource, single_etag_key},
 };
 use crate::{
-    cog::{CogReader, TileBounds},
+    cog::{CogCrs, CogReader, TileBounds, mercator_tile_bounds},
     config::NoDataConfig,
 };
 
@@ -93,10 +93,10 @@ impl CogTileSource {
         let (store, path) = self.create_object_store().await?;
         let reader = CogReader::open(store, path).await?;
 
-        // Cache bounds
-        if let Some(b) = reader.bounds() {
+        // Cache bounds in WGS84 (intersection tests run against WGS84 XYZ tiles).
+        if let Some(b) = reader.wgs84_bounds() {
             let mut bounds = self.bounds.write().await;
-            *bounds = Some(*b);
+            *bounds = Some(b);
         }
 
         *reader_guard = Some(reader);
@@ -211,13 +211,14 @@ impl TileSource for CogTileSource {
         // Ensure reader is initialized
         self.ensure_reader().await?;
 
-        let tile_bounds = xyz_to_bounds(z, x, y);
+        // WGS84 bounds for the intersection short-circuit (cached bounds are WGS84).
+        let wgs84_bounds = xyz_to_bounds(z, x, y);
 
         // Check if tile intersects COG bounds
         {
             let bounds = self.bounds.read().await;
             if let Some(cog_bounds) = &*bounds
-                && !cog_bounds.intersects(&tile_bounds)
+                && !cog_bounds.intersects(&wgs84_bounds)
             {
                 tracing::debug!(
                     url = %self.url,
@@ -231,7 +232,7 @@ impl TileSource for CogTileSource {
         tracing::debug!(
             url = %self.url,
             z = z, x = x, y = y,
-            tile_bounds = ?tile_bounds,
+            tile_bounds = ?wgs84_bounds,
             "Reading COG tile"
         );
 
@@ -240,6 +241,13 @@ impl TileSource for CogTileSource {
         let reader = reader_guard
             .as_ref()
             .ok_or_else(|| TileError::Internal("Reader not initialized".to_string()))?;
+
+        // Build the requested-tile bounds in the COG's native CRS so the linear
+        // sampling matches the COG's pixel grid (exact for Web Mercator).
+        let tile_bounds = match reader.crs() {
+            CogCrs::Geographic => wgs84_bounds,
+            CogCrs::WebMercator => mercator_tile_bounds(z, x, y),
+        };
 
         let rgba_data = reader
             .read_tile_rgba(&tile_bounds, self.tile_size, self.nodata.as_ref())


### PR DESCRIPTION
## What

Extend COG CRS support in the tile server beyond WGS84-only.

Previously, `CogReader` accepted only EPSG:4326 (WGS84) and rejected every other CRS as `UnsupportedCrs`. This broadens it to **classify** the CRS rather than gatekeeping a single code:

| CRS | EPSG | Handling |
|---|---|---|
| WGS84 geographic | 4326 | degrees (unchanged) |
| JGD2011 / JGD2000 geographic | 6668 / 4612 | degrees — treated as WGS84. The datum shift over Japan is sub-pixel, so the error is negligible |
| **Web Mercator** | 3857 / 3785 | meters. XYZ tiles *are* Web Mercator, so a request maps to a perfect square in this space and the linear sampling becomes **exact** (no latitude distortion) |
| JGD2011 plane rectangular (6677 etc.), UTM, … | — | still rejected (not degree-compatible) |

## Why

- JGD2011 is the standard datum for Japanese public data; geographic JGD2011 is numerically WGS84 to sub-pixel accuracy, so there's no reason to reject it.
- Web Mercator is arguably the *most* natural CRS for a tile pipeline — the requested XYZ tile and the COG grid both live in Mercator meters, so sampling needs no nonlinear reprojection and is exact.

## How

The rendering pipeline (`geo_to_pixel_*`, `resample_to_tile`, `TileRange::from_bounds`) already samples linearly between the requested-tile bounds and the COG bounds; it only requires both to be in the **same** coordinate space. So:

- COG bounds are stored in **native CRS units** (degrees or Mercator meters) and used for sampling.
- The requested tile bounds are built in that same native space (`xyz_to_bounds` for geographic, new `mercator_tile_bounds` for Web Mercator).
- Bounds are reprojected to **WGS84** (`wgs84_bounds()` / `mercator_to_wgs84()`) only for intersection short-circuits, the R*-tree footprint index, and the `/bounds` API — so catalog bookkeeping stays consistent regardless of native CRS.

Applies to both the `cog` overlay tile source (`src/tile/cog.rs`) and the COG DEM source (`src/terrain/cog_dem.rs`).

## Test plan

- `cargo test` — all unit + e2e tests pass (added unit tests for `CogCrs::from_epsg`, `mercator_tile_bounds`, and Mercator↔WGS84 reprojection incl. a Tokyo round-trip)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Notes

- No config schema or API changes; CRS is auto-detected from the GeoTIFF EPSG key. A COG with no EPSG key is still assumed WGS84 (unchanged).
- README updated with the supported-CRS matrix under the COG Layer section.
