### PR TITLE
feat(tile): decode WEBP-compressed COG tiles

### DIFF
--- a/tile/README.md
+++ b/tile/README.md
@@ -72,6 +72,13 @@ The base DEM is set via `DEM_URL` (env var). To **patch in higher-resolution dat
 - Cache keys aggregate base + every overlay's ETag (or `failed:slug` markers when an overlay's fetch fails for that tile), so updating any archive in place rolls all serving caches without a CDN partial purge.
 - Each pod refreshes every COG overlay's upstream ETag every **5 minutes** (single HEAD per overlay), so a CMS-side file swap that doesn't bump the config hash is picked up automatically — no `/reload` needed. The pod's own memory and persistent caches invalidate on ETag mismatch; downstream HTTP caches still honour their `Cache-Control: max-age` so end-users see the new tiles after at most one CDN TTL.
 
+### Supported COG tile compressions
+
+COG tiles are decoded via `async_tiff`, whose default decoders cover **uncompressed, Deflate, LZW, JPEG, and ZSTD**. On top of those the server also registers a **WebP** decoder (`src/cog/webp.rs`), so ortho-imagery COGs built with `-co COMPRESS=WEBP` (GDAL's private TIFF compression tag `50001`) decode correctly. Recommended choices:
+
+- **DEM (float32 elevation):** `ZSTD` (or `DEFLATE`) with `PREDICTOR=3` — lossless, see below.
+- **Ortho (RGB imagery):** `WEBP` or `JPEG` — both are decodable and give a good size/quality trade-off for aerial photography.
+
 ### Preparing COG DEM overlays
 
 When you build a COG to use as a `dem` overlay, **how you generate the overviews matters a lot at low zooms**. The default `gdal_translate -of COG` pipeline uses `average` resampling for overviews — which, even when nodata-aware, has a footprint-growing behavior: any 2×2 group with *at least one* valid pixel keeps a valid value in the parent. After five levels (×32 downsample) a single 5 m land pixel in the middle of the sea has spread to a ~160 m square block of "land" surrounding it.

--- a/tile/src/cog/mod.rs
+++ b/tile/src/cog/mod.rs
@@ -8,6 +8,7 @@ mod error;
 mod interpolate;
 mod reader;
 mod resample;
+mod webp;
 
 pub use bounds::{CogCrs, TileBounds, mercator_tile_bounds};
 pub use decode::MAX_PHYSICAL_ELEVATION_M;

--- a/tile/src/cog/reader.rs
+++ b/tile/src/cog/reader.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use async_tiff::{
     ImageFileDirectory, TIFF,
-    decoder::DecoderRegistry,
     metadata::{TiffMetadataReader, cache::ReadaheadMetadataCache},
     reader::ObjectReader,
     tags::SampleFormat,
@@ -18,6 +17,7 @@ use super::{
     error::CogError,
     interpolate::{bilinear_f64, bilinear_rgba},
     resample::{TileRange, resample_to_tile},
+    webp::decoder_registry,
 };
 use crate::config::NoDataConfig;
 
@@ -332,7 +332,7 @@ impl CogReader {
 
         // Fetch and decode tiles
         let reader = ObjectReader::new(self.store.clone(), self.path.clone());
-        let decoder_registry = DecoderRegistry::default();
+        let decoder_registry = decoder_registry();
 
         for ty in tile_range.y_start..tile_range.y_end {
             for tx in tile_range.x_start..tile_range.x_end {
@@ -471,7 +471,7 @@ impl CogReader {
         let mut pixel_buffer: Vec<f64> = vec![f64::NAN; buffer_width * buffer_height];
 
         let reader = ObjectReader::new(self.store.clone(), self.path.clone());
-        let decoder_registry = DecoderRegistry::default();
+        let decoder_registry = decoder_registry();
 
         for ty in tile_range.y_start..tile_range.y_end {
             for tx in tile_range.x_start..tile_range.x_end {

--- a/tile/src/cog/webp.rs
+++ b/tile/src/cog/webp.rs
@@ -1,0 +1,108 @@
+//! WebP tile decoder for COGs.
+//!
+//! `async_tiff`'s [`DecoderRegistry::default`] ships decoders for the standard
+//! TIFF compression methods (uncompressed, Deflate, LZW, JPEG, ZSTD) but not
+//! WebP. GDAL writes WebP-compressed tiles with the private TIFF compression
+//! tag `50001`, so ortho-imagery COGs built with `-co COMPRESS=WEBP` otherwise
+//! fail to decode with an "unknown compression method" error.
+//!
+//! `async_tiff` preserves unrecognised compression codes as
+//! [`CompressionMethod::Unknown`] rather than rejecting them, and
+//! [`DecoderRegistry`] is explicitly user-extensible, so we can register a WebP
+//! decoder here — backed by the (already-vendored) `image` crate — without
+//! patching the upstream crate.
+
+use async_tiff::decoder::{Decoder, DecoderRegistry};
+use async_tiff::error::AsyncTiffResult;
+use async_tiff::tags::{CompressionMethod, PhotometricInterpretation};
+use bytes::Bytes;
+use image::DynamicImage;
+
+/// TIFF compression tag that GDAL/libtiff use for WebP-compressed tiles
+/// (`COMPRESSION_WEBP`).
+const COMPRESSION_WEBP: u16 = 50001;
+
+/// A [`Decoder`] for WebP-compressed TIFF/COG tiles, backed by the `image` crate.
+#[derive(Debug, Clone)]
+pub struct WebpDecoder;
+
+impl Decoder for WebpDecoder {
+    fn decode_tile(
+        &self,
+        buffer: Bytes,
+        _photometric_interpretation: PhotometricInterpretation,
+        _jpeg_tables: Option<&[u8]>,
+    ) -> AsyncTiffResult<Bytes> {
+        let img = image::load_from_memory_with_format(&buffer, image::ImageFormat::WebP)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        // Return interleaved samples matching the source channel count so the
+        // caller's `samples_per_pixel`-based unpacking (see
+        // [`crate::cog::decode::decode_rgba`]) lines up: RGB WebP -> 3 bytes/px,
+        // RGBA WebP -> 4 bytes/px. Any other colour type is normalised to RGBA.
+        let raw = match img {
+            DynamicImage::ImageRgb8(b) => b.into_raw(),
+            DynamicImage::ImageRgba8(b) => b.into_raw(),
+            other => other.into_rgba8().into_raw(),
+        };
+        Ok(Bytes::from(raw))
+    }
+}
+
+/// Build a [`DecoderRegistry`] with the `async_tiff` defaults plus WebP support.
+///
+/// Use this in place of [`DecoderRegistry::default`] so COGs compressed with
+/// `-co COMPRESS=WEBP` (e.g. ortho imagery) decode correctly.
+pub fn decoder_registry() -> DecoderRegistry {
+    let mut registry = DecoderRegistry::default();
+    registry.as_mut().insert(
+        CompressionMethod::Unknown(COMPRESSION_WEBP),
+        Box::new(WebpDecoder),
+    );
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_tiff::tags::PhotometricInterpretation;
+    use image::{ImageFormat, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    #[test]
+    fn decodes_webp_to_interleaved_rgb() {
+        // Build a tiny image and encode it as (lossless) WebP in-memory.
+        let mut img = RgbImage::new(2, 2);
+        img.put_pixel(0, 0, Rgb([10, 20, 30]));
+        img.put_pixel(1, 0, Rgb([40, 50, 60]));
+        img.put_pixel(0, 1, Rgb([70, 80, 90]));
+        img.put_pixel(1, 1, Rgb([100, 110, 120]));
+
+        let mut webp = Cursor::new(Vec::new());
+        DynamicImage::ImageRgb8(img.clone())
+            .write_to(&mut webp, ImageFormat::WebP)
+            .expect("encode webp");
+
+        let decoded = WebpDecoder
+            .decode_tile(
+                Bytes::from(webp.into_inner()),
+                PhotometricInterpretation::RGB,
+                None,
+            )
+            .expect("decode webp");
+
+        // Lossless round-trip: 2x2 RGB -> 12 interleaved bytes, values preserved.
+        assert_eq!(decoded.len(), 2 * 2 * 3);
+        assert_eq!(&decoded[..], img.as_raw().as_slice());
+    }
+
+    #[test]
+    fn registry_has_webp_decoder() {
+        let registry = decoder_registry();
+        assert!(
+            registry
+                .as_ref()
+                .contains_key(&CompressionMethod::Unknown(COMPRESSION_WEBP))
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds support for reading **WEBP-compressed COG tiles** in the tile server, so ortho-imagery COGs built with `gdal_translate -of COG -co COMPRESS=WEBP` can be served as overlays.

## Why

`async_tiff`'s `DecoderRegistry::default()` ships decoders for the standard TIFF compression methods — uncompressed, Deflate, LZW, JPEG, ZSTD — but **not WEBP**. GDAL writes WEBP-compressed tiles with the private TIFF compression tag `50001`, so a WEBP ortho COG currently fails to decode with an *"unknown compression method"* error.

This is on the path to serving the PLATEAU ortho archive as on-demand COGs (`plateau-ortho`), where WEBP is a natural choice for aerial RGB imagery.

## How

- New `src/cog/webp.rs`:
  - `WebpDecoder` implements `async_tiff::decoder::Decoder`, decoding tile bytes via the already-vendored `image` crate (the `webp` feature is already enabled). It returns interleaved samples matching the source channel count (RGB → 3 B/px, RGBA → 4 B/px) so the caller's `samples_per_pixel`-based unpacking lines up.
  - `decoder_registry()` returns `DecoderRegistry::default()` **plus** a WEBP decoder registered at `CompressionMethod::Unknown(50001)`.
- `CogReader` uses `decoder_registry()` at both decode sites (RGBA + elevation) instead of `DecoderRegistry::default()`.

**No upstream `async_tiff` change is required**: unrecognised compression codes are preserved as `CompressionMethod::Unknown(n)` (not rejected), and `DecoderRegistry` is explicitly user-extensible.

## Tests

- `decodes_webp_to_interleaved_rgb` — WEBP encode→decode round-trip is lossless and byte-exact, verifying the decoder wiring.
- `registry_has_webp_decoder` — the extended registry contains the WEBP entry.
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt` all pass.

## Notes

Recommended COG compression: **DEM** → `ZSTD`/`DEFLATE` (lossless, `PREDICTOR=3`); **ortho** → `WEBP` or `JPEG`. README updated with a "Supported COG tile compressions" section.