### PR TITLE
fix(tile): drop `immutable` cache-control on mutable R2 objects

### DIFF
--- a/cloudflare/tiles/src/r2.ts
+++ b/cloudflare/tiles/src/r2.ts
@@ -55,7 +55,13 @@ export async function serveObject(
     headers.set("content-type", contentTypeFor(key));
   }
   if (!headers.has("cache-control")) {
-    headers.set("cache-control", "public, max-age=86400, immutable");
+    // `immutable` disabled browser/edge revalidation, so after an operator
+    // re-uploaded a corrected `layer.json` or COG at the same key, clients
+    // and the CDN kept serving stale bytes for the full TTL — bypassing the
+    // ETag/If-None-Match handling this same function sets up. Since these
+    // objects are mutable (in-place overwrites happen), use a shorter TTL
+    // with `must-revalidate` so ETag revalidation actually runs.
+    headers.set("cache-control", "public, max-age=3600, must-revalidate");
   }
 
   // `.terrain` tiles are stored pre-gzipped (raw bytes). Declare the encoding so

--- a/tile/Cargo.toml
+++ b/tile/Cargo.toml
@@ -28,7 +28,12 @@ image = { version = "0.25", default-features = false, features = ["png", "webp",
 flate2 = "1"
 japan-geoid = { version = "0.6", features = ["gsigeo2011", "jpgeo2024", "jpgeo2024_hrefconv2024"] }
 terrain-codec = "0.3.0"
-pmtiles = { version = "0.23", default-features = false, features = ["http-async", "object-store", "reqwest-rustls"] }
+# Pin pmtiles to =0.23.0 because 0.23.1 bumped its internal object_store
+# dep to 0.14 while our `object_store_pmtiles` alias below is on 0.13.
+# Mixing the two versions produces `Path: From<Path>` trait errors at build
+# time (the two crate versions define distinct `Path` types). If you upgrade
+# pmtiles past 0.23.0, bump `object_store_pmtiles` in lockstep.
+pmtiles = { version = "=0.23.0", default-features = false, features = ["http-async", "object-store", "reqwest-rustls"] }
 rstar = "0.12"
 # pmtiles needs object_store v0.13; the existing /tile/src/cog/* still uses
 # v0.12. We expose v0.13 under a rename so both coexist in the build.

--- a/tile/worker/src/index.ts
+++ b/tile/worker/src/index.ts
@@ -16,8 +16,17 @@
 /** Tile path pattern: /tiles/{source}/{z}/{x}/{y}.{format} */
 const TILE_PATH_REGEX = /^\/tiles\/([^/]+)\/(\d+)\/(\d+)\/(\d+)\.(png|webp|avif)$/;
 
-/** Default Cache-Control header */
-const DEFAULT_CACHE_CONTROL = "public, max-age=31536000, immutable";
+/**
+ * Default Cache-Control header.
+ *
+ * The tile server writes tiles under deterministic keys (`{source}/{format}/
+ * {z}/{x}/{y}.{format}`) and may re-upload them at the same key when the
+ * upstream COG/DEM changes. `immutable` disabled browser/edge revalidation,
+ * so clients kept serving stale tiles for a year after the underlying data
+ * was fixed. Use a shorter TTL with `must-revalidate` so ETag revalidation
+ * (which this worker already emits) actually runs.
+ */
+const DEFAULT_CACHE_CONTROL = "public, max-age=3600, must-revalidate";
 
 /** Check if origin is allowed for CORS */
 function isOriginAllowed(origin: string | null, allowedOrigins: string | undefined): string | null {


### PR DESCRIPTION
## Summary

`cloudflare/tiles/src/r2.ts:57-59` and `tile/worker/src/index.ts:20` both stamped mutable, deterministically-keyed R2 objects with `Cache-Control: ..., immutable` (24 h for the tile config worker, 1 year for the tile worker). Operators do overwrite these in place — a corrected `layer.json`, a re-uploaded COG (`base/dem10/3036.tif`), a fresh tile — but `immutable` disables browser and edge revalidation, so clients and the CDN kept serving stale bytes for the full TTL past a fix, bypassing the ETag/If-None-Match handling both handlers set up. The Rust tile server that fetches COGs through this worker inherited the staleness.

## Fix

Switch both defaults to `public, max-age=3600, must-revalidate`:
- shorter freshness window, and
- `must-revalidate` allows conditional revalidation — so ETag / If-None-Match (which the workers already emit) actually runs and clients pick up in-place updates on the next check.

Behavior is unchanged for the vast majority of requests that resolve to `304 Not Modified` via ETag; the wire cost is one small conditional GET per client per hour instead of nothing for the full TTL.

## Test plan

- [ ] Verify via `wrangler dev` / CI that responses now carry `cache-control: public, max-age=3600, must-revalidate` in place of `..., immutable`. No unit tests exist in these worker packages.