### PR TITLE
feat(cloudflare): add cumulative ortho-all source to /ortho/config.json

### DIFF
--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -186,35 +186,43 @@ function demPriority(key: string): number {
   return 150;
 }
 
-/** Raster sources: one per group (`<dataset>-<group>`), or one stacked source with `?source=`. */
+/**
+ * Raster sources: one footprint mosaic per group (`<dataset>-<group>`, e.g.
+ * `ortho-2024`), plus a cumulative `<dataset>-all` stacking every COG with layer
+ * `order` = numeric group, so newer groups win where footprints overlap — the
+ * COG equivalent of the production all-years ortho mosaic.
+ */
 function rasterSources(
   cogs: Cog[],
   dataset: string,
   origin: string,
-  single: string | null,
 ): Record<string, TileSource> {
   const sources: Record<string, TileSource> = {};
-  if (single) {
-    sources[single] = {
-      description: `${dataset} COG mosaic (${cogs.length} COGs)`,
+
+  // Per-group mosaics.
+  for (const o of cogs) {
+    const slash = o.key.indexOf("/");
+    const group = slash === -1 ? "" : o.key.slice(0, slash);
+    const name = group ? `${dataset}-${group}` : dataset;
+    (sources[name] ??= {
+      description: group ? `${dataset} ${group} COG mosaic` : `${dataset} COG mosaic`,
+      layers: [],
+    }).layers.push({ type: "cog", url: cogUrl(origin, dataset, o.key) });
+  }
+
+  // Cumulative "-all": every COG, newer group (higher order) on top.
+  if (cogs.length > 0) {
+    sources[`${dataset}-all`] = {
+      description: `${dataset} all groups, newest on top (${cogs.length} COGs)`,
       layers: cogs.map((o) => {
         const layer: TileCogLayer = { type: "cog", url: cogUrl(origin, dataset, o.key) };
         const group = Number(o.key.split("/")[0]);
-        if (Number.isFinite(group)) layer.order = group; // newer group on top
+        if (Number.isFinite(group)) layer.order = group;
         return layer;
       }),
     };
-  } else {
-    for (const o of cogs) {
-      const slash = o.key.indexOf("/");
-      const group = slash === -1 ? "" : o.key.slice(0, slash);
-      const name = group ? `${dataset}-${group}` : dataset;
-      (sources[name] ??= {
-        description: group ? `${dataset} ${group} COG mosaic` : `${dataset} COG mosaic`,
-        layers: [],
-      }).layers.push({ type: "cog", url: cogUrl(origin, dataset, o.key) });
-    }
   }
+
   return sources;
 }
 
@@ -252,7 +260,7 @@ function demSource(
  * `isDem` (from the `DEM_DATASETS` config, e.g. terrain) selects the mode:
  * - **raster** (ortho) — one `cog` source per group (first key segment, e.g.
  *   acquisition year): `<dataset>-<group>` (e.g. `ortho-2024`), each a footprint
- *   mosaic. `?source=<name>` instead stacks all COGs into one source with layer
+ *   mosaic, plus a cumulative `<dataset>-all` stacking every COG with layer
  *   `order` = numeric group (newer on top).
  * - **dem** (terrain) — a single `type: "dem"` source (name from `?name=`,
  *   default `dem` = the tile server's default DEM source) stacking every COG
@@ -300,7 +308,7 @@ export async function tileConfig(
 
   const sources = isDem
     ? demSource(cogs, dataset, origin, params.get("name")?.trim() || "dem")
-    : rasterSources(cogs, dataset, origin, params.get("source")?.trim() || null);
+    : rasterSources(cogs, dataset, origin);
 
   // FNV-1a over key+etag pairs; Math.imul keeps the mix 32-bit.
   let h = 0x811c9dc5;


### PR DESCRIPTION
## What & why

`GET /ortho/config.json` now always emits an **`ortho-all`** source alongside the per-year ones (`ortho-2020`, `ortho-2022`, `ortho-2023`, `ortho-2024`).

`ortho-all` stacks **every** COG into one source with each layer's `order` = its numeric group (year), so newer years render on top where footprints overlap — the COG-served equivalent of the production all-years cumulative ortho mosaic (`plateau-ortho-2024`). A consumer can point `/tile` at `ortho-2024` for just that year's captures, or at `ortho-all` for the full cumulative view.

This replaces the ad-hoc `?source=<name>` query param added earlier in this endpoint's life — the always-present `-all` source now covers that use, so the endpoint has no hidden mode.

## Test plan

`tsc --noEmit` ✅. E2E via `wrangler dev --local` with dummy COGs at `2020/…`, `2023/…`, `2024/…`:
- `/ortho/config.json` → sources `ortho-2020`, `ortho-2023`, `ortho-2024`, **`ortho-all`**.
- `ortho-all` layers each carry `order` = year (2020, 2023, 2024) → newer on top; it's a raster source (no `type`).

## Notes

- Terrain (`?type=dem` / `DEM_DATASETS`) is unaffected — the `-all` addition is raster-only.
- Cities are unique per acquisition year, so cross-year footprints don't actually overlap today; `order` is set defensively and matches production's newer-priority intent for any future overlaps.