### PR TITLE
feat(tile,cloudflare): compose multiple configs; emit /tile config.json from R2 COGs

### DIFF
--- a/cloudflare/tiles/src/index.ts
+++ b/cloudflare/tiles/src/index.ts
@@ -23,6 +23,21 @@ function pathBuckets(env: Env): Record<string, string> {
   return map && typeof map === "object" ? (map as Record<string, string>) : {};
 }
 
+/**
+ * Datasets whose COGs are DEM overlays (config.json emits a `type: "dem"` stack
+ * instead of raster sources). Config-driven via the `DEM_DATASETS` var, so no
+ * `?type=` query param is needed — `/terrain/config.json` just knows it's a DEM.
+ */
+function demDatasets(env: Env): string[] {
+  const raw = (env as unknown as Record<string, unknown>).DEM_DATASETS;
+  return typeof raw === "string"
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : [];
+}
+
 /** Resolve the R2 bucket for a dataset segment (e.g. "terrain"), or null. */
 function bucketForDataset(env: Env, segment: string): { bucket: R2Bucket; name: string } | null {
   const bindingName = pathBuckets(env)[segment];
@@ -91,6 +106,7 @@ export default {
         url.searchParams,
         cors,
         request.method,
+        demDatasets(env).includes(segment),
       );
     }
 

--- a/cloudflare/tiles/src/index.ts
+++ b/cloudflare/tiles/src/index.ts
@@ -84,7 +84,14 @@ export default {
     // dataset's COGs as `cog` sources (for the tile server's CONFIG_URL). Special
     // key, checked before object serving so it isn't looked up as an R2 object.
     if (key === "config.json") {
-      return tileConfig(resolved.bucket, resolved.name, url.origin, url.searchParams, cors);
+      return tileConfig(
+        resolved.bucket,
+        resolved.name,
+        url.origin,
+        url.searchParams,
+        cors,
+        request.method,
+      );
     }
 
     // A bare prefix (`/terrain`, `/terrain/`) or a trailing slash lists that

--- a/cloudflare/tiles/src/index.ts
+++ b/cloudflare/tiles/src/index.ts
@@ -15,7 +15,7 @@
  *   - the root (/)                                 -> index of available datasets
  */
 
-import { corsHeaders, listPrefix, serveObject } from "./r2";
+import { corsHeaders, listPrefix, serveObject, tileConfig } from "./r2";
 
 /** Read PATH_BUCKETS, tolerating a missing/malformed binding (fail closed). */
 function pathBuckets(env: Env): Record<string, string> {
@@ -78,6 +78,13 @@ export default {
     const resolved = bucketForDataset(env, segment);
     if (!resolved) {
       return new Response("Unknown dataset", { status: 404, headers: cors });
+    }
+
+    // `/<dataset>/config.json` emits a PLATEAU /tile config describing this
+    // dataset's COGs as `cog` sources (for the tile server's CONFIG_URL). Special
+    // key, checked before object serving so it isn't looked up as an R2 object.
+    if (key === "config.json") {
+      return tileConfig(resolved.bucket, resolved.name, url.origin, url.searchParams, cors);
     }
 
     // A bare prefix (`/terrain`, `/terrain/`) or a trailing slash lists that

--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -124,6 +124,106 @@ function resolveRange(range: R2Range, size: number): { start: number; end: numbe
   return { start, end };
 }
 
+interface TileCogLayer {
+  type: "cog";
+  url: string;
+  order?: number;
+}
+
+interface TileSource {
+  description: string;
+  layers: TileCogLayer[];
+}
+
+interface TileConfig {
+  version: string;
+  sources: Record<string, TileSource>;
+}
+
+/**
+ * Emit a PLATEAU `/tile` config.json describing this dataset's COGs as `cog`
+ * sources, so the tile server can be pointed at
+ * `https://<host>/<dataset>/config.json` (as one entry in its comma-separated
+ * `CONFIG_URL`) and render the R2 COGs on demand. The COGs never move — the tile
+ * server reads them straight from this Worker over HTTP Range.
+ *
+ * COG keys are `<group>/<file>.tif` (for ortho, group = acquisition year).
+ * Default: one source per group, named `<dataset>-<group>` (e.g. `ortho-2024`),
+ * each a footprint mosaic of that group's COGs. Pass `?source=<name>` to stack
+ * every COG into a single source instead; numeric groups become the layer
+ * `order` so newer groups render on top.
+ *
+ * `version` is a cheap FNV-1a hash of every key+etag, so the tile server's
+ * config revalidation picks up any added / changed / removed COG.
+ */
+export async function tileConfig(
+  bucket: R2Bucket,
+  dataset: string,
+  origin: string,
+  params: URLSearchParams,
+  cors: Headers,
+): Promise<Response> {
+  // Enumerate every COG in the bucket (paginated — no delimiter, full recurse).
+  const cogs: { key: string; etag: string }[] = [];
+  let cursor: string | undefined;
+  do {
+    const res = await bucket.list({ cursor, limit: 1000 });
+    for (const o of res.objects) {
+      if (o.key.endsWith(".tif") || o.key.endsWith(".tiff")) {
+        cogs.push({ key: o.key, etag: o.etag });
+      }
+    }
+    cursor = res.truncated ? (res.cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  cogs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+
+  const layerFor = (key: string): TileCogLayer => ({
+    type: "cog",
+    url: `${origin}/${dataset}/${key}`,
+  });
+
+  const sources: Record<string, TileSource> = {};
+  const single = params.get("source");
+  if (single) {
+    sources[single] = {
+      description: `${dataset} COG mosaic (${cogs.length} COGs)`,
+      layers: cogs.map((o) => {
+        const layer = layerFor(o.key);
+        const group = Number(o.key.split("/")[0]);
+        if (Number.isFinite(group)) layer.order = group; // newer group on top
+        return layer;
+      }),
+    };
+  } else {
+    for (const o of cogs) {
+      const slash = o.key.indexOf("/");
+      const group = slash === -1 ? "" : o.key.slice(0, slash);
+      const name = group ? `${dataset}-${group}` : dataset;
+      (sources[name] ??= {
+        description: group ? `${dataset} ${group} COG mosaic` : `${dataset} COG mosaic`,
+        layers: [],
+      }).layers.push(layerFor(o.key));
+    }
+  }
+
+  // FNV-1a over key+etag pairs; Math.imul keeps the mix 32-bit.
+  let h = 0x811c9dc5;
+  for (const o of cogs) {
+    const s = `${o.key}:${o.etag};`;
+    for (let i = 0; i < s.length; i++) {
+      h = Math.imul(h ^ s.charCodeAt(i), 0x01000193);
+    }
+  }
+  const version = `${dataset}-${cogs.length}-${(h >>> 0).toString(16)}`;
+
+  const config: TileConfig = { version, sources };
+  const headers = new Headers(cors);
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", "public, max-age=60");
+  return new Response(JSON.stringify(config, null, 2), { headers });
+}
+
 interface ListingEntry {
   key: string;
   size: number;

--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -131,6 +131,8 @@ interface TileCogLayer {
 }
 
 interface TileSource {
+  /** `"dem"` marks a CompositeDemProvider stack; omitted for raster overlays. */
+  type?: string;
   description: string;
   layers: TileCogLayer[];
 }
@@ -140,34 +142,17 @@ interface TileConfig {
   sources: Record<string, TileSource>;
 }
 
-/**
- * Emit a PLATEAU `/tile` config.json describing this dataset's COGs as `cog`
- * sources, so the tile server can be pointed at
- * `https://<host>/<dataset>/config.json` (as one entry in its comma-separated
- * `CONFIG_URL`) and render the R2 COGs on demand. The COGs never move — the tile
- * server reads them straight from this Worker over HTTP Range.
- *
- * COG keys are `<group>/<file>.tif` (for ortho, group = acquisition year).
- * Default: one source per group, named `<dataset>-<group>` (e.g. `ortho-2024`),
- * each a footprint mosaic of that group's COGs. Pass `?source=<name>` to stack
- * every COG into a single source instead; numeric groups become the layer
- * `order` so newer groups render on top.
- *
- * `version` is a cheap FNV-1a hash of every key+etag, so the tile server's
- * config revalidation picks up any added / changed / removed COG.
- */
-export async function tileConfig(
-  bucket: R2Bucket,
-  dataset: string,
-  origin: string,
-  params: URLSearchParams,
-  cors: Headers,
-): Promise<Response> {
-  // Enumerate every COG in the bucket (paginated — no delimiter, full recurse).
-  const cogs: { key: string; etag: string }[] = [];
+interface Cog {
+  key: string;
+  etag: string;
+}
+
+/** List every `.tif`/`.tiff` under `prefix` (paginated). Empty prefix = whole bucket. */
+async function listCogs(bucket: R2Bucket, prefix: string): Promise<Cog[]> {
+  const cogs: Cog[] = [];
   let cursor: string | undefined;
   do {
-    const res = await bucket.list({ cursor, limit: 1000 });
+    const res = await bucket.list({ prefix: prefix || undefined, cursor, limit: 1000 });
     for (const o of res.objects) {
       if (o.key.endsWith(".tif") || o.key.endsWith(".tiff")) {
         cogs.push({ key: o.key, etag: o.etag });
@@ -175,21 +160,36 @@ export async function tileConfig(
     }
     cursor = res.truncated ? (res.cursor ?? undefined) : undefined;
   } while (cursor);
+  return cogs;
+}
 
-  cogs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+/**
+ * Bottom→top paint priority for a terrain DEM overlay, from its key. Coarser and
+ * more general layers sit at the bottom; finer/more-specific win on top:
+ * `sea/` < `base/dem10` < `base/dem5` < `base/dem1` < `patch/`.
+ */
+function demPriority(key: string): number {
+  if (key.startsWith("sea/")) return 0;
+  const m = key.match(/^base\/dem(\d+)\//);
+  if (m) return 100 - Number(m[1]); // dem10 -> 90 (bottom) ... dem1 -> 99 (top of base)
+  if (key.startsWith("patch/")) return 200; // finest, frontmost
+  return 150;
+}
 
-  const layerFor = (key: string): TileCogLayer => ({
-    type: "cog",
-    url: `${origin}/${dataset}/${key}`,
-  });
-
+/** Raster sources: one per group (`<dataset>-<group>`), or one stacked source with `?source=`. */
+function rasterSources(
+  cogs: Cog[],
+  dataset: string,
+  origin: string,
+  single: string | null,
+): Record<string, TileSource> {
+  const url = (key: string) => `${origin}/${dataset}/${key}`;
   const sources: Record<string, TileSource> = {};
-  const single = params.get("source");
   if (single) {
     sources[single] = {
       description: `${dataset} COG mosaic (${cogs.length} COGs)`,
       layers: cogs.map((o) => {
-        const layer = layerFor(o.key);
+        const layer: TileCogLayer = { type: "cog", url: url(o.key) };
         const group = Number(o.key.split("/")[0]);
         if (Number.isFinite(group)) layer.order = group; // newer group on top
         return layer;
@@ -203,9 +203,87 @@ export async function tileConfig(
       (sources[name] ??= {
         description: group ? `${dataset} ${group} COG mosaic` : `${dataset} COG mosaic`,
         layers: [],
-      }).layers.push(layerFor(o.key));
+      }).layers.push({ type: "cog", url: url(o.key) });
     }
   }
+  return sources;
+}
+
+/**
+ * A single `type: "dem"` source stacking every COG bottom→top (see `demPriority`).
+ * No per-layer `nodata` — the tile server reads each COG's own NoData tag.
+ */
+function demSource(
+  cogs: Cog[],
+  dataset: string,
+  origin: string,
+  name: string,
+): Record<string, TileSource> {
+  const ordered = [...cogs].sort(
+    (a, b) => demPriority(a.key) - demPriority(b.key) || (a.key < b.key ? -1 : 1),
+  );
+  return {
+    [name]: {
+      type: "dem",
+      description: `${dataset} DEM overlay stack (${cogs.length} COGs, bottom->top)`,
+      layers: ordered.map((o) => ({
+        type: "cog",
+        url: `${origin}/${dataset}/${o.key}`,
+      })),
+    },
+  };
+}
+
+/**
+ * Emit a PLATEAU `/tile` config.json describing this dataset's COGs, so the tile
+ * server can list `https://<host>/<dataset>/config.json` in its (comma-separated)
+ * `CONFIG_URL` and render the R2 COGs on demand. The COGs never move — the tile
+ * server reads them straight from this Worker over HTTP Range.
+ *
+ * Modes (query params):
+ * - **raster (default)** — for ortho. One `cog` source per group (first key
+ *   segment, e.g. acquisition year): `<dataset>-<group>` (e.g. `ortho-2024`),
+ *   each a footprint mosaic. `?source=<name>` instead stacks all COGs into one
+ *   source with layer `order` = numeric group (newer on top).
+ * - **`?type=dem`** — for terrain. A single `type: "dem"` source (name from
+ *   `?name=`, default `<dataset>`) stacking every COG bottom→top via `demPriority`
+ *   (`sea` < `base/dem10` < `dem5` < `dem1` < `patch`). No per-layer `nodata` —
+ *   the tile server reads each COG's own NoData tag.
+ *
+ * `?prefix=a/,b/` scopes enumeration to those key prefixes (comma-separated);
+ * defaults to `base/,patch/,sea/` in dem mode (skips the quantized-mesh mirror)
+ * and the whole bucket otherwise. `version` is an FNV-1a hash of every key+etag,
+ * so the tile server's config revalidation picks up any COG add/change/remove.
+ */
+export async function tileConfig(
+  bucket: R2Bucket,
+  dataset: string,
+  origin: string,
+  params: URLSearchParams,
+  cors: Headers,
+): Promise<Response> {
+  const isDem = params.get("type") === "dem";
+
+  const prefixParam = params.get("prefix");
+  const prefixes =
+    prefixParam !== null
+      ? prefixParam
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : isDem
+        ? ["base/", "patch/", "sea/"]
+        : [""];
+
+  const cogs: Cog[] = [];
+  for (const prefix of prefixes) {
+    cogs.push(...(await listCogs(bucket, prefix)));
+  }
+  cogs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+
+  const sources = isDem
+    ? demSource(cogs, dataset, origin, params.get("name") ?? dataset)
+    : rasterSources(cogs, dataset, origin, params.get("source"));
 
   // FNV-1a over key+etag pairs; Math.imul keeps the mix 32-bit.
   let h = 0x811c9dc5;

--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -164,6 +164,16 @@ async function listCogs(bucket: R2Bucket, prefix: string): Promise<Cog[]> {
 }
 
 /**
+ * Absolute COG URL against this Worker's own origin. Each `/`-delimited key
+ * segment is percent-encoded (keys with spaces/unicode/# would otherwise produce
+ * a broken URL); the tile server round-trips it back via `decodeURIComponent`.
+ */
+function cogUrl(origin: string, dataset: string, key: string): string {
+  const path = key.split("/").map(encodeURIComponent).join("/");
+  return `${origin}/${dataset}/${path}`;
+}
+
+/**
  * Bottom→top paint priority for a terrain DEM overlay, from its key. Coarser and
  * more general layers sit at the bottom; finer/more-specific win on top:
  * `sea/` < `base/dem10` < `base/dem5` < `base/dem1` < `patch/`.
@@ -183,13 +193,12 @@ function rasterSources(
   origin: string,
   single: string | null,
 ): Record<string, TileSource> {
-  const url = (key: string) => `${origin}/${dataset}/${key}`;
   const sources: Record<string, TileSource> = {};
   if (single) {
     sources[single] = {
       description: `${dataset} COG mosaic (${cogs.length} COGs)`,
       layers: cogs.map((o) => {
-        const layer: TileCogLayer = { type: "cog", url: url(o.key) };
+        const layer: TileCogLayer = { type: "cog", url: cogUrl(origin, dataset, o.key) };
         const group = Number(o.key.split("/")[0]);
         if (Number.isFinite(group)) layer.order = group; // newer group on top
         return layer;
@@ -203,7 +212,7 @@ function rasterSources(
       (sources[name] ??= {
         description: group ? `${dataset} ${group} COG mosaic` : `${dataset} COG mosaic`,
         layers: [],
-      }).layers.push({ type: "cog", url: url(o.key) });
+      }).layers.push({ type: "cog", url: cogUrl(origin, dataset, o.key) });
     }
   }
   return sources;
@@ -228,7 +237,7 @@ function demSource(
       description: `${dataset} DEM overlay stack (${cogs.length} COGs, bottom->top)`,
       layers: ordered.map((o) => ({
         type: "cog",
-        url: `${origin}/${dataset}/${o.key}`,
+        url: cogUrl(origin, dataset, o.key),
       })),
     },
   };
@@ -261,7 +270,16 @@ export async function tileConfig(
   origin: string,
   params: URLSearchParams,
   cors: Headers,
+  method: string,
 ): Promise<Response> {
+  const headers = new Headers(cors);
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", "public, max-age=60");
+  // HEAD wants headers only — skip the (potentially whole-bucket) R2 listing.
+  if (method === "HEAD") {
+    return new Response(null, { status: 200, headers });
+  }
+
   const isDem = params.get("type") === "dem";
 
   const prefixParam = params.get("prefix");
@@ -282,8 +300,8 @@ export async function tileConfig(
   cogs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
 
   const sources = isDem
-    ? demSource(cogs, dataset, origin, params.get("name") ?? dataset)
-    : rasterSources(cogs, dataset, origin, params.get("source"));
+    ? demSource(cogs, dataset, origin, params.get("name")?.trim() || dataset)
+    : rasterSources(cogs, dataset, origin, params.get("source")?.trim() || null);
 
   // FNV-1a over key+etag pairs; Math.imul keeps the mix 32-bit.
   let h = 0x811c9dc5;
@@ -296,9 +314,6 @@ export async function tileConfig(
   const version = `${dataset}-${cogs.length}-${(h >>> 0).toString(16)}`;
 
   const config: TileConfig = { version, sources };
-  const headers = new Headers(cors);
-  headers.set("content-type", "application/json; charset=utf-8");
-  headers.set("cache-control", "public, max-age=60");
   return new Response(JSON.stringify(config, null, 2), { headers });
 }
 

--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -249,15 +249,15 @@ function demSource(
  * `CONFIG_URL` and render the R2 COGs on demand. The COGs never move — the tile
  * server reads them straight from this Worker over HTTP Range.
  *
- * Modes (query params):
- * - **raster (default)** — for ortho. One `cog` source per group (first key
- *   segment, e.g. acquisition year): `<dataset>-<group>` (e.g. `ortho-2024`),
- *   each a footprint mosaic. `?source=<name>` instead stacks all COGs into one
- *   source with layer `order` = numeric group (newer on top).
- * - **`?type=dem`** — for terrain. A single `type: "dem"` source (name from
- *   `?name=`, default `<dataset>`) stacking every COG bottom→top via `demPriority`
- *   (`sea` < `base/dem10` < `dem5` < `dem1` < `patch`). No per-layer `nodata` —
- *   the tile server reads each COG's own NoData tag.
+ * `isDem` (from the `DEM_DATASETS` config, e.g. terrain) selects the mode:
+ * - **raster** (ortho) — one `cog` source per group (first key segment, e.g.
+ *   acquisition year): `<dataset>-<group>` (e.g. `ortho-2024`), each a footprint
+ *   mosaic. `?source=<name>` instead stacks all COGs into one source with layer
+ *   `order` = numeric group (newer on top).
+ * - **dem** (terrain) — a single `type: "dem"` source (name from `?name=`,
+ *   default `dem` = the tile server's default DEM source) stacking every COG
+ *   bottom→top via `demPriority` (`sea` < `base/dem10` < `dem5` < `dem1` <
+ *   `patch`). No per-layer `nodata` — the tile server reads each COG's own tag.
  *
  * `?prefix=a/,b/` scopes enumeration to those key prefixes (comma-separated);
  * defaults to `base/,patch/,sea/` in dem mode (skips the quantized-mesh mirror)
@@ -271,6 +271,7 @@ export async function tileConfig(
   params: URLSearchParams,
   cors: Headers,
   method: string,
+  isDem: boolean,
 ): Promise<Response> {
   const headers = new Headers(cors);
   headers.set("content-type", "application/json; charset=utf-8");
@@ -279,8 +280,6 @@ export async function tileConfig(
   if (method === "HEAD") {
     return new Response(null, { status: 200, headers });
   }
-
-  const isDem = params.get("type") === "dem";
 
   const prefixParam = params.get("prefix");
   const prefixes =
@@ -300,7 +299,7 @@ export async function tileConfig(
   cogs.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
 
   const sources = isDem
-    ? demSource(cogs, dataset, origin, params.get("name")?.trim() || dataset)
+    ? demSource(cogs, dataset, origin, params.get("name")?.trim() || "dem")
     : rasterSources(cogs, dataset, origin, params.get("source")?.trim() || null);
 
   // FNV-1a over key+etag pairs; Math.imul keeps the mix 32-bit.

--- a/cloudflare/tiles/wrangler.toml
+++ b/cloudflare/tiles/wrangler.toml
@@ -24,6 +24,9 @@ CORS_ALLOW_ORIGIN = "*"
 # First path segment -> R2 binding name. The handler resolves env[binding], so a
 # new dataset only needs an entry here plus a matching r2_buckets binding.
 PATH_BUCKETS = { terrain = "TERRAIN", ortho = "ORTHO" }
+# Datasets whose `config.json` emits a DEM overlay stack (type: "dem") rather
+# than raster sources. Comma-separated; no query param needed.
+DEM_DATASETS = "terrain"
 
 [observability]
 enabled = true

--- a/tile/AGENTS.md
+++ b/tile/AGENTS.md
@@ -58,7 +58,7 @@ CONFIG_URL=file://path/to/config.json cargo run
 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
-| `CONFIG_URL` | No | - | Config JSON URL (file://, http://, https://). Omit to run with built-in terrain only |
+| `CONFIG_URL` | No | - | Config JSON URL(s) (file://, http://, https://). Comma-separated list allowed — sources merged in order, earlier wins on name collision. Omit to run with built-in terrain only |
 | `PORT` | No | 8080 | Server port |
 | `CACHE_SIZE_MB` | No | 512 | Memory cache size in MB |
 | `RELOAD_SECRET` | No | - | Secret for config reload endpoint |

--- a/tile/README.md
+++ b/tile/README.md
@@ -181,7 +181,7 @@ docker run -e CONFIG_URL=https://example.com/config.json -p 8080:8080 tile
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `CONFIG_URL` | No | - | URL to the configuration JSON file. Omit to run with terrain-only defaults; required only to enable `/tiles/...` sources |
+| `CONFIG_URL` | No | - | Config JSON URL(s). Omit to run with terrain-only defaults; required only to enable `/tiles/...` sources. Accepts a **comma-separated list** — each URL is fetched and their `sources` merged in list order (earlier wins on a name collision), so independent authorities can each publish a config |
 | `CONFIG_TTL_SECS` | No | `60` | Lazy revalidation TTL. Each tile/terrain request checks whether the config has been re-fetched within this window; on the first miss per pod the request synchronously re-fetches and, if the body hash changed, rebuilds sources before serving. `0` disables (manual `/reload` only). Synchronous on purpose — Cloud Run throttles CPU outside the active request, so a background poller could be paused or killed mid-rebuild |
 | `PORT` | No | `8080` | HTTP server port |
 | `CACHE_SIZE_MB` | No | `512` | Memory cache size in MB |
@@ -365,6 +365,19 @@ Query parameters:
 ## Configuration
 
 Configuration is loaded from a remote JSON file specified by `CONFIG_URL`.
+
+`CONFIG_URL` may list several comma-separated URLs (`file://`, `http(s)://`).
+Each is fetched and their `sources` are merged in list order; on a source-name
+collision the **earlier** URL wins (list order = precedence) and the duplicate
+is logged. The merged `version` joins each config's version with `+`, and the
+combined content hash folds in every body, so `/reload` (and lazy revalidation)
+picks up a change in any of them. This lets independent authorities each publish
+a config — e.g. the CMS-derived config plus a Cloudflare Worker that enumerates
+R2 COGs — without either having to know the other's contents:
+
+```bash
+CONFIG_URL="https://cms.example/config.json,https://tiles.example/r2-cogs.json" ./target/release/tile
+```
 
 ### Example Configuration
 

--- a/tile/src/config.rs
+++ b/tile/src/config.rs
@@ -322,7 +322,10 @@ pub struct CacheConfig {
 /// from the currently loaded state (eventually consistent).
 pub struct ConfigManager {
     config: Arc<RwLock<Config>>,
-    config_url: String,
+    /// One or more config URLs (from a comma-separated `CONFIG_URL`). Their
+    /// `sources` are merged in list order; on a name collision the earlier URL
+    /// wins (list order = precedence).
+    config_urls: Vec<String>,
     client: reqwest::Client,
     /// Unix-seconds timestamp of the last revalidation attempt. Bumped via CAS
     /// before fetching so concurrent requests only let one through per TTL
@@ -339,19 +342,26 @@ pub struct ConfigManager {
 }
 
 impl ConfigManager {
-    pub async fn new(config_url: &str, revalidate_ttl: Duration) -> Result<Self, ConfigError> {
+    pub async fn new(
+        config_urls: &[String],
+        revalidate_ttl: Duration,
+    ) -> Result<Self, ConfigError> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
             .map_err(|e| ConfigError::FetchError(e.to_string()))?;
 
-        let (config, body_hash) = Self::fetch_config(&client, config_url).await?;
+        let (config, body_hash) = Self::fetch_and_merge(&client, config_urls).await?;
 
-        tracing::info!("Loaded configuration with {} sources", config.sources.len());
+        tracing::info!(
+            "Loaded configuration with {} sources from {} config URL(s)",
+            config.sources.len(),
+            config_urls.len()
+        );
 
         Ok(Self {
             config: Arc::new(RwLock::new(config)),
-            config_url: config_url.to_string(),
+            config_urls: config_urls.to_vec(),
             client,
             last_checked: AtomicU64::new(unix_secs()),
             content_hash: AtomicU64::new(body_hash),
@@ -373,7 +383,7 @@ impl ConfigManager {
                 sources: HashMap::new(),
                 cache: None,
             })),
-            config_url: String::new(),
+            config_urls: Vec::new(),
             client,
             last_checked: AtomicU64::new(0),
             content_hash: AtomicU64::new(0),
@@ -383,7 +393,7 @@ impl ConfigManager {
 
     /// Reload is a no-op if no config URL is configured.
     pub fn has_url(&self) -> bool {
-        !self.config_url.is_empty()
+        !self.config_urls.is_empty()
     }
 
     /// Whether lazy revalidation is enabled (TTL > 0 and a URL is configured).
@@ -447,6 +457,56 @@ impl ConfigManager {
         Ok((cfg, hash))
     }
 
+    /// Fetch every configured URL and merge them into one `Config`.
+    ///
+    /// `sources` are unioned across URLs; on a name collision the earlier URL
+    /// wins (CONFIG_URL list order = precedence) and the duplicate is logged.
+    /// The combined content hash folds each body's hash in list order, so a
+    /// change in *any* config flips it and triggers a downstream rebuild. The
+    /// merged `version` joins each config's version with `+`; `cache` takes the
+    /// first config that specifies one. Any single fetch failure fails the whole
+    /// merge (callers keep serving the previously loaded state).
+    async fn fetch_and_merge(
+        client: &reqwest::Client,
+        urls: &[String],
+    ) -> Result<(Config, u64), ConfigError> {
+        let mut merged = Config {
+            version: None,
+            sources: HashMap::new(),
+            cache: None,
+        };
+        let mut versions: Vec<String> = Vec::new();
+        let mut combined_hash: u64 = 0;
+
+        for url in urls {
+            let (cfg, hash) = Self::fetch_config(client, url).await?;
+            combined_hash = xxh64(&hash.to_le_bytes(), combined_hash);
+            if let Some(v) = cfg.version {
+                versions.push(v);
+            }
+            if merged.cache.is_none() {
+                merged.cache = cfg.cache;
+            }
+            for (name, src) in cfg.sources {
+                match merged.sources.entry(name) {
+                    std::collections::hash_map::Entry::Occupied(e) => {
+                        tracing::warn!(
+                            "Duplicate source '{}' from {url}; keeping earlier \
+                             CONFIG_URL entry (first-wins)",
+                            e.key()
+                        );
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(src);
+                    }
+                }
+            }
+        }
+
+        merged.version = (!versions.is_empty()).then(|| versions.join("+"));
+        Ok((merged, combined_hash))
+    }
+
     /// Reload configuration from URL unconditionally and swap it in.
     /// Returns `Ok(true)` if the content hash changed (callers should rebuild
     /// downstream sources), `Ok(false)` if the body is byte-identical to the
@@ -456,7 +516,7 @@ impl ConfigManager {
             tracing::info!("Reload requested but no CONFIG_URL is set; nothing to do");
             return Ok(false);
         }
-        let (new_config, new_hash) = Self::fetch_config(&self.client, &self.config_url).await?;
+        let (new_config, new_hash) = Self::fetch_and_merge(&self.client, &self.config_urls).await?;
         let prev_hash = self.content_hash.swap(new_hash, Ordering::AcqRel);
         // Bump the revalidation timestamp so any concurrent lazy check that
         // arrives within the next TTL window short-circuits.
@@ -465,12 +525,12 @@ impl ConfigManager {
         if changed {
             let mut config = self.config.write().await;
             *config = new_config;
-            tracing::info!("Configuration reloaded from {}", self.config_url);
-        } else {
-            tracing::debug!(
-                "Config refetched from {} but content is unchanged",
-                self.config_url
+            tracing::info!(
+                "Configuration reloaded from {} config URL(s)",
+                self.config_urls.len()
             );
+        } else {
+            tracing::debug!("Config refetched but content is unchanged");
         }
         Ok(changed)
     }
@@ -562,5 +622,47 @@ mod tests {
         let config: Config = serde_json::from_str(json).unwrap();
         assert!(config.sources.contains_key("ortho"));
         assert_eq!(config.sources["ortho"].layers.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_multi_config_merge_first_wins() {
+        use std::io::Write;
+
+        let mut a = tempfile::NamedTempFile::new().unwrap();
+        a.write_all(
+            br#"{"version":"va","sources":{
+                "only_a":{"layers":[{"type":"xyz","url":"https://a/{z}/{x}/{y}.png"}]},
+                "shared":{"description":"from-a","layers":[{"type":"cog","url":"https://a/c.tif"}]}
+            }}"#,
+        )
+        .unwrap();
+        a.flush().unwrap();
+
+        let mut b = tempfile::NamedTempFile::new().unwrap();
+        b.write_all(
+            br#"{"version":"vb","sources":{
+                "only_b":{"layers":[{"type":"cog","url":"https://b/c.tif"}]},
+                "shared":{"description":"from-b","layers":[{"type":"cog","url":"https://b/c.tif"}]}
+            }}"#,
+        )
+        .unwrap();
+        b.flush().unwrap();
+
+        let urls = vec![
+            format!("file://{}", a.path().display()),
+            format!("file://{}", b.path().display()),
+        ];
+        let mgr = ConfigManager::new(&urls, Duration::from_secs(0))
+            .await
+            .unwrap();
+        let cfg = mgr.get().await;
+
+        // Union of sources across both configs.
+        assert!(cfg.sources.contains_key("only_a"));
+        assert!(cfg.sources.contains_key("only_b"));
+        // Collision: the earlier URL (config A) wins.
+        assert_eq!(cfg.sources["shared"].description.as_deref(), Some("from-a"));
+        // Versions are joined in list order.
+        assert_eq!(cfg.version.as_deref(), Some("va+vb"));
     }
 }

--- a/tile/src/main.rs
+++ b/tile/src/main.rs
@@ -142,20 +142,37 @@ async fn main() -> Result<()> {
         .unwrap_or(60);
     let config_ttl = Duration::from_secs(config_ttl_secs);
 
-    let config_manager = Arc::new(match config_url.as_deref() {
-        Some(url) => {
-            tracing::info!("Loading configuration from {}", url);
-            ConfigManager::new(url, config_ttl)
-                .await
-                .context("Failed to load configuration")?
-        }
-        None => {
-            tracing::info!(
-                "CONFIG_URL not set; starting with built-in terrain endpoint only \
-                 (set CONFIG_URL to enable /tiles/... sources)"
-            );
-            ConfigManager::empty()
-        }
+    // CONFIG_URL may list several comma-separated config URLs; their sources are
+    // merged in order (earlier wins on a name collision). This lets independent
+    // authorities each publish a config — e.g. the CMS-derived config plus a
+    // Cloudflare Worker that enumerates R2 COGs — without one having to know the
+    // other's contents.
+    let config_urls: Vec<String> = config_url
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|u| !u.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let config_manager = Arc::new(if config_urls.is_empty() {
+        tracing::info!(
+            "CONFIG_URL not set; starting with built-in terrain endpoint only \
+             (set CONFIG_URL to enable /tiles/... sources)"
+        );
+        ConfigManager::empty()
+    } else {
+        tracing::info!(
+            "Loading configuration from {} URL(s): {}",
+            config_urls.len(),
+            config_urls.join(", ")
+        );
+        ConfigManager::new(&config_urls, config_ttl)
+            .await
+            .context("Failed to load configuration")?
     });
 
     if config_ttl_secs == 0 {

--- a/tile/tests/common/server.rs
+++ b/tile/tests/common/server.rs
@@ -44,7 +44,7 @@ impl TestServer {
         // Create config manager
         let config_url = format!("file://{}", config_path.display());
         let config_manager = Arc::new(
-            ConfigManager::new(&config_url, Duration::from_secs(0))
+            ConfigManager::new(std::slice::from_ref(&config_url), Duration::from_secs(0))
                 .await
                 .expect("Failed to create config manager"),
         );
@@ -130,7 +130,7 @@ impl TestServer {
 
         let config_url = format!("file://{}", config_path.display());
         let config_manager = Arc::new(
-            ConfigManager::new(&config_url, Duration::from_secs(0))
+            ConfigManager::new(std::slice::from_ref(&config_url), Duration::from_secs(0))
                 .await
                 .expect("Failed to create config manager"),
         );
@@ -210,7 +210,7 @@ impl TestServer {
 
         let config_url = format!("file://{}", config_path.display());
         let config_manager = Arc::new(
-            ConfigManager::new(&config_url, Duration::from_secs(0))
+            ConfigManager::new(std::slice::from_ref(&config_url), Duration::from_secs(0))
                 .await
                 .expect("Failed to create config manager"),
         );


### PR DESCRIPTION
## What & why

Two changes that together let the PLATEAU `/tile` server render the R2-hosted ortho **and** terrain COGs on demand, with config **generated next to the data** (Cloudflare Worker, which can see R2) instead of in `server/tiles` (which cannot).

### 1. `/tile`: multiple comma-separated `CONFIG_URL`s

`CONFIG_URL` now accepts a comma-separated list. Each URL is fetched and their `sources` merged in list order:

- **name collision → earlier URL wins** (list order = precedence), duplicate logged.
- merged `version` joins each config's version with `+`; combined content hash folds in every body, so `/reload` and lazy revalidation notice a change in **any** of them.

This lets independent authorities each publish a config — the CMS-derived config (`server/tiles`) **plus** a Worker that enumerates R2 COGs — without either knowing the other's contents. FME→COG migration becomes: serve both under distinct names, validate, flip.

### 2. `cloudflare/tiles`: `GET /<dataset>/config.json`

Enumerates the dataset's COGs in R2 and returns a `/tile` config describing them. The COGs never move — `/tile` reads them straight from this Worker over HTTP Range (see #520). Self-host absolute URLs (each key segment percent-encoded), CORS, `version` = FNV-1a of every key+etag so `/tile` revalidation picks up any add/change/remove. `HEAD` returns headers only (skips the listing).

Which datasets are DEM vs raster is **config-driven** via the `DEM_DATASETS` var (= `terrain`) — no query param needed:

- **raster (ortho)** — one `cog` source per group (first key segment = year): `<dataset>-<group>` (e.g. `ortho-2024`), each a footprint mosaic. `?source=<name>` instead stacks all COGs into one source with layer `order` = numeric group (newer on top).
- **dem (terrain)** — a single `type: "dem"` source (default name `dem` = the tile server's default DEM source; override with `?name=`, e.g. `dem-r2` for side-by-side validation) stacking every COG **bottom→top** by key priority (`sea` < `base/dem10` < `dem5` < `dem1` < `patch`). No per-layer `nodata` — the tile server reads each COG's own NoData tag.
- **`?prefix=a/,b/`** scopes enumeration; defaults to `base/,patch/,sea/` in dem mode so it never walks the quantized-mesh mirror (millions of `.terrain` tiles) under the terrain bucket, and the whole bucket otherwise.

Point the tile server at both:
```bash
CONFIG_URL="https://cms.example/config.json,https://tiles.plateau.city/ortho/config.json,https://tiles.plateau.city/terrain/config.json?name=dem-r2" ./tile
```

## Test plan

**`/tile` (Rust):** `cargo clippy --all-targets -- -D warnings` ✅, `cargo test --lib` ✅ (93 + new `test_multi_config_merge_first_wins`). E2E: two configs (25-COG ortho mosaic + GSI xyz) → `Loaded configuration with 2 sources from 2 config URL(s)`; catalog lists both; a tile from each 200; unknown 404.

**`cloudflare/tiles` (TS):** `tsc --noEmit` ✅. E2E via `wrangler dev --local` with dummy COGs:
- `/ortho/config.json` → per-year raster sources; `?source=` → one stacked source with `order` = year; keys with special chars percent-encoded; `?source=<whitespace>` ignored; `HEAD` → 200 no body.
- `/terrain/config.json` (no query param) → auto `type:"dem"` source named `dem` (from `DEM_DATASETS`), layers `base/dem10 → dem5 → dem1 → patch/*`, mirror `.terrain` excluded, no `nodata`; `?name=dem-r2` renames.

## Notes

- Precedence is deterministic (list order); in practice distinct names (e.g. `plateau-ortho-2024-new`, `dem-r2`) avoid collisions.
- No change to existing object/listing/Range behaviour.