### PR TITLE
fix(server): cache CMS metadata + verify SendGrid response

### DIFF
--- a/server/opinion/echo.go
+++ b/server/opinion/echo.go
@@ -93,12 +93,19 @@ func Echo(g *echo.Group, conf Config) {
 		}
 
 		response, err := client.Send(message)
-		if err != nil {
+		// SendGrid returns a nil error for any completed HTTP round-trip
+		// including 4xx/5xx responses (e.g. expired API key, rate limit,
+		// upstream outage). We must also inspect the status code — a
+		// successful send is 2xx (202 Accepted for /v3/mail/send) — otherwise
+		// user submissions are silently discarded.
+		if err != nil || response == nil || response.StatusCode < 200 || response.StatusCode >= 300 {
 			e := ""
 			if err != nil {
 				e = err.Error()
-			} else {
+			} else if response != nil {
 				e = fmt.Sprintf("code=%d,body=%s", response.StatusCode, response.Body)
+			} else {
+				e = "no response"
 			}
 
 			log.Errorfc(ctx, "opinion: failed to send email: %s", e)

--- a/server/opinion/echo_test.go
+++ b/server/opinion/echo_test.go
@@ -22,7 +22,8 @@ import (
 func TestEcho(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.Deactivate()
-	httpmock.RegisterResponder("POST", "https://api.sendgrid.com/v3/mail/send", httpmock.NewJsonResponderOrPanic(http.StatusOK, `{}`))
+	// SendGrid returns 202 Accepted on success for /v3/mail/send.
+	httpmock.RegisterResponder("POST", "https://api.sendgrid.com/v3/mail/send", httpmock.NewJsonResponderOrPanic(http.StatusAccepted, `{}`))
 
 	e := echo.New()
 	e.Validator = &customValidator{validator: validator.New()}
@@ -101,6 +102,32 @@ func TestEcho(t *testing.T) {
 	e.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, `"invalid file"`, strings.TrimSpace(w.Body.String()))
+}
+
+// TestEcho_SendGridRejects guards REL-01: a non-2xx SendGrid response
+// (e.g. expired API key, rate limit) must surface as a 502 rather than
+// being silently reported as success.
+func TestEcho_SendGridRejects(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.Deactivate()
+	httpmock.RegisterResponder("POST", "https://api.sendgrid.com/v3/mail/send", httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized, `{"errors":[{"message":"invalid api key"}]}`))
+
+	e := echo.New()
+	e.Validator = &customValidator{validator: validator.New()}
+	g := e.Group("")
+	Echo(g, Config{
+		SendGridAPIKey: "xxx",
+		From:           "hoge@example.com",
+		To:             "hoge@example.com",
+	})
+
+	rb := `{"email":"from@example.com","content":"aaaa","name":"name"}`
+	r := httptest.NewRequest("POST", "/", strings.NewReader(rb))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, `"failed to send email"`, strings.TrimSpace(w.Body.String()))
 }
 
 type customValidator struct {

--- a/server/plateaucms/cms.go
+++ b/server/plateaucms/cms.go
@@ -7,13 +7,21 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eukarya-inc/PLATEAU-VIEW/server/putil"
 	"github.com/labstack/echo/v4"
 	cms "github.com/reearth/reearth-cms-api/go"
 	"github.com/reearth/reearthx/rerror"
+	"golang.org/x/sync/singleflight"
 )
+
+// defaultMetadataCacheTTL is the time-to-live for the in-memory metadata cache.
+// Metadata rarely changes at request cadence (adding a project / rotating a token
+// happens on human timescales), so a short TTL absorbs bursts of concurrent
+// requests without noticeably delaying propagation of legitimate edits.
+const defaultMetadataCacheTTL = 60 * time.Second
 
 const (
 	ProjectNameParam             = "pid"
@@ -60,6 +68,13 @@ type CMS struct {
 	cmsMainProject string
 	cmsToken       string
 	adminToken     string
+
+	// metadata cache
+	metadataCacheTTL time.Duration
+	metadataSF       singleflight.Group
+	metadataMu       sync.RWMutex
+	metadataCache    MetadataList
+	metadataFetched  time.Time
 }
 
 func New(c Config) (*CMS, error) {
@@ -77,9 +92,10 @@ func New(c Config) (*CMS, error) {
 		cmsSysProject: c.CMSSystemProject,
 		cmsMain:       cmsMain,
 		// compat
-		cmsMainProject: c.CMSMainProject,
-		cmsToken:       c.CMSMainToken,
-		adminToken:     c.AdminToken,
+		cmsMainProject:   c.CMSMainProject,
+		cmsToken:         c.CMSMainToken,
+		adminToken:       c.AdminToken,
+		metadataCacheTTL: defaultMetadataCacheTTL,
 	}, nil
 }
 
@@ -100,9 +116,12 @@ func (h *CMS) Clone() *CMS {
 		cmsSysProject: h.cmsSysProject,
 		cmsMain:       h.cmsMain,
 		// compat
-		cmsMainProject: h.cmsMainProject,
-		cmsToken:       h.cmsToken,
-		adminToken:     h.adminToken,
+		cmsMainProject:   h.cmsMainProject,
+		cmsToken:         h.cmsToken,
+		adminToken:       h.adminToken,
+		metadataCacheTTL: h.metadataCacheTTL,
+		// Note: singleflight.Group and cache state intentionally not copied —
+		// a clone is a fresh instance that maintains its own cache.
 	}
 }
 

--- a/server/plateaucms/cms_test.go
+++ b/server/plateaucms/cms_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -307,6 +308,60 @@ func mockCMS(t *testing.T) {
 			},
 		}),
 	)
+}
+
+// TestHandler_AllMetadata_Cache guards SCA-01: repeated AllMetadata calls
+// within the cache TTL must hit the upstream CMS at most once, and concurrent
+// misses must be deduplicated via singleflight.
+func TestHandler_AllMetadata_Cache(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.Deactivate()
+	mockCMS(t)
+
+	h := newHandler()
+	h.metadataCacheTTL = time.Minute
+
+	ctx := context.Background()
+
+	// Prime the cache.
+	_, err := h.AllMetadata(ctx, false)
+	assert.NoError(t, err)
+	baseline := httpmock.GetCallCountInfo()["GET "+lo.Must(url.JoinPath(testCMSHost, "api", "projects", tokenProject, "models", metadataModel, "items"))]
+	assert.Positive(t, baseline)
+
+	// Subsequent calls within the TTL must not hit upstream again.
+	for range 5 {
+		_, err := h.AllMetadata(ctx, false)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, baseline, httpmock.GetCallCountInfo()["GET "+lo.Must(url.JoinPath(testCMSHost, "api", "projects", tokenProject, "models", metadataModel, "items"))])
+
+	// Concurrent misses on a fresh handler should be deduplicated by singleflight.
+	// Collect errors in per-goroutine slots and assert on the main goroutine
+	// (testify's assertions are not safe to call concurrently, and doing so
+	// races against -race under real contention).
+	h2 := newHandler()
+	h2.metadataCacheTTL = time.Minute
+	const workers = 10
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := h2.AllMetadata(ctx, false)
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+	// After the concurrent burst the counter should have advanced by only 1
+	// (singleflight collapses the misses); allow ≤ baseline to tolerate that
+	// GetItemsByKeyInParallel may issue more than one HTTP call per fetch.
+	after := httpmock.GetCallCountInfo()["GET "+lo.Must(url.JoinPath(testCMSHost, "api", "projects", tokenProject, "models", metadataModel, "items"))]
+	assert.LessOrEqual(t, after-baseline, baseline, "singleflight should collapse concurrent misses to a single upstream fetch")
 }
 
 func TestMetadataList_PlateauProjects(t *testing.T) {

--- a/server/plateaucms/metadata.go
+++ b/server/plateaucms/metadata.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	cms "github.com/reearth/reearth-cms-api/go"
 	"github.com/reearth/reearthx/rerror"
@@ -214,11 +215,87 @@ func (h *CMS) Metadata(ctx context.Context, prj string, findDataCatalog, useDefa
 	return md, all, nil
 }
 
+// AllMetadata returns the full metadata list for the system project.
+//
+// This is on the hot path of AuthMiddleware — invoked on every authenticated
+// request through the sidebar, share, and datacatalog services — so the result
+// is cached in memory with a short TTL. Concurrent misses are deduplicated via
+// singleflight so a burst of cache-miss requests results in a single upstream
+// fan-out to the CMS rather than one per request. The `findDataCatalog`
+// parameter does not affect the fetched set (filtering happens downstream in
+// MetadataList methods), so a single cache entry serves both cases.
 func (h *CMS) AllMetadata(ctx context.Context, findDataCatalog bool) (MetadataList, error) {
 	if h.cmsSysProject == "" {
 		return nil, rerror.ErrNotFound
 	}
 
+	if cached, ok := h.cachedAllMetadata(); ok {
+		return cached, nil
+	}
+
+	v, err, _ := h.metadataSF.Do("all", func() (any, error) {
+		// Recheck under singleflight: an earlier waiter may have populated the
+		// cache while this goroutine was queued.
+		if cached, ok := h.cachedAllMetadata(); ok {
+			return cached, nil
+		}
+
+		// Detach cancellation for the shared fetch: singleflight has multiple
+		// waiters and the leader is a coincidence — if the leader's request is
+		// cancelled (client disconnect / handler deadline), the upstream fetch
+		// must still complete so the other waiters aren't poisoned by
+		// context.Canceled. A bounded timeout keeps a stuck upstream from
+		// hanging the group forever.
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), metadataFetchTimeout)
+		defer cancel()
+
+		list, err := h.fetchAllMetadata(fetchCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		h.storeAllMetadata(list)
+		return list, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(MetadataList), nil
+}
+
+// metadataFetchTimeout bounds the shared upstream fetch inside singleflight so
+// a stuck CMS API can't keep followers waiting indefinitely. This is separate
+// from any per-request deadline because the leader's context is detached (see
+// AllMetadata for the rationale).
+const metadataFetchTimeout = 30 * time.Second
+
+func (h *CMS) cachedAllMetadata() (MetadataList, bool) {
+	ttl := h.metadataCacheTTL
+	if ttl <= 0 {
+		return nil, false
+	}
+
+	h.metadataMu.RLock()
+	defer h.metadataMu.RUnlock()
+
+	if h.metadataCache == nil || time.Since(h.metadataFetched) >= ttl {
+		return nil, false
+	}
+	return h.metadataCache, true
+}
+
+func (h *CMS) storeAllMetadata(list MetadataList) {
+	if h.metadataCacheTTL <= 0 {
+		return
+	}
+
+	h.metadataMu.Lock()
+	defer h.metadataMu.Unlock()
+	h.metadataCache = list
+	h.metadataFetched = time.Now()
+}
+
+func (h *CMS) fetchAllMetadata(ctx context.Context) (MetadataList, error) {
 	items, err := h.cmsMain.GetItemsByKeyInParallel(ctx, h.cmsSysProject, metadataModel, false, 100)
 	if err != nil || items == nil {
 		if errors.Is(err, cms.ErrNotFound) || items == nil {


### PR DESCRIPTION
## Summary

Fixes the two `CRITICAL` findings from the 2026-07 AI scan (eukarya-inc/compliance#83).

### SCA-01 — Full CMS metadata refetched on every authenticated request

`plateaucms.CMS.AllMetadata` sits on the hot `AuthMiddleware` path, which fronts the `sidebar`, `share`, and `datacatalog` services (all hit by PLATEAU VIEW on load). Every authenticated request was doing a full paginated fan-out (`GetItemsByKeyInParallel(..., 100)`) with no cache — cost grows linearly with `request_rate × metadata_row_count`, and concurrent viewers saturate the upstream CMS API on Cloud Run (default concurrency 80).

**Fix:** short-TTL in-memory cache (60s default) plus a `singleflight.Group` on the fetch, so a burst of concurrent cache-miss requests collapses to a single upstream fetch. The `findDataCatalog` parameter does not affect the fetched set (filtering is downstream, in `MetadataList` methods), so one cache entry serves both callers. `Clone()` copies the TTL setting but starts each clone with its own fresh cache and singleflight state.

TTL rationale: metadata edits (adding a project, rotating a token) happen on human timescales, so 60s absorbs bursts without noticeably delaying legitimate edits.

### REL-01 — Opinion submissions silently dropped on SendGrid 4xx/5xx

`opinion.Echo` treated any completed round-trip as success, because the response-status check lived in an unreachable `else` branch of `if err != nil`. SendGrid returns a `nil` error for HTTP-level failures (expired API key, rate limit, upstream 5xx), so every user-feedback submission was returning `200 "ok"` while nothing was sent — pure data loss until someone noticed.

**Fix:** also verify `response.StatusCode` is in the 2xx range (success on `/v3/mail/send` is `202 Accepted`), otherwise log the code/body and return `502`.

## Test plan

- [x] `go build ./plateaucms/... ./opinion/...`
- [x] `go vet ./plateaucms/... ./opinion/...`
- [x] `gofmt -l` clean
- [x] `go test -race ./plateaucms/... ./opinion/...`
- [x] New `TestHandler_AllMetadata_Cache` — asserts serial calls within TTL hit upstream once, and 10 concurrent misses are collapsed by singleflight
- [x] New `TestEcho_SendGridRejects` — asserts a SendGrid `401` surfaces as `502` (would have returned `200 "ok"` before this change)
- [x] Existing `TestHandler_Metadata` / `TestEcho` still green (also switched the SendGrid mock from `200` to the real-world `202 Accepted`)

## Out of scope

The scan also flagged 6 HIGH and 3 MEDIUM issues (SEC-01…03, SCA-02/03, REL-02…05). This PR fixes only the 2 CRITICAL ones per the request; the rest can be addressed in follow-ups.

Refs: eukarya-inc/compliance#83