### PR TITLE
fix(cms): guard asset import-from-URL against SSRF

### DIFF
--- a/cms/server/pkg/file/file.go
+++ b/cms/server/pkg/file/file.go
@@ -62,6 +62,16 @@ func FromURL(ctx context.Context, rawURL string) (*File, error) {
 		return nil, err
 	}
 
+	// Refuse imports that point at internal addresses. Callers are
+	// authenticated workspace members, but a "fetch from URL" primitive
+	// with no host / scheme / IP guard turns any write-capable member into
+	// a cloud-metadata / internal-network reader who can then download the
+	// result as a stored asset. Enforced both up front and at dial time
+	// (safeHTTPClient's DialContext) to close the DNS-rebinding gap.
+	if err := checkExternalURL(URL); err != nil {
+		return nil, rerror.ErrInternalBy(err)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), nil)
 	if err != nil {
 		return nil, errors.New("failed to request")
@@ -70,7 +80,7 @@ func FromURL(ctx context.Context, rawURL string) (*File, error) {
 	// TODO: support gzip
 	// req.Header.Set("Accept-Encoding", "gzip")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := safeHTTPClient.Do(req)
 	if err != nil {
 		return nil, rerror.ErrInternalBy(err)
 	}

--- a/cms/server/pkg/file/file_test.go
+++ b/cms/server/pkg/file/file_test.go
@@ -17,6 +17,9 @@ import (
 func TestFromURL(t *testing.T) {
 	ctx := context.Background()
 
+	// FromURL uses safeHTTPClient (its own Transport), so activate httpmock
+	// on that client in addition to DefaultTransport.
+	httpmock.ActivateNonDefault(safeHTTPClient)
 	httpmock.Activate()
 	defer httpmock.Deactivate()
 

--- a/cms/server/pkg/file/safeurl.go
+++ b/cms/server/pkg/file/safeurl.go
@@ -1,0 +1,166 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ErrUnsafeURL is returned when a caller-supplied URL (e.g. `POST /api/.../
+// assets {"url":...}`) points at something the asset importer refuses to
+// fetch: bad scheme, or a resolved address in a private / loopback / cloud-
+// metadata range. Surfaces as an internal error to the caller.
+var ErrUnsafeURL = errors.New("unsafe url")
+
+// checkExternalURL runs a pre-flight SSRF check on the raw URL. It rejects
+// non-http/https schemes and IP literals in a non-public range. Actual DNS
+// resolution is re-checked in safeDialContext below so a rebinding attacker
+// who returns a public A record here and a private one at connect time is
+// still stopped.
+func checkExternalURL(u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("%w: nil url", ErrUnsafeURL)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("%w: scheme %q not allowed", ErrUnsafeURL, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: empty host", ErrUnsafeURL)
+	}
+	if ip := net.ParseIP(host); ip != nil && !isPublicIP(ip) {
+		return fmt.Errorf("%w: address %s is not public", ErrUnsafeURL, ip)
+	}
+	return nil
+}
+
+// isPublicIP mirrors the same-named helper in the sibling PLATEAU server
+// citygml package: return true only for addresses safe to open an outbound
+// connection to from a workspace-tenant-facing service.
+func isPublicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() ||
+		ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		// 169.254.169.254 (cloud metadata), 100.64.0.0/10 (CGNAT),
+		// 0.0.0.0/8, 240.0.0.0/4 (reserved).
+		if v4[0] == 0 || v4[0] >= 240 {
+			return false
+		}
+		if v4[0] == 169 && v4[1] == 254 {
+			return false
+		}
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return false
+		}
+		return true
+	}
+	// IPv6 unique-local (fc00::/7).
+	if len(ip) == net.IPv6len && (ip[0]&0xfe) == 0xfc {
+		return false
+	}
+	return true
+}
+
+// safeDialContext refuses to connect to non-public addresses even after DNS
+// resolution — the defense-in-depth check that closes the DNS-rebinding gap
+// left by a purely pre-flight URL check.
+//
+// Dials each validated public IP in resolver order, returning the first
+// success. This keeps dual-stack (A + AAAA) hosts working even when one
+// family is unreachable — e.g. a container network with no IPv6 route
+// would otherwise fail even though the A record resolved fine.
+func safeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := (&net.Resolver{}).LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("%w: no addresses resolved for %s", ErrUnsafeURL, host)
+	}
+	// Validate all resolved IPs up front. Any non-public one aborts the
+	// dial: partial-public / partial-private records could otherwise let
+	// an attacker exfiltrate to an internal address by dominating the
+	// resolver order.
+	for _, ipa := range ips {
+		if !isPublicIP(ipa.IP) {
+			return nil, fmt.Errorf("%w: resolved address %s not public", ErrUnsafeURL, ipa.IP)
+		}
+	}
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			if ip := net.ParseIP(host); ip != nil && !isPublicIP(ip) {
+				return fmt.Errorf("%w: dial to non-public address %s blocked", ErrUnsafeURL, ip)
+			}
+			return nil
+		},
+	}
+	// Try each validated IP; return on first success. `lastErr` is the
+	// last dial error so callers see the actual TCP-level failure when
+	// none of the IPs are reachable.
+	var lastErr error
+	for _, ipa := range ips {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ipa.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		// Respect context cancellation so a caller-side timeout doesn't
+		// wait through every remaining IP.
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return nil, lastErr
+}
+
+// safeHTTPClient is the SSRF-safe client used for caller-supplied URLs in
+// `file.FromURL` (asset import-from-URL via the integration API / GraphQL
+// createAsset). Rejects non-public destinations at dial time, limits
+// redirects, and re-validates each redirect target.
+//
+// `Proxy: nil` is explicit: with `http.ProxyFromEnvironment` an operator-
+// set `HTTP(S)_PROXY` would let `DialContext` dial the proxy — a public
+// address — while the CONNECT tunnel terminated at an internal target,
+// defeating the public-IP check.
+var safeHTTPClient = &http.Client{
+	Timeout: 60 * time.Second,
+	Transport: &http.Transport{
+		Proxy:                 nil,
+		DialContext:           safeDialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	},
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return checkExternalURL(req.URL)
+	},
+}

--- a/cms/server/pkg/file/safeurl_test.go
+++ b/cms/server/pkg/file/safeurl_test.go
@@ -1,0 +1,76 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckExternalURL_BlocksNonPublic(t *testing.T) {
+	// The pre-flight check only inspects the URL as given — hostname
+	// literals like "localhost" are handled by safeDialContext at connect
+	// time (a full integration test would need a controllable resolver;
+	// TestFromURL_RejectsUnsafe covers the IP-literal path end-to-end).
+	for _, raw := range []string{
+		"http://127.0.0.1/x",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://10.0.0.1/",
+		"http://192.168.1.1/",
+		"http://172.16.0.1/",
+		"http://100.64.0.1/",
+		"http://0.0.0.0/",
+		"http://240.0.0.1/",
+		"http://[::1]/",
+		"http://[fe80::1]/",
+		"http://[fc00::1]/",
+		"http://[fd00::1]/",
+		"http://[ff02::1]/",
+		"http://[::ffff:127.0.0.1]/",
+	} {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		err = checkExternalURL(u)
+		if assert.Error(t, err, "expected block for %s", raw) {
+			assert.True(t, errors.Is(err, ErrUnsafeURL), "expected ErrUnsafeURL for %s, got %v", raw, err)
+		}
+	}
+}
+
+func TestCheckExternalURL_AllowsPublic(t *testing.T) {
+	for _, raw := range []string{
+		"http://example.com/",
+		"https://cms.com/xyz/test.txt",
+		"http://8.8.8.8/",
+		"https://[2606:4700:4700::1111]/",
+	} {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		assert.NoError(t, checkExternalURL(u), "expected allow for %s", raw)
+	}
+}
+
+func TestCheckExternalURL_BadSchemes(t *testing.T) {
+	for _, raw := range []string{
+		"file:///etc/passwd",
+		"gopher://example.com/",
+		"ftp://example.com/file",
+	} {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err, raw)
+		assert.Error(t, checkExternalURL(u), "expected block for %s", raw)
+	}
+}
+
+// TestFromURL_RejectsUnsafe covers the FromURL integration: a caller URL
+// pointing at cloud metadata must be rejected before any HTTP round-trip
+// happens. `rerror.ErrInternalBy` conceals the wrapped cause in .Error(),
+// so this just asserts the call fails — TestCheckExternalURL_BlocksNonPublic
+// covers the underlying classification.
+func TestFromURL_RejectsUnsafe(t *testing.T) {
+	got, err := FromURL(context.Background(), "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
## Summary

`file.FromURL` (`cms/server/pkg/file/file.go`) backs both the integration API `POST /api/.../assets` with `{\"url\":...}` and the GraphQL `createAsset` resolver. It fetched the caller-supplied URL with `http.DefaultClient` — no scheme allowlist, no IP guard, no redirect limit. Any workspace member with write access (integration token or authenticated `createAsset`) could point the importer at `http://169.254.169.254/latest/meta-data/iam/security-credentials/` or any internal endpoint and the CMS would fetch it and store the result as a downloadable asset — a tenant-member → cloud-credential / internal-network read escalation.

## Fix

Add an SSRF-safe URL check and a dedicated `safeHTTPClient` used only by `FromURL`:

- **Scheme allowlist**: only `http` / `https` accepted.
- **Pre-flight `checkExternalURL`**: rejects IP literals in loopback / RFC1918 / cloud metadata / link-local / CGNAT / ULA / IPv6 link-local / reserved / multicast / unspecified ranges.
- **`safeDialContext`**: at connect time, re-resolves the host via `net.Resolver`, refuses if any resolved IP is non-public, and dials the validated IP directly so the socket target matches what we checked — this closes the DNS-rebinding gap between the pre-flight check and the actual TCP connect.
- **`CheckRedirect`**: runs the same URL check on every redirect target and caps at 10 hops.

The existing `TestFromURL` was updated to `httpmock.ActivateNonDefault(safeHTTPClient)` so the mock intercepts the new client's Transport.

## Test plan

- [x] `go build ./pkg/file/...`
- [x] `go vet ./pkg/file/...`
- [x] `gofmt -l` clean
- [x] `go test -count=1 ./pkg/file/...`
- [x] New `TestCheckExternalURL_BlocksNonPublic` — table-driven matrix over metadata IP, RFC1918, CGNAT, IPv6 loopback / link-local / ULA / multicast / mapped-loopback
- [x] New `TestCheckExternalURL_AllowsPublic` — public v4/v6 destinations still accepted
- [x] New `TestCheckExternalURL_BadSchemes` — file/gopher/ftp rejected
- [x] New `TestFromURL_RejectsUnsafe` — end-to-end: a metadata-service URL through `FromURL` fails before any HTTP round-trip
- [x] Existing `TestFromURL` still passes with the new httpmock activation

## Note

This backports an SSRF guard onto the vendored re-earth-cms code that ships under `cms/`. Fixing this upstream in reearth/reearth-cms would be the ideal long-term path so any future re-vendor picks it up automatically; this patch keeps our deployment safe in the meantime.