### PR TITLE
fix(server): harden CityGML fetchers, webhooks, FME, and dataconv

### DIFF
--- a/server/citygml/attributes_test.go
+++ b/server/citygml/attributes_test.go
@@ -96,9 +96,12 @@ func TestAttributesHandlerCodeOnly(t *testing.T) {
 	citygml, err := os.ReadFile("testdata/" + testdata)
 	require.NoError(t, err)
 
-	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
+	// attributeHandler routes through safeHTTPClient, which has its own
+	// Transport, so activate httpmock on it too.
+	httpmock.ActivateNonDefault(safeHTTPClient)
 	httpmock.Activate()
 	defer httpmock.Deactivate()
+	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
 
 	u := &url.URL{Path: "/attributes"}
 	q := url.Values{}
@@ -144,9 +147,12 @@ func TestAttributesHandler(t *testing.T) {
 		}
 	}
 
-	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
+	// attributeHandler routes through safeHTTPClient, which has its own
+	// Transport, so activate httpmock on it too.
+	httpmock.ActivateNonDefault(safeHTTPClient)
 	httpmock.Activate()
 	defer httpmock.Deactivate()
+	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
 
 	u := &url.URL{Path: "/attributes"}
 	q := url.Values{}

--- a/server/citygml/echo.go
+++ b/server/citygml/echo.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -81,6 +82,18 @@ func attributeHandler(domain string) echo.HandlerFunc {
 			})
 		}
 
+		// Independent of the operator-configured Domain allowlist, refuse
+		// URLs that resolve to non-public addresses (loopback / RFC1918 /
+		// cloud metadata / link-local). The actual outbound socket is
+		// re-checked in safeDialContext so a DNS-rebinding attacker cannot
+		// bypass the pre-flight guard.
+		if err := checkExternalURL(u); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"url":   citygmlURL,
+				"error": "invalid url",
+			})
+		}
+
 		ids := strings.Split(c.QueryParam("id"), ",")
 		if len(ids) == 0 || (len(ids) == 1 && ids[0] == "") {
 			return c.JSON(http.StatusBadRequest, map[string]any{
@@ -98,7 +111,7 @@ func attributeHandler(domain string) echo.HandlerFunc {
 			})
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := safeHTTPClient.Do(req)
 		if err != nil {
 			log.Errorfc(c.Request().Context(), "citygml: failed to fetch: %v", err)
 			return c.JSON(http.StatusInternalServerError, map[string]any{
@@ -120,7 +133,7 @@ func attributeHandler(domain string) echo.HandlerFunc {
 		var resolver CodeResolver
 		if !skipCodeListFetch {
 			resolver = &fetchCodeResolver{
-				client: httpClient,
+				client: safeHTTPClient,
 				url:    citygmlURL,
 			}
 		}
@@ -188,12 +201,26 @@ func spatialIDAttributesHandler(dc *dataCatalogAPI) echo.HandlerFunc {
 			})
 		}
 
+		// Cap the fan-out so a broad, low-zoom spatial ID can't enqueue
+		// thousands of full-file GETs into a single request.
+		if len(urls) > spatialIDMaxURLs {
+			log.Warnfc(ctx, "citygml: capping %d urls to %d", len(urls), spatialIDMaxURLs)
+			urls = urls[:spatialIDMaxURLs]
+		}
+
 		log.Debugfc(ctx, "citygml: fetch %d citygml files", len(urls))
 
 		rs := make([]Reader, 0, len(urls))
 		etagCache := make(map[string]string)
+		var etagMu sync.Mutex
 		for _, u := range urls {
-			rs = append(rs, &urlReader{URL: u, client: httpClient, etagCache: etagCache, skipCodeListFetch: skipCodeListFetch})
+			rs = append(rs, &urlReader{
+				URL:               u,
+				client:            httpClient,
+				etagCache:         etagCache,
+				etagCacheMu:       &etagMu,
+				skipCodeListFetch: skipCodeListFetch,
+			})
 		}
 
 		// Stream the JSON array to avoid buffering every matched feature in memory.
@@ -255,6 +282,15 @@ func featureHandler(domain string) echo.HandlerFunc {
 			})
 		}
 
+		// See attributeHandler: reject non-public targets regardless of the
+		// operator-configured Domain allowlist.
+		if err := checkExternalURL(u); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"url":   citygmlURL,
+				"error": "invalid url",
+			})
+		}
+
 		ids := strings.Split(c.QueryParam("sid"), ",")
 		if len(ids) == 0 || (len(ids) == 1 && ids[0] == "") {
 			return c.JSON(http.StatusBadRequest, map[string]any{
@@ -270,7 +306,7 @@ func featureHandler(domain string) echo.HandlerFunc {
 			})
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := safeHTTPClient.Do(req)
 		if err != nil {
 			log.Errorfc(c.Request().Context(), "citygml: failed to fetch: %v", err)
 			return c.JSON(http.StatusInternalServerError, map[string]any{

--- a/server/citygml/features_test.go
+++ b/server/citygml/features_test.go
@@ -80,9 +80,13 @@ func TestFeaturesHandler(t *testing.T) {
 	citygmlURL := "http://example.com/udx/bldg/52382287_bldg_6697_psc_op.gml"
 	citygml, err := os.ReadFile("testdata/" + testdata)
 	require.NoError(t, err)
-	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
+	// featureHandler uses safeHTTPClient, which has its own Transport, so
+	// activate httpmock on it too — plain httpmock.Activate() only patches
+	// http.DefaultTransport.
+	httpmock.ActivateNonDefault(safeHTTPClient)
 	httpmock.Activate()
 	defer httpmock.Deactivate()
+	httpmock.RegisterResponder(http.MethodGet, citygmlURL, httpmock.NewBytesResponder(http.StatusOK, citygml))
 
 	u := &url.URL{Path: "/features"}
 	q := url.Values{}

--- a/server/citygml/packer.go
+++ b/server/citygml/packer.go
@@ -152,6 +152,14 @@ func (p *packer) handlePackRequest(c echo.Context) error {
 				"error": "invalid domain",
 			})
 		}
+		// Block private / loopback / cloud-metadata destinations even when
+		// the operator has not configured a Domain allowlist.
+		if err := checkExternalURL(u); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"url":   citygmlURL,
+				"error": "invalid url",
+			})
+		}
 	}
 
 	// sort urls and calculate hash

--- a/server/citygml/safeurl.go
+++ b/server/citygml/safeurl.go
@@ -1,0 +1,149 @@
+package citygml
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ErrUnsafeURL is returned when a caller-supplied URL points at something we
+// refuse to fetch from the CityGML endpoints (bad scheme, or a resolved
+// address that lives in a private / loopback / link-local range).
+var ErrUnsafeURL = errors.New("unsafe url")
+
+// checkExternalURL performs a static, pre-flight SSRF check against a
+// caller-supplied URL for the CityGML fetchers. It rejects anything that is
+// not http/https, and — when the host is an IP literal — anything in a
+// non-public range (loopback / private / link-local / multicast / unspecified /
+// unique-local IPv6 / IPv6 link-local). Actual DNS resolution is re-checked in
+// safeDialContext below so a rebinding attacker who returned a public A record
+// at check time and a private one at connect time is still stopped.
+//
+// This intentionally does not consult the operator's `Domain` allowlist —
+// domain is a positive allow, this is a negative block, and both apply.
+func checkExternalURL(u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("%w: nil url", ErrUnsafeURL)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("%w: scheme %q not allowed", ErrUnsafeURL, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: empty host", ErrUnsafeURL)
+	}
+	if ip := net.ParseIP(host); ip != nil && !isPublicIP(ip) {
+		return fmt.Errorf("%w: address %s is not public", ErrUnsafeURL, ip)
+	}
+	return nil
+}
+
+// isPublicIP returns true if the given address is safe to open an outbound
+// connection to from a server that must not reach internal services (e.g.
+// cloud metadata, RFC1918 hosts, loopback).
+func isPublicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() ||
+		ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// IPv4-mapped IPv6: unwrap before further checks.
+	if v4 := ip.To4(); v4 != nil {
+		// 169.254.169.254 (AWS/GCP/Azure metadata), 100.64.0.0/10 (CGNAT),
+		// 0.0.0.0/8, 240.0.0.0/4 (reserved).
+		if v4[0] == 0 || v4[0] >= 240 {
+			return false
+		}
+		if v4[0] == 169 && v4[1] == 254 {
+			return false
+		}
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return false
+		}
+		return true
+	}
+	// IPv6 unique-local (fc00::/7). net.IP.IsPrivate covers this on Go 1.17+ —
+	// keep the explicit check for defense in depth in case that changes.
+	if len(ip) == net.IPv6len && (ip[0]&0xfe) == 0xfc {
+		return false
+	}
+	return true
+}
+
+// safeDialContext refuses to connect to non-public addresses even after DNS
+// resolution. This is the defense-in-depth check that closes the DNS-rebinding
+// gap left by a purely pre-flight URL check.
+func safeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := (&net.Resolver{}).LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, ipa := range ips {
+		if !isPublicIP(ipa.IP) {
+			return nil, fmt.Errorf("%w: resolved address %s not public", ErrUnsafeURL, ipa.IP)
+		}
+	}
+	// Use the first resolved IP directly so the actual TCP connect target is
+	// exactly what we validated (net.Dial re-resolves the name otherwise).
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			// Belt-and-braces: also verify the address we're about to connect
+			// to. `Control` receives the resolved sockaddr as a string.
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			if ip := net.ParseIP(host); ip != nil && !isPublicIP(ip) {
+				return fmt.Errorf("%w: dial to non-public address %s blocked", ErrUnsafeURL, ip)
+			}
+			return nil
+		},
+	}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}
+
+// safeHTTPClient is an SSRF-safe HTTP client for caller-supplied URLs. It uses
+// safeDialContext to block connections to non-public addresses and also
+// re-validates the redirect target on every hop.
+//
+// `Proxy` is explicitly nil (rather than defaulting to
+// `http.ProxyFromEnvironment`): with a proxy configured, `DialContext` would
+// dial the proxy — a public address — and the CONNECT tunnel could still
+// terminate at an internal destination, bypassing our public-IP check
+// entirely. If a validating proxy setup is ever needed, wire in a `Proxy`
+// func that also runs `checkExternalURL` on the tunneled target.
+var safeHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		Proxy:                 nil,
+		DialContext:           safeDialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	},
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return checkExternalURL(req.URL)
+	},
+}

--- a/server/citygml/safeurl_test.go
+++ b/server/citygml/safeurl_test.go
@@ -1,0 +1,76 @@
+package citygml
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckExternalURL(t *testing.T) {
+	// Non-public destinations that must be rejected regardless of scheme.
+	// This includes cloud metadata IPs, loopback, RFC1918, link-local,
+	// CGNAT, IPv6 loopback / link-local / ULA, and reserved ranges.
+	blocked := []string{
+		"http://127.0.0.1/",
+		"http://localhost/",       // hostname literal that resolves to loopback — blocked via public-IP dial check, but scheme-check alone can't catch this. Skipped here (dial-time check).
+		"http://169.254.169.254/", // AWS/GCP/Azure metadata
+		"http://10.0.0.1/",
+		"http://192.168.1.1/",
+		"http://172.16.0.1/",
+		"http://100.64.0.1/", // CGNAT
+		"http://0.0.0.0/",
+		"http://240.0.0.1/",
+		"http://[::1]/",
+		"http://[fe80::1]/", // link-local
+		"http://[fc00::1]/", // ULA
+		"http://[fd00::1]/", // ULA
+		"http://[ff02::1]/", // multicast
+		"http://[::ffff:127.0.0.1]/",
+	}
+	for _, raw := range blocked {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		if u.Hostname() == "localhost" {
+			// hostname literal — pre-flight check can't catch this, only
+			// safeDialContext can. Skip.
+			continue
+		}
+		err = checkExternalURL(u)
+		assert.Error(t, err, "expected block for %s", raw)
+		assert.True(t, errors.Is(err, ErrUnsafeURL), "expected ErrUnsafeURL for %s, got %v", raw, err)
+	}
+
+	// Public destinations that must be allowed.
+	allowed := []string{
+		"http://example.com/",
+		"https://plateau.example/foo",
+		"http://8.8.8.8/",
+		"https://[2606:4700:4700::1111]/",
+	}
+	for _, raw := range allowed {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		assert.NoError(t, checkExternalURL(u), "expected allow for %s", raw)
+	}
+
+	// Bad schemes.
+	for _, raw := range []string{
+		"file:///etc/passwd",
+		"gopher://example.com/",
+		"ftp://example.com/",
+		"javascript:alert(1)",
+	} {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		assert.Error(t, checkExternalURL(u), "expected block for %s", raw)
+	}
+
+	// Nil / empty.
+	assert.Error(t, checkExternalURL(nil))
+	{
+		u, _ := url.Parse("http:///path")
+		assert.Error(t, checkExternalURL(u))
+	}
+}

--- a/server/citygml/spatialid_attributes.go
+++ b/server/citygml/spatialid_attributes.go
@@ -6,12 +6,27 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sync"
 
 	"github.com/eukarya-inc/PLATEAU-VIEW/server/geo/spatialid"
 	"github.com/klauspost/compress/gzip"
 	"github.com/orisano/gosax/xmlb"
 	"github.com/reearth/reearthx/log"
+	"golang.org/x/sync/errgroup"
 )
+
+// spatialIDConcurrency bounds the number of upstream CityGML files fetched and
+// parsed in parallel by SpatialIDAttributes. Matches the sibling
+// /datacatalog/citygml handler's cap so a broad, low-zoom spatial ID doesn't
+// tie up an instance for minutes issuing sequential HTTP calls.
+const spatialIDConcurrency = 10
+
+// spatialIDMaxURLs caps the number of files a single request will fetch. A
+// broad spatial ID over many cities can otherwise enqueue thousands of full-
+// file HTTP GETs; even parallelized, that eats up the request budget and
+// upstream quota. 500 covers realistic multi-city queries but stops obvious
+// blowups.
+const spatialIDMaxURLs = 500
 
 type Reader interface {
 	Open(ctx context.Context) (io.Reader, func() error, error)
@@ -23,7 +38,10 @@ type urlReader struct {
 	client *http.Client
 
 	skipCodeListFetch bool
-	etagCache         map[string]string
+	// etagCache is shared across parallel readers within the same request,
+	// so mutate it under mu.
+	etagCache   map[string]string
+	etagCacheMu *sync.Mutex
 }
 
 func (r *urlReader) Open(ctx context.Context) (io.Reader, func() error, error) {
@@ -36,8 +54,16 @@ func (r *urlReader) Open(ctx context.Context) (io.Reader, func() error, error) {
 	cacheKey := path.Base(u.Path)
 
 	req.Header.Set("Accept-Encoding", "gzip")
-	if etag, ok := r.etagCache[cacheKey]; ok {
-		req.Header.Set("If-None-Match", etag)
+	// The ETag cache and its mutex are wired together — both non-nil, or
+	// neither. Guarding both defends against a partially-initialised reader
+	// where a caller passes an etagCache map but forgets the mutex.
+	etagCacheEnabled := r.etagCache != nil && r.etagCacheMu != nil
+	if etagCacheEnabled {
+		r.etagCacheMu.Lock()
+		if etag, ok := r.etagCache[cacheKey]; ok {
+			req.Header.Set("If-None-Match", etag)
+		}
+		r.etagCacheMu.Unlock()
 	}
 	resp, err := r.client.Do(req)
 	if err != nil {
@@ -50,7 +76,11 @@ func (r *urlReader) Open(ctx context.Context) (io.Reader, func() error, error) {
 		log.Debugfc(ctx, "citygml: failed to open: %s", resp.Status)
 		return nil, nil, resp.Body.Close()
 	}
-	r.etagCache[cacheKey] = resp.Header.Get("ETag")
+	if etagCacheEnabled {
+		r.etagCacheMu.Lock()
+		r.etagCache[cacheKey] = resp.Header.Get("ETag")
+		r.etagCacheMu.Unlock()
+	}
 	if resp.Header.Get("Content-Encoding") == "gzip" {
 		gr, err := gzip.NewReader(resp.Body)
 		if err != nil {
@@ -89,86 +119,105 @@ func SpatialIDAttributes(ctx context.Context, rs []Reader, spatialIDs []string, 
 	if len(filter.Bounds) == 0 {
 		return nil
 	}
+
+	// Fetch and parse each URL concurrently. Each goroutine owns its own
+	// XML-decoder buffer and tag-handler cache; the caller's yield is
+	// serialized under yieldMu so JSON output stays well-formed.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(spatialIDConcurrency)
+	var yieldMu sync.Mutex
+	safeYield := func(v map[string]any) error {
+		yieldMu.Lock()
+		defer yieldMu.Unlock()
+		return yield(v)
+	}
+
+	for _, r := range rs {
+		r := r
+		g.Go(func() error {
+			return processSpatialIDReader(gctx, r, filter, safeYield)
+		})
+	}
+
+	return g.Wait()
+}
+
+func processSpatialIDReader(ctx context.Context, r Reader, filter lod1SolidFilter, yield func(map[string]any) error) error {
+	rc, cleanup, err := r.Open(ctx)
+	if err != nil {
+		return err
+	}
+	if rc == nil {
+		log.Debugfc(ctx, "citygml: skip scan")
+		return nil
+	}
+	defer func() {
+		_ = cleanup()
+	}()
+
+	// Buffer and tag-handler cache are per-goroutine — sharing them across
+	// concurrent parses would corrupt scanner state.
+	buf := make([]byte, 32*1024)
 	h := lod1SolidHandler{
 		Filter: filter,
 	}
+	fs := &featureScanner{
+		Dec: xmlb.NewDecoder(rc, buf),
+	}
+	count, matched := 0, 0
+	thCache := map[string]tagHandler{}
+	for fs.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		count++
 
-	buf := make([]byte, 32*1024)
-	for _, r := range rs {
-		err := func(r Reader) error {
-			rc, cleanup, err := r.Open(ctx)
-			if err != nil {
-				return err
-			}
-			if rc == nil {
-				log.Debugfc(ctx, "citygml: skip scan")
-				return nil
-			}
-			defer func() {
-				_ = cleanup()
-			}()
-
-			fs := &featureScanner{
-				Dec: xmlb.NewDecoder(rc, buf),
-			}
-			count, matched := 0, 0
-			thCache := map[string]tagHandler{}
-			for fs.Scan() {
-				count++
-
-				id, el := fs.Feature()
-				tag := tagName(el.Name)
-				if _, ok := thCache[tag]; !ok {
-					thCache[tag] = toTagHandler(tag, schemaDefs, r.Resolver())
-				}
-				fah, err := newFeatureAttributeHandler(fs.ns, id, tag, thCache[tag])
-				if err != nil {
-					return err
-				}
-				h.Next = fah
-				h.boundingBox = nil // Reset bounding box for each feature
-				ok, err := processFeature(fs.Dec, &h)
-				if err != nil {
-					return err
-				}
-				if ok {
-					// Add bounding box information if available
-					if h.boundingBox != nil {
-						fah.Val["_bbox"] = map[string]any{
-							"min": map[string]float64{
-								"lng": h.boundingBox.Min.X,
-								"lat": h.boundingBox.Min.Y,
-								"alt": h.boundingBox.Min.Z,
-							},
-							"max": map[string]float64{
-								"lng": h.boundingBox.Max.X,
-								"lat": h.boundingBox.Max.Y,
-								"alt": h.boundingBox.Max.Z,
-							},
-							"center": map[string]float64{
-								"lng": (h.boundingBox.Min.X + h.boundingBox.Max.X) / 2,
-								"lat": (h.boundingBox.Min.Y + h.boundingBox.Max.Y) / 2,
-								"alt": (h.boundingBox.Min.Z + h.boundingBox.Max.Z) / 2,
-							},
-						}
-					}
-					matched++
-					if err := yield(fah.Val); err != nil {
-						return err
-					}
-				}
-			}
-
-			if err := fs.Err(); err != nil {
-				return err
-			}
-
-			log.Debugfc(ctx, "citygml: %d features scanned and %d intersected", count, matched)
-			return nil
-		}(r)
+		id, el := fs.Feature()
+		tag := tagName(el.Name)
+		if _, ok := thCache[tag]; !ok {
+			thCache[tag] = toTagHandler(tag, schemaDefs, r.Resolver())
+		}
+		fah, err := newFeatureAttributeHandler(fs.ns, id, tag, thCache[tag])
 		if err != nil {
 			return err
 		}
+		h.Next = fah
+		h.boundingBox = nil // Reset bounding box for each feature
+		ok, err := processFeature(fs.Dec, &h)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if h.boundingBox != nil {
+				fah.Val["_bbox"] = map[string]any{
+					"min": map[string]float64{
+						"lng": h.boundingBox.Min.X,
+						"lat": h.boundingBox.Min.Y,
+						"alt": h.boundingBox.Min.Z,
+					},
+					"max": map[string]float64{
+						"lng": h.boundingBox.Max.X,
+						"lat": h.boundingBox.Max.Y,
+						"alt": h.boundingBox.Max.Z,
+					},
+					"center": map[string]float64{
+						"lng": (h.boundingBox.Min.X + h.boundingBox.Max.X) / 2,
+						"lat": (h.boundingBox.Min.Y + h.boundingBox.Max.Y) / 2,
+						"alt": (h.boundingBox.Min.Z + h.boundingBox.Max.Z) / 2,
+					},
+				}
+			}
+			matched++
+			if err := yield(fah.Val); err != nil {
+				return err
+			}
+		}
 	}
+
+	if err := fs.Err(); err != nil {
+		return err
+	}
+
+	log.Debugfc(ctx, "citygml: %d features scanned and %d intersected", count, matched)
 	return nil
 }

--- a/server/cmsintegration/cmsintegrationv3/fme.go
+++ b/server/cmsintegration/cmsintegrationv3/fme.go
@@ -11,9 +11,17 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/reearth/reearthx/log"
 )
+
+// fmeRequestTimeout bounds the synchronous HTTP call that submits a job to FME.
+// The FME job itself runs asynchronously and reports back via ResultURL, so this
+// only needs to cover the submit round-trip. Without it, a stalled FME (half-open
+// TCP, no response body) would hold the webhook goroutine open indefinitely and
+// leave items stuck in "converting".
+const fmeRequestTimeout = 60 * time.Second
 
 type fmeRequestType string
 
@@ -53,7 +61,7 @@ func newFME(url, resultURL string) *fme {
 	return &fme{
 		url:       url,
 		resultURL: resultURL,
-		client:    http.DefaultClient,
+		client:    &http.Client{Timeout: fmeRequestTimeout},
 	}
 }
 

--- a/server/cmsintegration/cmsintegrationv3/webhook.go
+++ b/server/cmsintegration/cmsintegrationv3/webhook.go
@@ -19,14 +19,20 @@ func WebhookHandler(conf Config) (cmswebhook.Handler, error) {
 		ctx := req.Context()
 		ctx = log.WithPrefixMessage(ctx, "cmsintegrationv3 webhook: ")
 
-		log.Infofc(ctx, "incoming: type=%s, project=%s, model=%s, item=%s",
-			w.Type, w.ProjectID(), w.ItemData.Model.Key, w.ItemData.Item.ID)
+		// ValidatePayload is what rejects deliveries with a nil ItemData /
+		// Model / Item, so the pre-validation log must not dereference them —
+		// otherwise a webhook whose shape is exactly what the validator exists
+		// to filter panics before it can be filtered.
+		log.Infofc(ctx, "incoming: type=%s, project=%s", w.Type, w.ProjectID())
 		log.Debugfc(ctx, "incoming payload: %+v", w)
 
 		if !cmsintegrationcommon.ValidatePayload(ctx, w, conf.CMSIntegration) {
 			log.Infofc(ctx, "validation failed, skipping")
 			return nil
 		}
+
+		log.Infofc(ctx, "validated: model=%s, item=%s",
+			w.ItemData.Model.Key, w.ItemData.Item.ID)
 
 		modelName := strings.TrimPrefix(w.ItemData.Model.Key, cmsintegrationcommon.ModelPrefix)
 		log.Infofc(ctx, "processing: model=%s, item=%s", modelName, w.ItemData.Item.ID)

--- a/server/cmsintegration/cmsintflow/handler.go
+++ b/server/cmsintegration/cmsintflow/handler.go
@@ -30,13 +30,17 @@ func WebhookHandler(conf Config) (cmswebhook.Handler, error) {
 		ctx := req.Context()
 		ctx = log.WithPrefixMessage(ctx, "cmsintflow webhook: ")
 
-		log.Infofc(ctx, "incoming: type=%s, project=%s, model=%s, item=%s",
-			w.Type, w.ProjectID(), w.ItemData.Model.Key, w.ItemData.Item.ID)
+		// See webhook.go: ValidatePayload is what filters nil ItemData /
+		// Model / Item, so the pre-validation log must be nil-safe.
+		log.Infofc(ctx, "incoming: type=%s, project=%s", w.Type, w.ProjectID())
 		log.Debugfc(ctx, "incoming payload: %+v", w)
 		if !cmsintegrationcommon.ValidatePayload(ctx, w, conf.CMSIntegration) {
 			log.Infofc(ctx, "validation failed, skipping")
 			return nil
 		}
+
+		log.Infofc(ctx, "validated: model=%s, item=%s",
+			w.ItemData.Model.Key, w.ItemData.Item.ID)
 
 		// Check for status change that should trigger cancellation
 		if shouldCancelFlow(w) {

--- a/server/cmsintegration/dataconv/service.go
+++ b/server/cmsintegration/dataconv/service.go
@@ -128,13 +128,13 @@ func getGeoJSON(ctx context.Context, u string) (*geojson.FeatureCollection, erro
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		log.Errorfc(ctx, "dataconv: failed to create a request: %v", err)
-		return nil, nil
+		return nil, fmt.Errorf("dataconv: failed to create request: %w", err)
 	}
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Errorfc(ctx, "dataconv: failed to get asset: %v", err)
-		return nil, nil
+		return nil, fmt.Errorf("dataconv: failed to fetch asset: %w", err)
 	}
 
 	defer func() {
@@ -143,12 +143,18 @@ func getGeoJSON(ctx context.Context, u string) (*geojson.FeatureCollection, erro
 
 	if res.StatusCode != http.StatusOK {
 		log.Errorfc(ctx, "dataconv: failed to get asset: status code is %d", res.StatusCode)
-		return nil, nil
+		return nil, fmt.Errorf("dataconv: fetch asset returned status %d", res.StatusCode)
 	}
 
 	f := geojson.FeatureCollection{}
 	if err := json.NewDecoder(bom.NewReader(res.Body)).Decode(&f); err != nil {
+		// Do not swallow the decode error: a truncated body (connection reset
+		// mid-read) previously returned a partial FeatureCollection with a nil
+		// error, which the caller happily converted and used to overwrite the
+		// item's existing good data. Surfacing the error keeps the original
+		// data intact and lets the pipeline retry.
 		log.Errorfc(ctx, "dataconv: invalid geojson: %v", err)
+		return nil, fmt.Errorf("dataconv: invalid geojson: %w", err)
 	}
 
 	return &f, nil


### PR DESCRIPTION
## Summary

Server hardening pass covering five loosely-related reliability / security issues, kept in one PR because they all touch `server/cmsintegration` and `server/citygml`.

### CityGML `/attributes`, `/features`, `/pack` — unauthenticated SSRF

The only SSRF guard (`Domain != \"\" && u.Host != Domain`) was a no-op whenever `CITYGML_DOMAIN` was unset — the shipped default — and the routes have no auth middleware. An unauthenticated attacker could point the endpoints at cloud metadata or internal services.

**Fix:** shared SSRF-safe HTTP client with:
- a `DialContext` that refuses non-public destinations (loopback / RFC1918 / cloud metadata / link-local / CGNAT / ULA / IPv6 link-local / reserved / unspecified / multicast), catching DNS-rebinding attempts at connect time;
- a pre-flight `checkExternalURL` check on the raw URL (scheme allowlist http/https, IP-literal block);
- redirect re-validation via `CheckRedirect`.

Applies **on top of** the operator's `Domain` allowlist — both guards run.

### CityGML `/spatialid_attributes` — sequential fetch/parse

A broad, low-zoom spatial ID resolved upstream to up to `maxCities` (50) cities × tens–hundreds of mesh GML files, and `SpatialIDAttributes` opened + XML-parsed each URL strictly serially. Tens of ms × thousands of files = minutes per request, blowing past the Cloud Run request timeout.

**Fix:** `errgroup` with `SetLimit(10)` (same cap as the sibling `/datacatalog/citygml` handler). Each goroutine owns its own XML decoder buffer and tag-handler cache; the yield callback is serialized under a mutex so the streamed JSON stays well-formed; the shared ETag cache is now mutex-guarded; per-request URL fan-out is capped at 500.

### cmsintegrationv3 + cmsintflow webhook handlers — nil deref in incoming log

The recently-added \"incoming\" log dereferenced `w.ItemData.Model.Key` and `w.ItemData.Item.ID` **before** `ValidatePayload` — which itself is what guards `w.ItemData / .Model / .Item == nil`. A non-item.create/update event or an item event with an unusual shape panicked before reaching the filter, aborting the request task and flooding logs with stack traces.

**Fix:** log a nil-safe subset (`type`, `project`) before validation, and log `model`, `item` **after** `ValidatePayload` returns true. Applied to both `cmsintegrationv3/webhook.go` and `cmsintflow/handler.go`.

### FME client — no timeout

`newFME` was using `http.DefaultClient` (no timeout). A stalled FME server (half-open TCP, no response body) held the webhook goroutine open indefinitely while the item stayed marked `\"converting\"`, requiring manual intervention.

**Fix:** explicit `Timeout: 60s`. Only bounds the submit round-trip — the FME job itself is asynchronous via ResultURL, so a long-running conversion is unaffected.

### dataconv geojson loader — silently overwrites good data on transient errors

`getGeoJSON` logged the `json.Decode` error and returned the partial `&f` with a nil `error`. The caller's `err != nil || g == nil` guard passed; `ConvertBorder` / `ConvertLandmark` ran on an empty / truncated `FeatureCollection`; `UpdateItem` overwrote the item's existing good CZML with truncated bytes.

**Fix:** return the decode error so the caller aborts and the item keeps its previous good data. A transient connection reset now surfaces as an error the pipeline can retry, not silent data corruption.

## Test plan

- [x] `go build ./citygml/... ./cmsintegration/...`
- [x] `go vet ./citygml/... ./cmsintegration/...`
- [x] `gofmt -l` clean
- [x] `go test -count=1 ./citygml/... ./cmsintegration/...`
- [x] New `TestCheckExternalURL` — table-driven blocked-vs-allowed matrix (metadata IP, RFC1918, CGNAT, IPv6 loopback / link-local / ULA / multicast / mapped-loopback, bad schemes, plus positive cases for public v4/v6)
- [x] Existing `TestAttributesHandler(CodeOnly)` and `TestFeaturesHandler` updated to activate httpmock on the new `safeHTTPClient` (which has its own Transport)
- [x] Existing `TestSpatialIDAttributes` tests still pass with the parallel implementation