### PR TITLE
fix(server,extension): percent-encode spatial ID slashes in citygml file API URL

### DIFF
--- a/extension/src/shared/api/citygml/client.ts
+++ b/extension/src/shared/api/citygml/client.ts
@@ -37,8 +37,11 @@ export class CityGMLClient {
   async getFiles(params: CityGMLGetFilesParams) {
     const conditions = makeFileAPIConditionsByParams(params);
     if (!conditions) return;
+    // Spatial IDs (s:z/f/x/y) contain slashes that must be percent-encoded so the
+    // whole condition stays a single path segment; otherwise the datacatalog route
+    // (/citygml/:conditions) does not match and returns 404.
     return this.handleError(
-      await fetchWithGet(`${this.fileUrl}/${conditions}`).catch((e: any) => {
+      await fetchWithGet(`${this.fileUrl}/${conditions.replace(/\//g, "%2F")}`).catch((e: any) => {
         console.error(e);
       }),
     ) as CityGMLGetFilesData;

--- a/server/citygml/datacatalog.go
+++ b/server/citygml/datacatalog.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/eukarya-inc/PLATEAU-VIEW/server/datacatalog"
@@ -28,7 +29,11 @@ func NewDataCatalogAPI(httpClient *http.Client, url string) *dataCatalogAPI {
 }
 
 func (a *dataCatalogAPI) FetchCityGMLFiles(ctx context.Context, cond string) (*datacatalog.CityGMLFilesResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.url+"/"+cond, nil)
+	// Spatial IDs (s:z/f/x/y) contain slashes that must be percent-encoded so the
+	// whole condition stays a single path segment; otherwise the datacatalog route
+	// (/citygml/:conditions) does not match and returns 404.
+	escaped := strings.ReplaceAll(cond, "/", "%2F")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.url+"/"+escaped, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes a 404 returned by the CityGML files API (`/datacatalog/citygml/:conditions`) when a spatial ID condition (`s:z/f/x/y`) is passed, even for data that exists.

### Root cause

The spatial ID `18/0/232847/103232` contains slashes, but callers concatenated it into the path **without percent-encoding**.

- The receiving route `GET /citygml/:conditions` (`server/datacatalog/v3.go`) matches echo's `:conditions` as a **single path segment**.
- Raw slashes are interpreted as segment boundaries, so the value splits into multiple segments, the route does not match → **404**.
- The handler `server/datacatalog/citygml_files.go` calls `url.PathUnescape(cond)`, i.e. it **expects the value to arrive percent-encoded**.

Verified against production:

```
s:/18/0/232847/103232         -> 404   (raw slashes)
s:%2F18%2F0%2F232847%2F103232 -> 200   (encoded; returns buildings for Chiyoda ward, 13101)
```

Mesh codes (`m:`) and rectangles (`r:`) contain no slashes, so they were unaffected; only the `s:` ZFXY form was broken.

### Fix

In the two callers that failed to encode, replace slashes in the condition string with `%2F`. The `s:` prefix and `,` separators are preserved.

- `extension/src/shared/api/citygml/client.ts` (frontend `getFiles`)
- `server/citygml/datacatalog.go` (server-side internal client used by `/citygml/spatialid_attributes`)

## Test plan

- `go build ./citygml/...` and `gofmt` pass.
- Confirmed the encoded URL (`s:%2F...`) returns 200 with Chiyoda ward buildings against the production API.

## Impact

- CityGML file/attribute lookups by spatial ID now work correctly.
- No breaking changes.