### PR TITLE
fix(geo): clamp EstatAreas limit to prevent unbounded Firestore load

### DIFF
--- a/geo/src/prototypes/nest-estat-areas/EstatAreasService.ts
+++ b/geo/src/prototypes/nest-estat-areas/EstatAreasService.ts
@@ -47,6 +47,14 @@ function createAreas(snapshot: AreaQuerySnapshot, searchTokens?: readonly string
   );
 }
 
+// Cap the client-controlled `limit` argument. Without this the resolver
+// forwards the caller's value straight into `.limit(limit * 2)` and
+// `uniqBy([...result, ...createAreas(...)])`, materializing every returned
+// document in memory — a single `limit: 1_000_000` request would pull up to
+// ~2M docs onto the geo Cloud Run service and OOM the instance.
+const ESTAT_AREAS_MAX_LIMIT = 1000;
+const ESTAT_AREAS_DEFAULT_LIMIT = 100;
+
 const searchFields = ["shortAddress", "middleAddress", "fullAddress"];
 const compoundSearchFields = [
   ["properties.S_NAME", "properties.CSS_NAME", "properties.GST_NAME", "properties.PREF_NAME"],
@@ -73,7 +81,19 @@ export class EstatAreasService {
   ) {}
 
   async findAll(params: { searchTokens: readonly string[]; limit?: number }): Promise<EstatArea[]> {
-    const { limit = 100 } = params;
+    const requested = params.limit ?? ESTAT_AREAS_DEFAULT_LIMIT;
+    // Clamp to [1, ESTAT_AREAS_MAX_LIMIT]. Non-finite / non-positive values
+    // fall back to the default; sub-1 positive fractions (e.g. `0.5` → floor
+    // = 0) would otherwise sneak through `> 0` and produce a `.limit(0)`
+    // query that always returns empty — floor first, then re-check the
+    // effective integer against the same lower bound.
+    let limit = ESTAT_AREAS_DEFAULT_LIMIT;
+    if (Number.isFinite(requested) && requested > 0) {
+      const floored = Math.floor(requested);
+      if (floored >= 1) {
+        limit = Math.min(floored, ESTAT_AREAS_MAX_LIMIT);
+      }
+    }
 
     let result: EstatArea[] = [];
     for (const fields of compoundSearchFields) {


### PR DESCRIPTION
## Summary

The `estatAreas` GraphQL query forwarded the caller-supplied `limit` straight into `.limit(limit * 2)` and then accumulated every returned Firestore doc via `createAreas(...)` + `uniqBy(...)`. A single request with `limit: 1_000_000` pulled up to ~2M matching docs into an in-memory `EstatArea[]` on the geo Cloud Run service (default 512 MB) — OOM / instance crash without any data growth needed, since N is just a client integer.

## Fix

Clamp the client-supplied `limit` inside `EstatAreasService.findAll` to `[1, ESTAT_AREAS_MAX_LIMIT=1000]`, defaulting to 100 on missing / non-finite / non-positive values so no caller path (resolver or any future direct caller) can bypass it. Also `Math.floor` so a fractional limit doesn't tip Firestore's per-query cap.

## Test plan

- [ ] CI `ci-geo` (`yarn build` / `yarn lint`) — the change is a single clamp; no local yarn install possible in this sandbox due to disk pressure