### PR TITLE
fix(cloudflare): return 206 Partial Content for honored Range requests

### DIFF
--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -67,16 +67,61 @@ export async function serveObject(
     headers.set("content-encoding", "gzip");
   }
 
-  // `get` returns R2ObjectBody (with body) only on success; a failed conditional
-  // yields a bodyless R2Object -> 304.
-  const body = "body" in object ? object.body : null;
-  const status = body ? (headers.has("content-range") ? 206 : 200) : 304;
+  // Advertise byte-range support on every response; COG readers probe for it.
+  headers.set("accept-ranges", "bytes");
 
-  return new Response(body, {
+  // A failed conditional (If-None-Match / If-Modified-Since) yields a bodyless
+  // R2Object -> 304 Not Modified.
+  if (!("body" in object) || !object.body) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  // R2 sets `range` when it honored a Range request, but writeHttpMetadata does
+  // NOT emit Content-Range -- build it ourselves and return 206 Partial Content.
+  // Without this a satisfied range would wrongly read as a full 200.
+  // Only a client-sent Range makes this a partial response. (R2/Miniflare may
+  // populate `object.range` regardless, so gate on the actual request header.)
+  let status = 200;
+  if (request.headers.has("range") && object.range) {
+    const resolved = resolveRange(object.range, object.size);
+    if (resolved) {
+      headers.set("content-range", `bytes ${resolved.start}-${resolved.end}/${object.size}`);
+      headers.set("content-length", String(resolved.end - resolved.start + 1));
+      status = 206;
+    }
+  }
+
+  return new Response(object.body, {
     status,
     headers,
     encodeBody: isTerrain ? "manual" : "automatic",
   });
+}
+
+/**
+ * Resolve an R2Range to an inclusive byte [start, end], or null if it doesn't
+ * describe a valid sub-range. `suffix`/`offset`/`length` are read by value (not
+ * `"key" in range`) because some runtimes attach all three keys as undefined.
+ */
+function resolveRange(range: R2Range, size: number): { start: number; end: number } | null {
+  const suffix = (range as { suffix?: number }).suffix;
+  const offset = (range as { offset?: number }).offset;
+  const length = (range as { length?: number }).length;
+
+  let start: number;
+  let end: number;
+  if (typeof suffix === "number") {
+    start = size - Math.min(suffix, size);
+    end = size - 1;
+  } else {
+    start = typeof offset === "number" ? offset : 0;
+    end = typeof length === "number" ? start + length - 1 : size - 1;
+  }
+
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start) {
+    return null;
+  }
+  return { start, end };
 }
 
 interface ListingEntry {


### PR DESCRIPTION
## What & why

The `cloudflare/tiles` Worker mishandled satisfied **Range** requests: it decided 206 vs 200 by checking `headers.has("content-range")`, but `writeHttpMetadata` **never emits `Content-Range`**. So a Range request that R2 *did* honor was returned as:

- status **200** (not 206),
- **no** `Content-Range`,
- a **full-object** `Content-Length`,

…even though the body R2 returned was only the requested byte range. Clients that rely on byte-range reads (COG readers, Cesium terrain) saw a length/body mismatch → **corrupted reads**.

## Fix

In `serveObject` (`src/r2.ts`):

- Detect a partial response from the **client `Range` header + `object.range`** (not from an absent response header).
- Build `Content-Range` and `Content-Length` ourselves via a new `resolveRange`, which handles **suffix** (`bytes=-N`), **offset**, and **open-ended** (`bytes=N-`) ranges, and returns `null` for anything invalid.
- Always advertise `Accept-Ranges: bytes` so COG readers probe range support correctly.
- Streaming is unchanged: `object.body` (a `ReadableStream`) is passed straight to `Response` — no buffering, so large COGs never load into Worker memory. R2 does the byte-range slicing server-side.

## Test plan

Verified locally with `wrangler dev` against a known 36-byte object (`curl` with `Range` headers):

| Request | Result |
|---|---|
| full GET | `200`, `Content-Length: 36`, full body |
| `bytes=0-9`, `bytes=10-19` | `206`, correct `Content-Range`, `CL 10`, matching body |
| suffix `bytes=-6` | `206`, `Content-Range: bytes 30-35/36`, `CL 6` |
| open-ended `bytes=30-` | `206`, `bytes 30-35/36` |
| suffix over-size `bytes=-100` | `206`, full body `bytes 0-35/36` |
| `HEAD` + Range | `206` headers, no body |
| last byte `bytes=35-35` | `206`, `bytes 35-35/36`, `CL 1` |

In every case the `Content-Range` / `Content-Length` headers agree with the body — no mismatch. `tsc --noEmit` passes.

## Notes

- No breaking change; full (non-Range) responses are unaffected (still `200`).
- Out-of-range requests (e.g. `bytes=100-200` past EOF) return R2's full body as `206 bytes 0-35/36` rather than a strict `416`; headers still agree with the body, and COG/terrain readers never request out-of-bounds ranges, so there is no practical impact.